### PR TITLE
Enhance Metadata for SEO and User Experience on Review Guesser Pages

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -53,7 +53,10 @@ const xenon = localFont({
 const description = 'Steam Review Guessing Game';
 
 export const metadata: Metadata = {
-    title: 'Steam5',
+    title: {
+        default: 'Steam5',
+        template: '%s | Steam5',
+    },
     description: description,
     keywords: 'Review, Steam, Guessing Game',
     creator: 'Luca Nerlich',

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,4 @@
+import type {Metadata} from "next";
 import Link from "next/link";
 import {Routes} from "./routes";
 
@@ -15,3 +16,20 @@ export default function Home() {
         </section>
     );
 }
+
+export const metadata: Metadata = {
+    title: 'Home',
+    description: 'Steam5 — Steam Review guessing games.',
+    openGraph: {
+        title: 'Home',
+        description: 'Steam5 — Steam Review guessing games.',
+        url: '/',
+        images: ['/opengraph-image'],
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Home',
+        description: 'Steam5 — Steam Review guessing games.',
+        images: ['/opengraph-image'],
+    },
+};

--- a/frontend/app/review-guesser/archive/[date]/page.tsx
+++ b/frontend/app/review-guesser/archive/[date]/page.tsx
@@ -1,3 +1,4 @@
+import type {Metadata} from "next";
 import type {ReviewGameState} from "@/types/review-game";
 import ReviewGuesserHero from "@/components/ReviewGuesserHero";
 import Link from "next/link";
@@ -50,6 +51,29 @@ export default async function ArchivePage({params}: { params: Promise<{ date: st
             <Link href="/review-guesser/1" className="btn-ghost">Back to today’s game</Link>
         </section>
     );
+}
+
+export async function generateMetadata({params}: { params: Promise<{ date: string }> }): Promise<Metadata> {
+    const {date} = await params;
+    const title = `Archive — ${formatDate(date)}`;
+    const description = `Past daily challenge for ${formatDate(date)} — Steam Review Guesser.`;
+    const ogUrl = '/opengraph-image';
+    return {
+        title,
+        description,
+        openGraph: {
+            title,
+            description,
+            url: `/review-guesser/archive/${encodeURIComponent(date)}`,
+            images: [ogUrl],
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title,
+            description,
+            images: [ogUrl],
+        },
+    };
 }
 
 

--- a/frontend/app/review-guesser/archive/page.tsx
+++ b/frontend/app/review-guesser/archive/page.tsx
@@ -1,4 +1,5 @@
 export const revalidate = 600;
+import type {Metadata} from "next";
 import "@/styles/components/archive-list.css";
 
 async function loadDays(): Promise<string[]> {
@@ -60,5 +61,22 @@ export default async function ArchiveIndexPage() {
         </section>
     );
 }
+
+export const metadata: Metadata = {
+    title: 'Archive',
+    description: 'Browse previous daily challenges for Steam Review Guesser.',
+    openGraph: {
+        title: 'Archive',
+        description: 'Browse previous daily challenges for Steam Review Guesser.',
+        url: '/review-guesser/archive',
+        images: ['/opengraph-image'],
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Archive',
+        description: 'Browse previous daily challenges for Steam Review Guesser.',
+        images: ['/opengraph-image'],
+    },
+};
 
 

--- a/frontend/app/review-guesser/leaderboard/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/page.tsx
@@ -1,3 +1,4 @@
+import type {Metadata} from "next";
 import Link from "next/link";
 import LeaderboardTable from "@/components/LeaderboardTable";
 
@@ -16,5 +17,22 @@ export default async function LeaderboardPage() {
         </section>
     );
 }
+
+export const metadata: Metadata = {
+    title: 'Leaderboard — All-time',
+    description: 'Overall points summed across all days for Steam Review Guesser.',
+    openGraph: {
+        title: 'Leaderboard — All-time',
+        description: 'Overall points summed across all days for Steam Review Guesser.',
+        url: '/review-guesser/leaderboard',
+        images: ['/opengraph-image'],
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Leaderboard — All-time',
+        description: 'Overall points summed across all days for Steam Review Guesser.',
+        images: ['/opengraph-image'],
+    },
+};
 
 

--- a/frontend/app/review-guesser/leaderboard/today/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/today/page.tsx
@@ -1,3 +1,4 @@
+import type {Metadata} from "next";
 import Link from "next/link";
 import LeaderboardTable from "@/components/LeaderboardTable";
 
@@ -16,3 +17,20 @@ export default async function LeaderboardTodayPage() {
         </section>
     );
 }
+
+export const metadata: Metadata = {
+    title: 'Leaderboard — Today',
+    description: "Today's total points by player for Steam Review Guesser.",
+    openGraph: {
+        title: 'Leaderboard — Today',
+        description: "Today's total points by player for Steam Review Guesser.",
+        url: '/review-guesser/leaderboard/today',
+        images: ['/opengraph-image'],
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Leaderboard — Today',
+        description: "Today's total points by player for Steam Review Guesser.",
+        images: ['/opengraph-image'],
+    },
+};

--- a/frontend/app/review-guesser/leaderboard/weekly/page.tsx
+++ b/frontend/app/review-guesser/leaderboard/weekly/page.tsx
@@ -1,3 +1,4 @@
+import type {Metadata} from "next";
 import Link from "next/link";
 import LeaderboardTable from "@/components/LeaderboardTable";
 
@@ -16,3 +17,20 @@ export default async function LeaderboardWeeklyPage() {
         </section>
     );
 }
+
+export const metadata: Metadata = {
+    title: 'Leaderboard — Weekly',
+    description: 'Weekly total points by player for Steam Review Guesser.',
+    openGraph: {
+        title: 'Leaderboard — Weekly',
+        description: 'Weekly total points by player for Steam Review Guesser.',
+        url: '/review-guesser/leaderboard/weekly',
+        images: ['/opengraph-image'],
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Leaderboard — Weekly',
+        description: 'Weekly total points by player for Steam Review Guesser.',
+        images: ['/opengraph-image'],
+    },
+};

--- a/frontend/app/review-guesser/page.tsx
+++ b/frontend/app/review-guesser/page.tsx
@@ -1,7 +1,25 @@
+import type {Metadata} from "next";
 import {redirect} from "next/navigation";
 
 export default function ReviewGuesserEntryPage() {
     redirect('/review-guesser/1');
 }
+
+export const metadata: Metadata = {
+    title: 'Review Guesser',
+    description: 'Play the Steam Review guessing game — 5 daily rounds.',
+    openGraph: {
+        title: 'Review Guesser',
+        description: 'Play the Steam Review guessing game — 5 daily rounds.',
+        url: '/review-guesser',
+        images: ['/opengraph-image'],
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Review Guesser',
+        description: 'Play the Steam Review guessing game — 5 daily rounds.',
+        images: ['/opengraph-image'],
+    },
+};
 
 


### PR DESCRIPTION
- Added `Metadata` import from `next` in multiple components:
  - Weekly leaderboard (`weekly/page.tsx`)
  - Layout enhancements (`layout.tsx`)
  - Review guesser entry page (`page.tsx`)
  - Today's leaderboard (`today/page.tsx`)
  - Archive main and specific date pages (`archive/page.tsx`, `[date]/page.tsx`)

- Integrated structured metadata for SEO optimization, including:
  - Titles with relevant keywords
  - Descriptive content
  - Open Graph and Twitter card settings for enhanced social sharing

This update improves the discoverability and presentation of the Review Guesser game across web platforms.