### PR TITLE
Fix avg points per round chart starting at R2 instead of R1

### DIFF
--- a/frontend/src/components/performance/RoundPositionChart.tsx
+++ b/frontend/src/components/performance/RoundPositionChart.tsx
@@ -12,7 +12,7 @@ export default function RoundPositionChart({rounds}: { rounds: Round[] }): React
     const bars = useMemo(() => {
         const groups = new Map<number, { total: number; count: number }>();
         for (const r of rounds) {
-            const pos = (r.roundIndex ?? 0) + 1;
+            const pos = r.roundIndex ?? 1;
             if (!groups.has(pos)) groups.set(pos, {total: 0, count: 0});
             const g = groups.get(pos)!;
             g.total += r.points;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The "Avg points by round position" chart on the profile page starts at R2 instead of R1. This is an off-by-one error.

## Root Cause

In `RoundPositionChart.tsx`, the display position was computed as:

```js
const pos = (r.roundIndex ?? 0) + 1;
```

However, `roundIndex` is already **1-based** from the backend (`ReviewGameStateController.java` sets `roundIndex = foundIdx + 1`). Adding `+1` again in the frontend shifts all labels by one — R1 becomes R2, R2 becomes R3, etc.

## Fix

Use `roundIndex` directly without the extra `+1`, defaulting to 1 when the value is missing:

```js
const pos = r.roundIndex ?? 1;
```

## Changed Files

- `frontend/src/components/performance/RoundPositionChart.tsx` — single line fix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f16b3ddc-1d82-4529-b28d-736c116ac748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f16b3ddc-1d82-4529-b28d-736c116ac748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

