### PR TITLE
Introduce Steam App Reviews Refresh Job and configure nightly refresh…

### DIFF
--- a/backend/src/main/java/org/steam5/config/QuartzConfig.java
+++ b/backend/src/main/java/org/steam5/config/QuartzConfig.java
@@ -63,4 +63,14 @@ public class QuartzConfig {
                 .withSchedule(simpleSchedule().repeatForever().withIntervalInHours(24))
                 .build();
     }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "jobs.reviews-refresh", name = "enabled", havingValue = "true", matchIfMissing = true)
+    public Trigger triggerReviewsRefreshJob(@Qualifier("SteamAppReviewsRefreshJob") JobDetail job) {
+        return TriggerBuilder.newTrigger().forJob(job)
+                .withIdentity("SteamAppReviewsRefreshJob_Trigger")
+                // nightly at 02:00
+                .withSchedule(CronScheduleBuilder.cronSchedule("0 0 2 * * ?"))
+                .build();
+    }
 }

--- a/backend/src/main/java/org/steam5/config/SteamAppsConfig.java
+++ b/backend/src/main/java/org/steam5/config/SteamAppsConfig.java
@@ -14,6 +14,7 @@ public class SteamAppsConfig {
     private final boolean includeGames = true;
     private final String downloadCron = "0 5 0 * * *"; // default: daily 00:05 UTC
     private final int httpTimeoutMs = 120_000;
+    private final int reviewsNightlyLimit = 15_000;
     @Value("${STEAM_API_KEY}")
     private String apiKey;
 

--- a/backend/src/main/java/org/steam5/job/SteamAppReviewsRefreshJob.java
+++ b/backend/src/main/java/org/steam5/job/SteamAppReviewsRefreshJob.java
@@ -1,0 +1,71 @@
+package org.steam5.job;
+
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.steam5.config.SteamAppsConfig;
+import org.steam5.repository.SteamAppReviewsRepository;
+import org.steam5.service.SteamAppReviewsFetcher;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+@DisallowConcurrentExecution
+public class SteamAppReviewsRefreshJob implements Job {
+
+    // Tuneables: number refreshed per run (respecting 1 req/sec via SteamHttpClient)
+    private static final int DEFAULT_NIGHTLY_REFRESH = 2500; // fallback
+    private final SteamAppReviewsFetcher fetcher;
+    private final SteamAppReviewsRepository reviewsRepository;
+    private final SteamAppsConfig steamAppsConfig;
+
+    public SteamAppReviewsRefreshJob(SteamAppReviewsFetcher fetcher, SteamAppReviewsRepository reviewsRepository, SteamAppsConfig steamAppsConfig) {
+        this.fetcher = fetcher;
+        this.reviewsRepository = reviewsRepository;
+        this.steamAppsConfig = steamAppsConfig;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        final long start = System.nanoTime();
+        int refreshed = 0;
+        try {
+            int limit = steamAppsConfig.getReviewsNightlyLimit() > 0 ? steamAppsConfig.getReviewsNightlyLimit() : DEFAULT_NIGHTLY_REFRESH;
+            final JobDataMap map = context.getMergedJobDataMap();
+            if (map != null && map.containsKey("limit")) {
+                try {
+                    limit = Math.max(1, Integer.parseInt(String.valueOf(map.get("limit"))));
+                } catch (Exception ignored) {
+                }
+            }
+            final List<Long> ids = reviewsRepository.findIdsOrderByUpdatedAtAsc(org.springframework.data.domain.PageRequest.of(0, limit));
+            for (Long appId : ids) {
+                try {
+                    fetcher.fetchForAppId(appId);
+                    refreshed++;
+                } catch (Exception e) {
+                    log.warn("Failed refreshing reviews for appId {}: {}", appId, e.toString());
+                }
+            }
+        } catch (Exception e) {
+            log.error("SteamAppReviewsRefreshJob error", e);
+            throw new JobExecutionException(e, false);
+        } finally {
+            long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+            log.info("SteamAppReviewsRefreshJob refreshed={} durationMs={}", refreshed, ms);
+        }
+    }
+
+    @Bean("SteamAppReviewsRefreshJob")
+    public JobDetail jobDetail() {
+        return JobBuilder.newJob().ofType(SteamAppReviewsRefreshJob.class)
+                .storeDurably()
+                .withIdentity("SteamAppReviewsRefreshJob")
+                .build();
+    }
+}
+
+

--- a/backend/src/main/java/org/steam5/repository/SteamAppReviewsRepository.java
+++ b/backend/src/main/java/org/steam5/repository/SteamAppReviewsRepository.java
@@ -67,6 +67,9 @@ public interface SteamAppReviewsRepository extends JpaRepository<SteamAppReviews
     @Query(value = "SELECT COALESCE(MAX(updated_at), now()) FROM steam_app_reviews", nativeQuery = true)
     OffsetDateTime maxUpdatedAt();
 
+    @Query(value = "SELECT app_id FROM steam_app_reviews ORDER BY updated_at ASC", nativeQuery = true)
+    List<Long> findIdsOrderByUpdatedAtAsc(Pageable pageable);
+
     interface ReviewThresholds {
         Integer getLowThreshold();
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -28,3 +28,5 @@ jobs:
     enabled: true
   blurhashAvatar:
     enabled: true
+  reviews-refresh:
+    enabled: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -69,4 +69,7 @@ jobs:
     enabled: ${JOB_BLURHASH:false}
   blurhashAvatar:
     enabled: ${JOB_BLURHASH_AVATAR:false}
+  reviews-refresh:
+    enabled: ${JOB_REVIEWS_REFRESH:false}
+    nightly-limit: ${JOB_REVIEWS_REFRESH_LIMIT:15000}
 


### PR DESCRIPTION
… settings

```markdown
- Added `SteamAppReviewsRefreshJob` to handle periodic refreshing of app reviews using Quartz scheduling.
- Configured job details including disabling concurrent execution for reliability during batch processing.
- Introduced new configuration options in `application.yml` and environment-specific files (`application-dev.yml`) for enabling the job and setting a nightly refresh limit.
- Implemented logic within `SteamAppReviewsRefreshJob` to fetch and update reviews based on configurable limits, improving maintainability and scalability by using repository methods.
```

This commit establishes infrastructure for automated review refreshing, enhancing data freshness with scheduled tasks and configurable parameters.