### PR TITLE
Refine leaderboard logic for cumulative achievements; restore prefill…

### DIFF
--- a/backend/src/main/java/org/steam5/repository/GuessRepository.java
+++ b/backend/src/main/java/org/steam5/repository/GuessRepository.java
@@ -25,6 +25,9 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
             "group by u.steamId, u.personaName order by sum(g.points) desc")
     List<LeaderboardRow> leaderboardAllTime();
 
+    @Query("select g from Guess g where g.gameDate = :date")
+    List<Guess> findAllByDate(@Param("date") LocalDate date);
+
     interface LeaderboardRow {
         String getSteamId();
 

--- a/backend/src/main/java/org/steam5/web/LeaderboardController.java
+++ b/backend/src/main/java/org/steam5/web/LeaderboardController.java
@@ -6,6 +6,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.steam5.domain.Guess;
 import org.steam5.repository.GuessRepository;
 import org.steam5.service.ReviewGameStateService;
 
@@ -21,27 +22,64 @@ public class LeaderboardController {
     private final GuessRepository guessRepository;
     private final ReviewGameStateService reviewGameStateService;
 
-    public record LeaderEntry(String steamId, String personaName, long totalPoints, long rounds) {
-    }
-
     @GetMapping("/today")
     public ResponseEntity<List<LeaderEntry>> today() {
         final var picks = reviewGameStateService.generateDailyPicks();
         final LocalDate date = picks.isEmpty() ? LocalDate.now() : picks.getFirst().getPickDate();
-        final List<GuessRepository.LeaderboardRow> rows = guessRepository.leaderboardForDay(date);
-        final List<LeaderEntry> out = rows.stream()
-                .map(r -> new LeaderEntry(r.getSteamId(), r.getPersonaName(), r.getTotalPoints() == null ? 0 : r.getTotalPoints(), r.getRounds() == null ? 0 : r.getRounds()))
-                .toList();
+        final var guesses = guessRepository.findAllByDate(date);
+        final java.util.Map<String, java.util.List<Guess>> byUser = guesses.stream().collect(java.util.stream.Collectors.groupingBy(Guess::getSteamId));
+        final List<LeaderEntry> out = byUser.entrySet().stream().map(e -> {
+            final String steamId = e.getKey();
+            final var list = e.getValue();
+            long totalPoints = list.stream().mapToLong(Guess::getPoints).sum();
+            long rounds = list.size();
+            long hits = list.stream().filter(g -> g.getSelectedBucket().equals(g.getActualBucket())).count();
+            long tooHigh = list.stream().filter(g -> {
+                final java.util.List<String> buckets = reviewGameStateService.getBucketLabels();
+                return buckets.indexOf(g.getSelectedBucket()) > buckets.indexOf(g.getActualBucket());
+            }).count();
+            long tooLow = list.stream().filter(g -> {
+                final java.util.List<String> buckets = reviewGameStateService.getBucketLabels();
+                return buckets.indexOf(g.getSelectedBucket()) < buckets.indexOf(g.getActualBucket());
+            }).count();
+            double avgPoints = rounds > 0 ? ((double) totalPoints) / rounds : 0.0;
+            final String personaName = list.stream().findFirst()
+                    .map(g -> (String) null)
+                    .orElse(null);
+            return new LeaderEntry(steamId, personaName, totalPoints, rounds, hits, tooHigh, tooLow, avgPoints);
+        }).sorted((a, b) -> Long.compare(b.totalPoints, a.totalPoints)).toList();
         return ResponseEntity.ok(out);
     }
 
     @GetMapping(value = {"", "/", "/all"})
     public ResponseEntity<List<LeaderEntry>> allTime() {
-        final List<GuessRepository.LeaderboardRow> rows = guessRepository.leaderboardAllTime();
-        final List<LeaderEntry> out = rows.stream()
-                .map(r -> new LeaderEntry(r.getSteamId(), r.getPersonaName(), r.getTotalPoints() == null ? 0 : r.getTotalPoints(), r.getRounds() == null ? 0 : r.getRounds()))
-                .toList();
+        final var guesses = guessRepository.findAll();
+        final java.util.Map<String, java.util.List<Guess>> byUser = guesses.stream().collect(java.util.stream.Collectors.groupingBy(Guess::getSteamId));
+        final List<LeaderEntry> out = byUser.entrySet().stream().map(e -> {
+            final String steamId = e.getKey();
+            final var list = e.getValue();
+            long totalPoints = list.stream().mapToLong(Guess::getPoints).sum();
+            long rounds = list.size();
+            long hits = list.stream().filter(g -> g.getSelectedBucket().equals(g.getActualBucket())).count();
+            long tooHigh = list.stream().filter(g -> {
+                final java.util.List<String> buckets = reviewGameStateService.getBucketLabels();
+                return buckets.indexOf(g.getSelectedBucket()) > buckets.indexOf(g.getActualBucket());
+            }).count();
+            long tooLow = list.stream().filter(g -> {
+                final java.util.List<String> buckets = reviewGameStateService.getBucketLabels();
+                return buckets.indexOf(g.getSelectedBucket()) < buckets.indexOf(g.getActualBucket());
+            }).count();
+            double avgPoints = rounds > 0 ? ((double) totalPoints) / rounds : 0.0;
+            String personaName = steamId;
+            return new LeaderEntry(steamId, personaName, totalPoints, rounds, hits, tooHigh, tooLow, avgPoints);
+        }).sorted((a, b) -> Long.compare(b.totalPoints, a.totalPoints)).toList();
         return ResponseEntity.ok(out);
+    }
+
+    public record LeaderEntry(String steamId, String personaName,
+                              long totalPoints, long rounds,
+                              long hits, long tooHigh, long tooLow,
+                              double avgPoints) {
     }
 }
 

--- a/frontend/app/review-guesser/leaderboard/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/page.tsx
@@ -3,7 +3,16 @@ import "@/styles/components/leaderboard.css";
 
 export const dynamic = 'force-dynamic';
 
-type LeaderEntry = { steamId: string; personaName: string; totalPoints: number; rounds: number };
+type LeaderEntry = {
+    steamId: string;
+    personaName: string;
+    totalPoints: number;
+    rounds: number;
+    hits: number;
+    tooHigh: number;
+    tooLow: number;
+    avgPoints: number;
+};
 
 async function loadLeaderboardAll(): Promise<LeaderEntry[]> {
     const backend = process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
@@ -34,6 +43,10 @@ export default async function LeaderboardPage() {
                         <th scope="col">Player</th>
                         <th scope="col" className="num">Points</th>
                         <th scope="col" className="num">Rounds</th>
+                        <th scope="col" className="num">Hits</th>
+                        <th scope="col" className="num">Too High</th>
+                        <th scope="col" className="num">Too Low</th>
+                        <th scope="col" className="num">Avg</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -43,6 +56,10 @@ export default async function LeaderboardPage() {
                             <td><strong>{e.personaName || e.steamId}</strong></td>
                             <td className="num">{e.totalPoints}</td>
                             <td className="num">{e.rounds}</td>
+                            <td className="num">{e.hits}</td>
+                            <td className="num">{e.tooHigh}</td>
+                            <td className="num">{e.tooLow}</td>
+                            <td className="num">{e.avgPoints.toFixed(2)}</td>
                         </tr>
                     ))}
                     </tbody>

--- a/frontend/app/review-guesser/leaderboard/today/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/today/page.tsx
@@ -3,7 +3,16 @@ export const dynamic = 'force-dynamic';
 import "@/styles/components/leaderboard.css";
 import Link from "next/link";
 
-type LeaderEntry = { steamId: string; personaName: string; totalPoints: number; rounds: number };
+type LeaderEntry = {
+    steamId: string;
+    personaName: string;
+    totalPoints: number;
+    rounds: number;
+    hits: number;
+    tooHigh: number;
+    tooLow: number;
+    avgPoints: number;
+};
 
 async function loadLeaderboardToday(): Promise<LeaderEntry[]> {
     const backend = process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
@@ -34,6 +43,10 @@ export default async function LeaderboardTodayPage() {
                         <th scope="col">Player</th>
                         <th scope="col" className="num">Points</th>
                         <th scope="col" className="num">Rounds</th>
+                        <th scope="col" className="num">Hits</th>
+                        <th scope="col" className="num">Too High</th>
+                        <th scope="col" className="num">Too Low</th>
+                        <th scope="col" className="num">Avg</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -43,6 +56,10 @@ export default async function LeaderboardTodayPage() {
                             <td><strong>{e.personaName || e.steamId}</strong></td>
                             <td className="num">{e.totalPoints}</td>
                             <td className="num">{e.rounds}</td>
+                            <td className="num">{e.hits}</td>
+                            <td className="num">{e.tooHigh}</td>
+                            <td className="num">{e.tooLow}</td>
+                            <td className="num">{e.avgPoints.toFixed(2)}</td>
                         </tr>
                     ))}
                     </tbody>


### PR DESCRIPTION
…ed guesses

- Modified the frontend leaderboard component to prioritize displaying cumulative scores across all days instead of focusing solely on daily achievements.
- Ensured that prefilled guesses are restored from server-side data without storing them in local storage, maintaining UI consistency with server data.

These changes enhance leaderboard accuracy and user experience by emphasizing comprehensive player performance and ensuring guess submissions reflect genuine interactions.