### PR TITLE
Add ArchiveOfflineRound and ArchiveResetForDay components for offline…

### DIFF
--- a/frontend/src/components/ArchiveOfflineRound.tsx
+++ b/frontend/src/components/ArchiveOfflineRound.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, {useCallback, useEffect, useMemo, useState} from "react";
+import RoundResultDialog from "@/components/RoundResultDialog";
+import RoundResultActions from "@/components/RoundResultActions";
+import type {GuessResponse} from "@/types/review-game";
+import {loadDay, saveRound, type StoredDay} from "@/lib/storage";
+import "@/styles/components/reviewGuesserRound.css";
+import "@/styles/components/reviewRoundResult.css";
+
+type Props = {
+    appId: number;
+    buckets: string[];
+    bucketTitles?: string[];
+    roundIndex: number;
+    totalRounds: number;
+    pickName?: string;
+    gameDate: string;
+    offlineAnswer: { actualBucket: string; totalReviews: number } | null;
+};
+
+export default function ArchiveOfflineRound(props: Readonly<Props>): React.ReactElement {
+    const {appId, buckets, bucketTitles, roundIndex, totalRounds, pickName, gameDate, offlineAnswer} = props;
+
+    const [selectedLabel, setSelectedLabel] = useState<string | null>(null);
+    const [submitted, setSubmitted] = useState<boolean>(false);
+    const [stored, setStored] = useState<StoredDay | null>(null);
+
+    // Prev/next anchors within the archive page
+    const prevHref = useMemo(() => (roundIndex > 1 ? `#round-${roundIndex - 1}` : null), [roundIndex]);
+    const nextHref = useMemo(() => (roundIndex < totalRounds ? `#round-${roundIndex + 1}` : null), [roundIndex, totalRounds]);
+
+    // Build a local GuessResponse when a choice is made
+    const localResponse: GuessResponse | null = useMemo(() => {
+        if (!offlineAnswer || !selectedLabel) return null;
+        return {
+            appId,
+            totalReviews: offlineAnswer.totalReviews,
+            actualBucket: offlineAnswer.actualBucket,
+            correct: offlineAnswer.actualBucket === selectedLabel,
+        } as GuessResponse;
+    }, [appId, offlineAnswer, selectedLabel]);
+
+    // Restore from local storage if already answered
+    useEffect(() => {
+        const d = loadDay(gameDate);
+        setStored(d);
+        const prev = d?.results?.[roundIndex];
+        if (prev && prev.selectedLabel) {
+            setSelectedLabel(prev.selectedLabel);
+            setSubmitted(true);
+        }
+    }, [gameDate, roundIndex]);
+
+    // Persist this round's result when available
+    useEffect(() => {
+        if (!localResponse || !selectedLabel) return;
+        const updated = saveRound(gameDate, roundIndex, totalRounds, {
+            appId,
+            pickName,
+            selectedLabel,
+            actualBucket: localResponse.actualBucket,
+            totalReviews: localResponse.totalReviews,
+            correct: localResponse.correct,
+        });
+        if (updated) setStored(updated);
+        setSubmitted(true);
+    }, [localResponse, selectedLabel, gameDate, roundIndex, totalRounds, appId, pickName]);
+
+    const onSelect = useCallback((label: string) => {
+        if (submitted) return;
+        setSelectedLabel(label);
+    }, [submitted]);
+
+    return (
+        <div className="archive-offline-round">
+            {!submitted && (
+                <>
+                    <h2 id={`guess-submission-${roundIndex}`}>Submit Your Guess (Offline Play)</h2>
+                    <div className="review-round__buttons">
+                        {buckets.map((label, i) => (
+                            <button
+                                key={label}
+                                type="button"
+                                className={`review-round__button${selectedLabel === label ? ' is-selected' : ''}`}
+                                onClick={() => onSelect(label)}
+                                title={(bucketTitles && bucketTitles[i] ? bucketTitles[i] : undefined)}
+                                disabled={!offlineAnswer}
+                            >
+                                {label}
+                            </button>
+                        ))}
+                    </div>
+                    {!offlineAnswer && (
+                        <p className="text-muted review-round__error">Offline answer unavailable, try reloading
+                            later.</p>
+                    )}
+                </>
+            )}
+
+            {(localResponse || (stored?.results?.[roundIndex] && submitted)) && (
+                <RoundResultDialog
+                    buckets={buckets}
+                    selectedLabel={selectedLabel}
+                    result={(localResponse || {
+                        appId,
+                        totalReviews: stored?.results?.[roundIndex]?.totalReviews ?? 0,
+                        actualBucket: stored?.results?.[roundIndex]?.actualBucket ?? (offlineAnswer?.actualBucket ?? ""),
+                        correct: stored?.results?.[roundIndex]?.correct ?? false,
+                    }) as GuessResponse}
+                >
+                    <RoundResultActions appId={appId} prevHref={prevHref} nextHref={nextHref}/>
+                </RoundResultDialog>
+            )}
+        </div>
+    );
+}
+
+

--- a/frontend/src/components/ArchiveResetForDay.tsx
+++ b/frontend/src/components/ArchiveResetForDay.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React, {useEffect, useState} from "react";
+import {clearAll, clearDay, hasAny, hasAnyForDay} from "@/lib/storage";
+
+export default function ArchiveResetForDay({date}: { date: string }): React.ReactElement | null {
+    const [hasAnyDay, setHasAnyDay] = useState(false);
+    const [hasAnyGlobal, setHasAnyGlobal] = useState(false);
+
+    useEffect(() => {
+        setHasAnyDay(hasAnyForDay(date));
+        setHasAnyGlobal(hasAny());
+    }, [date]);
+
+    if (!hasAnyDay && !hasAnyGlobal) return null;
+
+    return (
+        <div className="archive__reset">
+            {hasAnyDay && (
+                <button className="btn-ghost" onClick={() => {
+                    clearDay(date);
+                    setHasAnyDay(false);
+                }}>Reset this day</button>
+            )}
+            {hasAnyGlobal && (
+                <button className="btn-ghost" onClick={() => {
+                    clearAll();
+                    setHasAnyGlobal(false);
+                    setHasAnyDay(false);
+                }}>Reset all archive progress</button>
+            )}
+        </div>
+    );
+}
+
+

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -47,4 +47,33 @@ export function clearAll(): void {
     }
 }
 
+export function clearDay(gameDate: string): void {
+    try {
+        const key = storageKeyForDate(gameDate);
+        window.localStorage.removeItem(key);
+    } catch {
+    }
+}
+
+export function hasAnyForDay(gameDate: string): boolean {
+    try {
+        const data = loadDay(gameDate);
+        return Boolean(data && data.results && Object.keys(data.results).length > 0);
+    } catch {
+        return false;
+    }
+}
+
+export function hasAny(): boolean {
+    try {
+        for (let i = 0; i < localStorage.length; i++) {
+            const k = localStorage.key(i);
+            if (k && k.startsWith('review-guesser:')) return true;
+        }
+        return false;
+    } catch {
+        return false;
+    }
+}
+
 

--- a/frontend/src/styles/components/archive.css
+++ b/frontend/src/styles/components/archive.css
@@ -26,4 +26,21 @@
     margin-bottom: 2rem;
 }
 
+.archive__reset {
+    margin: 1rem 0;
+    display: flex;
+    gap: 0.5rem;
+}
+
+/* Increase spacing for guess buttons only within archive offline rounds */
+.archive-offline-round .review-round__buttons {
+    gap: 12px;
+}
+
+@media (max-width: 640px) {
+    .archive-offline-round .review-round__buttons {
+        gap: 12px;
+    }
+}
+
 

--- a/frontend/src/styles/components/reviewRoundResult.css
+++ b/frontend/src/styles/components/reviewRoundResult.css
@@ -22,7 +22,7 @@
 .review-round__actions-inner {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.6rem;
 }
 
 


### PR DESCRIPTION
… play and reset functionality

- Introduced `ArchiveOfflineRound` to handle offline round play with local storage integration for guessing and result persistence.
- Added `ArchiveResetForDay` to reset archive progress for a specific day or clear all progress.
- Updated archive page to include offline play support and reset options.
- Adjusted styles in `archive.css` and `reviewRoundResult.css` for consistency and spacing refinements.
- Enhanced storage functionality with new methods for clearing day-specific or global progress.