### PR TITLE
Add weekly leaderboard support

### DIFF
--- a/backend/src/main/java/org/steam5/repository/GuessRepository.java
+++ b/backend/src/main/java/org/steam5/repository/GuessRepository.java
@@ -28,6 +28,10 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
     @Query("select g from Guess g where g.gameDate = :date")
     List<Guess> findAllByDate(@Param("date") LocalDate date);
 
+    @Query("select g from Guess g where g.gameDate between :start and :end")
+    List<Guess> findAllBetween(@Param("start") LocalDate start,
+                                @Param("end") LocalDate end);
+
     interface LeaderboardRow {
         String getSteamId();
 

--- a/backend/src/main/java/org/steam5/web/LeaderboardController.http
+++ b/backend/src/main/java/org/steam5/web/LeaderboardController.http
@@ -1,0 +1,21 @@
+### Today leaderboard
+GET {{host}}/api/leaderboard/today
+Accept: application/json
+
+### Weekly leaderboard (last full week, Monday..Sunday before current week)
+GET {{host}}/api/leaderboard/weekly
+Accept: application/json
+
+### Weekly leaderboard (floating last 7 days, including today)
+GET {{host}}/api/leaderboard/weekly?floating=true
+Accept: application/json
+
+### All-time leaderboard
+GET {{host}}/api/leaderboard
+Accept: application/json
+
+### All-time leaderboard (explicit alias)
+GET {{host}}/api/leaderboard/all
+Accept: application/json
+
+

--- a/frontend/app/review-guesser/leaderboard/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/page.tsx
@@ -7,6 +7,7 @@ export default async function LeaderboardPage() {
             <h1>Review Guesser — Leaderboard</h1>
             <nav className="leaderboard__toggle" aria-label="Leaderboard view">
                 <Link href="/review-guesser/leaderboard" className="btn-ghost is-active">All-time</Link>
+                <Link href="/review-guesser/leaderboard/weekly" className="btn-ghost">Weekly</Link>
                 <Link href="/review-guesser/leaderboard/today" className="btn-ghost">Today</Link>
             </nav>
             <h2>All-time</h2>

--- a/frontend/app/review-guesser/leaderboard/today/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/today/page.tsx
@@ -7,6 +7,7 @@ export default async function LeaderboardTodayPage() {
             <h1>Review Guesser — Leaderboard</h1>
             <nav className="leaderboard__toggle" aria-label="Leaderboard view">
                 <Link href="/review-guesser/leaderboard" className="btn-ghost">All-time</Link>
+                <Link href="/review-guesser/leaderboard/weekly" className="btn-ghost">Weekly</Link>
                 <Link href="/review-guesser/leaderboard/today" className="btn-ghost is-active">Today</Link>
             </nav>
             <h2>Today</h2>

--- a/frontend/app/review-guesser/leaderboard/weekly/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/weekly/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import LeaderboardTable from "@/components/LeaderboardTable";
+
+export default async function LeaderboardWeeklyPage() {
+    return (
+        <section className="container">
+            <h1>Review Guesser — Leaderboard</h1>
+            <nav className="leaderboard__toggle" aria-label="Leaderboard view">
+                <Link href="/review-guesser/leaderboard" className="btn-ghost">All-time</Link>
+                <Link href="/review-guesser/leaderboard/weekly" className="btn-ghost is-active">Weekly</Link>
+                <Link href="/review-guesser/leaderboard/today" className="btn-ghost">Today</Link>
+            </nav>
+            <h2>Weekly</h2>
+            <p className="text-muted">Last seven days total points by player (sorted highest first)</p>
+            <LeaderboardTable mode="weekly-floating" refreshMs={10000}/>
+        </section>
+    );
+}

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -7,6 +7,7 @@ export const Routes = {
     reviewGuesser4: '/review-guesser/4',
     reviewGuesser5: '/review-guesser/5',
     leaderboard: '/review-guesser/leaderboard',
+    leaderboardWeekly: '/review-guesser/leaderboard/weekly',
     leaderboardToday: '/review-guesser/leaderboard/today',
     archive: '/review-guesser/archive',
 }


### PR DESCRIPTION
- Backend: Added endpoints for weekly leaderboards (fixed and floating 7-day range).
- Frontend: Updated routing, navigation, and components for the new leaderboard modes.
- Refactored leaderboard logic to handle multiple modes more efficiently.