### PR TITLE
Add descriptive legend and tooltips to play activity heatmap

### DIFF
--- a/frontend/src/components/performance/CalendarHeatmap.tsx
+++ b/frontend/src/components/performance/CalendarHeatmap.tsx
@@ -69,6 +69,9 @@ export default function CalendarHeatmap({rounds}: { rounds: Round[] }): React.Re
     return (
         <div className="perf-card perf-card--full">
             <div className="perf-card__title">Play activity (last year)</div>
+            <p style={{color: "var(--color-muted)", fontSize: "0.8rem", margin: "0 0 0.25rem"}}>
+                Color intensity shows average points scored per round each day
+            </p>
             <div className="perf-heatmap-wrap">
                 <svg
                     viewBox={`0 0 ${svgW} ${svgH}`}
@@ -109,13 +112,16 @@ export default function CalendarHeatmap({rounds}: { rounds: Round[] }): React.Re
                             rx={2}
                             fill={avg === null ? "var(--color-border)" : "var(--color-primary, #6366f1)"}
                             fillOpacity={avg === null ? 0.5 : 0.15 + (avg / 5) * 0.85}
-                            aria-label={avg !== null ? `${dateStr}: ${avg.toFixed(1)} avg pts` : `${dateStr}: no play`}
-                        />
+                            aria-label={avg !== null ? `${dateStr}: ${avg.toFixed(1)} avg pts/round` : `${dateStr}: no play`}
+                        >
+                            <title>{avg !== null ? `${dateStr}\n${avg.toFixed(1)} avg pts/round` : `${dateStr}\nNo play`}</title>
+                        </rect>
                     ))}
                 </svg>
             </div>
             <div className="perf-heatmap-legend">
-                <span style={{color: "var(--color-muted)", fontSize: "0.75rem"}}>Less</span>
+                <span style={{color: "var(--color-muted)", fontSize: "0.75rem"}}>Avg pts/round:</span>
+                <span style={{color: "var(--color-muted)", fontSize: "0.75rem"}}>0</span>
                 {[0, 0.25, 0.5, 0.75, 1].map(t => (
                     <span
                         key={t}
@@ -130,7 +136,7 @@ export default function CalendarHeatmap({rounds}: { rounds: Round[] }): React.Re
                         }}
                     />
                 ))}
-                <span style={{color: "var(--color-muted)", fontSize: "0.75rem"}}>More</span>
+                <span style={{color: "var(--color-muted)", fontSize: "0.75rem"}}>5</span>
             </div>
         </div>
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The play activity year chart on the profile page previously had a vague legend with just "Less" and "More" labels, leaving users guessing what the colored squares represent. This PR makes the chart self-explanatory.

## Changes

**`frontend/src/components/performance/CalendarHeatmap.tsx`**

1. **Added subtitle** below the chart title: *"Color intensity shows average points scored per round each day"* — immediately explains the chart's purpose.

2. **Improved legend labels** — replaced the generic "Less" / "More" with explicit **"Avg pts/round: 0 ... 5"** so users understand the scale and its units.

3. **Added native hover tooltips** — each cell now contains an SVG `<title>` element showing the date and average points per round (e.g. "2025-12-15\n3.2 avg pts/round"), giving users exact values on hover.

4. **Updated aria-labels** to use "avg pts/round" for improved accessibility.

## Before / After

| Before | After |
|--------|-------|
| Legend: `Less ▪▪▪▪▪ More` | Legend: `Avg pts/round: 0 ▪▪▪▪▪ 5` |
| No subtitle | Subtitle: "Color intensity shows average points scored per round each day" |
| No hover tooltip | Hover shows date + avg pts/round |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4be931f3-5668-480b-a947-3c502c8a3d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4be931f3-5668-480b-a947-3c502c8a3d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

