### PR TITLE
Clarify improvement trend chart with timeframe context

### DIFF
--- a/frontend/src/components/performance/ImprovementTrend.tsx
+++ b/frontend/src/components/performance/ImprovementTrend.tsx
@@ -2,19 +2,37 @@
 
 import React, {useMemo} from "react";
 
-type Round = { points: number };
+type Round = { points: number; date?: string };
 
 function avgPoints(rs: Round[]): number {
     return rs.reduce((s, r) => s + r.points, 0) / rs.length;
 }
 
 export default function ImprovementTrend({rounds}: { rounds: Round[] }): React.ReactElement {
-    const {early, recent, delta} = useMemo(() => {
-        if (rounds.length < 6) return {early: null, recent: null, delta: null};
-        const third = Math.floor(rounds.length / 3);
-        const e = avgPoints(rounds.slice(0, third));
-        const r = avgPoints(rounds.slice(rounds.length - third));
-        return {early: e, recent: r, delta: r - e};
+    const {early, recent, delta, third, earlyLabel, recentLabel} = useMemo(() => {
+        if (rounds.length < 6) return {early: null, recent: null, delta: null, third: 0, earlyLabel: "", recentLabel: ""};
+        const t = Math.floor(rounds.length / 3);
+        const earlySlice = rounds.slice(0, t);
+        const recentSlice = rounds.slice(rounds.length - t);
+        const e = avgPoints(earlySlice);
+        const r = avgPoints(recentSlice);
+
+        const fmtLabel = (slice: Round[]): string => {
+            const dates = slice.map(rd => rd.date).filter(Boolean) as string[];
+            if (dates.length >= 2) {
+                const first = dates[0];
+                const last = dates[dates.length - 1];
+                const fmt = (d: string) => {
+                    const parts = d.split("-");
+                    return `${parts[1]}/${parts[2]}`;
+                };
+                if (first === last) return fmt(first);
+                return `${fmt(first)} – ${fmt(last)}`;
+            }
+            return "";
+        };
+
+        return {early: e, recent: r, delta: r - e, third: t, earlyLabel: fmtLabel(earlySlice), recentLabel: fmtLabel(recentSlice)};
     }, [rounds]);
 
     const noData = delta === null;
@@ -39,6 +57,10 @@ export default function ImprovementTrend({rounds}: { rounds: Round[] }): React.R
     const plotH = HEIGHT - PAD.top - PAD.bottom;
     const yScale = (v: number) => PAD.top + plotH - (Math.max(0, Math.min(5, v)) / 5) * plotH;
 
+    const subtitle = noData
+        ? null
+        : `First ${third} vs last ${third} of ${rounds.length} rounds`;
+
     return (
         <div className="perf-card">
             <div className="perf-card__title">Improvement trend</div>
@@ -47,48 +69,69 @@ export default function ImprovementTrend({rounds}: { rounds: Round[] }): React.R
                     Not enough data (need at least 6 rounds)
                 </p>
             ) : (
-                <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="perf-line" role="img"
-                     aria-label={`Improvement trend: early avg ${early!.toFixed(2)}, recent avg ${recent!.toFixed(2)}`}>
-                    {/* Reference lines */}
-                    {[0, 5].map(v => (
-                        <line key={v} x1={PAD.left} x2={WIDTH - PAD.right} y1={yScale(v)} y2={yScale(v)}
-                              stroke="var(--color-border)" strokeOpacity="0.4" strokeWidth="1"/>
-                    ))}
-                    {/* Connecting line */}
-                    <line
-                        x1={PAD.left + plotW * 0.18}
-                        y1={yScale(early!)}
-                        x2={PAD.left + plotW * 0.82}
-                        y2={yScale(recent!)}
-                        stroke={trendColor}
-                        strokeWidth="2"
-                        strokeDasharray={improving || declining ? "none" : "4 3"}
-                        opacity="0.7"
-                    />
-                    {/* Early dot */}
-                    <circle cx={PAD.left + plotW * 0.18} cy={yScale(early!)} r="5"
-                            fill="var(--color-primary, #6366f1)" fillOpacity="0.7"/>
-                    <text x={PAD.left + plotW * 0.18} y={yScale(early!) - 8} fontSize="11"
-                          fill="var(--color-muted)" textAnchor="middle">Early</text>
-                    <text x={PAD.left + plotW * 0.18} y={yScale(early!) + 18} fontSize="12"
-                          fill="var(--color-primary, #6366f1)" textAnchor="middle" fontWeight="600">
-                        {early!.toFixed(2)}
-                    </text>
-                    {/* Recent dot */}
-                    <circle cx={PAD.left + plotW * 0.82} cy={yScale(recent!)} r="5"
-                            fill={trendColor} fillOpacity="0.9"/>
-                    <text x={PAD.left + plotW * 0.82} y={yScale(recent!) - 8} fontSize="11"
-                          fill="var(--color-muted)" textAnchor="middle">Recent</text>
-                    <text x={PAD.left + plotW * 0.82} y={yScale(recent!) + 18} fontSize="12"
-                          fill={trendColor} textAnchor="middle" fontWeight="600">
-                        {recent!.toFixed(2)}
-                    </text>
-                    {/* Trend label */}
-                    <text x={WIDTH / 2} y={HEIGHT - 1} fontSize="11" fill={trendColor}
-                          textAnchor="middle" fontWeight="600">
-                        {trendArrow} {trendLabel} ({delta! >= 0 ? "+" : ""}{delta!.toFixed(2)})
-                    </text>
-                </svg>
+                <>
+                    <p style={{color: "var(--color-muted)", fontSize: "0.75rem", margin: "0.15rem 0 0.35rem", lineHeight: 1.3}}>
+                        {subtitle}
+                    </p>
+                    <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="perf-line" role="img"
+                         aria-label={`Improvement trend: first ${third} rounds avg ${early!.toFixed(2)}, last ${third} rounds avg ${recent!.toFixed(2)}`}>
+                        {/* Reference lines */}
+                        {[0, 5].map(v => (
+                            <line key={v} x1={PAD.left} x2={WIDTH - PAD.right} y1={yScale(v)} y2={yScale(v)}
+                                  stroke="var(--color-border)" strokeOpacity="0.4" strokeWidth="1"/>
+                        ))}
+                        {/* Connecting line */}
+                        <line
+                            x1={PAD.left + plotW * 0.18}
+                            y1={yScale(early!)}
+                            x2={PAD.left + plotW * 0.82}
+                            y2={yScale(recent!)}
+                            stroke={trendColor}
+                            strokeWidth="2"
+                            strokeDasharray={improving || declining ? "none" : "4 3"}
+                            opacity="0.7"
+                        />
+                        {/* Early dot */}
+                        <circle cx={PAD.left + plotW * 0.18} cy={yScale(early!)} r="5"
+                                fill="var(--color-primary, #6366f1)" fillOpacity="0.7"/>
+                        <text x={PAD.left + plotW * 0.18} y={yScale(early!) - 8} fontSize="10"
+                              fill="var(--color-muted)" textAnchor="middle">
+                            {earlyLabel ? `First ${third}` : "First ⅓"}
+                        </text>
+                        <text x={PAD.left + plotW * 0.18} y={yScale(early!) + 16} fontSize="12"
+                              fill="var(--color-primary, #6366f1)" textAnchor="middle" fontWeight="600">
+                            {early!.toFixed(2)}
+                        </text>
+                        {earlyLabel && (
+                            <text x={PAD.left + plotW * 0.18} y={yScale(early!) + 28} fontSize="9"
+                                  fill="var(--color-muted)" textAnchor="middle" opacity="0.8">
+                                {earlyLabel}
+                            </text>
+                        )}
+                        {/* Recent dot */}
+                        <circle cx={PAD.left + plotW * 0.82} cy={yScale(recent!)} r="5"
+                                fill={trendColor} fillOpacity="0.9"/>
+                        <text x={PAD.left + plotW * 0.82} y={yScale(recent!) - 8} fontSize="10"
+                              fill="var(--color-muted)" textAnchor="middle">
+                            {recentLabel ? `Last ${third}` : "Last ⅓"}
+                        </text>
+                        <text x={PAD.left + plotW * 0.82} y={yScale(recent!) + 16} fontSize="12"
+                              fill={trendColor} textAnchor="middle" fontWeight="600">
+                            {recent!.toFixed(2)}
+                        </text>
+                        {recentLabel && (
+                            <text x={PAD.left + plotW * 0.82} y={yScale(recent!) + 28} fontSize="9"
+                                  fill="var(--color-muted)" textAnchor="middle" opacity="0.8">
+                                {recentLabel}
+                            </text>
+                        )}
+                        {/* Trend label */}
+                        <text x={WIDTH / 2} y={HEIGHT - 1} fontSize="11" fill={trendColor}
+                              textAnchor="middle" fontWeight="600">
+                            {trendArrow} {trendLabel} ({delta! >= 0 ? "+" : ""}{delta!.toFixed(2)})
+                        </text>
+                    </svg>
+                </>
             )}
         </div>
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The improvement trend chart on the profile page displayed vague "Early" and "Recent" labels on its two data points, with no explanation of what timeframe or how many rounds were being compared. This made the chart confusing — users couldn't understand what they were looking at.

## Solution

Updated `ImprovementTrend.tsx` to provide clear context:

1. **Subtitle** — Added a descriptive subtitle below the card title explaining the methodology, e.g. *"First 10 vs last 10 of 30 rounds"*
2. **Specific dot labels** — Replaced the vague "Early" / "Recent" labels with "First N" / "Last N" where N is the actual number of rounds in each group
3. **Date ranges** — When round dates are available (they always are on the profile page), the chart now shows the date range for each group (e.g. "04/01 – 04/05") beneath each data point
4. **Improved accessibility** — Updated the `aria-label` on the SVG to include round counts for screen readers

## How it works

The component splits all rounds into thirds and compares the first third (oldest) against the last third (most recent). The middle third is excluded to create a clearer comparison. This logic is unchanged — only the labels and context are new.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03668897-c73a-4f29-af1d-239ebe0412ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03668897-c73a-4f29-af1d-239ebe0412ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

