### PR TITLE
fix: make Best & Worst Bucket cards responsive on profile page

### DIFF
--- a/frontend/src/components/performance/BucketAccuracyBars.tsx
+++ b/frontend/src/components/performance/BucketAccuracyBars.tsx
@@ -14,8 +14,6 @@ export default function BucketAccuracyBars({rounds}: { rounds: Round[] }): React
         const cutoffStr = cutoffDate.toISOString().slice(0, 10);
         return rounds.filter(r => r.date && r.date >= cutoffStr);
     }, [rounds]);
-    const width = 600;
-    const padding = 24;
 
     const stats = useMemo(() => {
         const map = new Map<string, { hits: number; total: number }>();
@@ -35,35 +33,27 @@ export default function BucketAccuracyBars({rounds}: { rounds: Round[] }): React
             .map(([label, v]) => ({label, pct: v.total > 0 ? (v.hits / v.total) * 100 : 0}));
     }, [last]);
 
-    const rowH = 26;
-    const svgH = Math.max(1, stats.length) * rowH + 10;
-    const barX = padding + 100;
-    const barW = width - padding * 2 - 112;
-
     return (
         <div className="perf-card">
             <div className="perf-card__title">Accuracy by bucket (last {DAYS_WINDOW} days)</div>
             {stats.length === 0 ? (
                 <p className="text-muted">No data</p>
             ) : (
-                <svg viewBox={`0 0 ${width} ${svgH}`} className="perf-line" role="img" aria-label="Accuracy by bucket">
-                    <rect x="0" y="0" width={width} height={svgH} fill="transparent"/>
-                    {stats.map((row, i) => {
-                        const y = 8 + i * rowH;
-                        const filled = Math.max(0, Math.min(1, row.pct / 100)) * barW;
-                        return (
-                            <g key={row.label}>
-                                <text x={padding} y={y + 14} fontSize="14" fill="var(--color-muted)" textAnchor="start">{row.label}</text>
-                                <rect x={barX} y={y} width={barW} height={14} fill="var(--color-border)" />
-                                <rect x={barX} y={y} width={filled} height={14} fill="var(--color-primary, #6366f1)" />
-                                <text x={barX + barW + 4} y={y + 14} fontSize="14" fill="var(--color-muted)" textAnchor="start">{Math.round(row.pct)}%</text>
-                            </g>
-                        );
-                    })}
-                </svg>
+                <div className="bucket-bars" role="img" aria-label="Accuracy by bucket">
+                    {stats.map((row) => (
+                        <div key={row.label} className="bucket-bars__row">
+                            <span className="bucket-bars__label">{row.label}</span>
+                            <div className="bucket-bars__track">
+                                <div
+                                    className="bucket-bars__fill"
+                                    style={{width: `${Math.max(0, Math.min(100, row.pct))}%`}}
+                                />
+                            </div>
+                            <span className="bucket-bars__pct">{Math.round(row.pct)}%</span>
+                        </div>
+                    ))}
+                </div>
             )}
         </div>
     );
 }
-
-

--- a/frontend/src/components/performance/BucketCallouts.tsx
+++ b/frontend/src/components/performance/BucketCallouts.tsx
@@ -6,6 +6,21 @@ type Round = { selectedBucket: string; actualBucket: string };
 
 const MIN_ROUNDS = 20;
 
+function PctBar({pct, color}: { pct: number; color: string }) {
+    const widthPct = Math.max(0, Math.min(1, pct)) * 100;
+    return (
+        <div className="bucket-callout__bar-track">
+            <div className="bucket-callout__bar-bg">
+                <div
+                    className="bucket-callout__bar-fill"
+                    style={{width: `${widthPct}%`, backgroundColor: color}}
+                />
+            </div>
+            <span className="bucket-callout__bar-pct">{Math.round(pct * 100)}%</span>
+        </div>
+    );
+}
+
 export default function BucketCallouts({rounds}: { rounds: Round[] }): React.ReactElement {
     const {best, worst} = useMemo(() => {
         const stats = new Map<string, { hits: number; total: number }>();
@@ -29,25 +44,6 @@ export default function BucketCallouts({rounds}: { rounds: Round[] }): React.Rea
 
     const hasData = best !== null;
 
-    const WIDTH = 300;
-    const HEIGHT = hasData ? 110 : 40;
-    const PAD = {top: 8, right: 12, bottom: 8, left: 12};
-    const barW = WIDTH - PAD.left - PAD.right;
-    const barH = 12;
-
-    function pctBar(pct: number, color: string, y: number) {
-        return (
-            <g>
-                <rect x={PAD.left} y={y} width={barW} height={barH} rx={2}
-                      fill="var(--color-border)" fillOpacity="0.3"/>
-                <rect x={PAD.left} y={y} width={Math.max(0, pct) * barW} height={barH} rx={2}
-                      fill={color} fillOpacity="0.85"/>
-                <text x={PAD.left + barW + 4} y={y + barH * 0.85} fontSize="10"
-                      fill="var(--color-muted)">{Math.round(pct * 100)}%</text>
-            </g>
-        );
-    }
-
     return (
         <div className="perf-card">
             <div className="perf-card__title">Best &amp; worst bucket</div>
@@ -56,26 +52,24 @@ export default function BucketCallouts({rounds}: { rounds: Round[] }): React.Rea
                     Need at least {MIN_ROUNDS} rounds per bucket
                 </p>
             ) : (
-                <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="perf-line" role="img"
-                     aria-label="Best and worst price bucket by hit rate">
-                    {/* Best */}
-                    <text x={PAD.left} y={PAD.top + 8} fontSize="10" fill="var(--color-muted)">
-                        Best: <tspan fontWeight="600" fill="var(--color-success, #16a34a)">{best!.label}</tspan>
-                        <tspan fill="var(--color-muted)"> ({best!.total} rounds)</tspan>
-                    </text>
-                    {pctBar(best!.pct, "var(--color-success, #16a34a)", PAD.top + 14)}
-
-                    {/* Worst */}
+                <div className="bucket-callout" role="img" aria-label="Best and worst bucket by hit rate">
+                    <div className="bucket-callout__row">
+                        <span className="bucket-callout__label">
+                            Best: <strong className="bucket-callout__label--success">{best!.label}</strong>
+                            <span className="bucket-callout__rounds">({best!.total} rounds)</span>
+                        </span>
+                        <PctBar pct={best!.pct} color="var(--color-success, #16a34a)" />
+                    </div>
                     {worst && worst.label !== best!.label && (
-                        <>
-                            <text x={PAD.left} y={PAD.top + 50} fontSize="10" fill="var(--color-muted)">
-                                Worst: <tspan fontWeight="600" fill="var(--color-danger, #ef4444)">{worst.label}</tspan>
-                                <tspan fill="var(--color-muted)"> ({worst.total} rounds)</tspan>
-                            </text>
-                            {pctBar(worst.pct, "var(--color-danger, #ef4444)", PAD.top + 56)}
-                        </>
+                        <div className="bucket-callout__row">
+                            <span className="bucket-callout__label">
+                                Worst: <strong className="bucket-callout__label--danger">{worst.label}</strong>
+                                <span className="bucket-callout__rounds">({worst.total} rounds)</span>
+                            </span>
+                            <PctBar pct={worst.pct} color="var(--color-danger, #ef4444)" />
+                        </div>
                     )}
-                </svg>
+                </div>
             )}
         </div>
     );

--- a/frontend/src/styles/components/profile.css
+++ b/frontend/src/styles/components/profile.css
@@ -228,6 +228,125 @@
     margin-top: 0.2rem;
 }
 
+/* BucketCallouts (best & worst bucket) */
+.bucket-callout {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.bucket-callout__row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.bucket-callout__label {
+    font-size: 0.8rem;
+    color: var(--color-muted);
+}
+
+.bucket-callout__label--success {
+    color: var(--color-success, #16a34a);
+}
+
+.bucket-callout__label--danger {
+    color: var(--color-danger, #ef4444);
+}
+
+.bucket-callout__rounds {
+    margin-left: 0.25rem;
+}
+
+.bucket-callout__bar-track {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.bucket-callout__bar-bg {
+    flex: 1;
+    height: 0.75rem;
+    border-radius: 2px;
+    background: var(--color-border);
+    opacity: 0.3;
+    overflow: hidden;
+    min-width: 0;
+}
+
+.bucket-callout__bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    opacity: 0.85;
+}
+
+.bucket-callout__bar-pct {
+    font-size: 0.75rem;
+    color: var(--color-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+/* BucketAccuracyBars (accuracy by bucket chart) */
+.bucket-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.bucket-bars__row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 1.25rem;
+}
+
+.bucket-bars__label {
+    flex-shrink: 0;
+    width: 6.5rem;
+    font-size: 0.8rem;
+    color: var(--color-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bucket-bars__track {
+    flex: 1;
+    height: 0.75rem;
+    background: var(--color-border);
+    border-radius: 2px;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.bucket-bars__fill {
+    height: 100%;
+    background: var(--color-primary, #6366f1);
+    border-radius: 2px;
+    transition: width 0.2s ease;
+}
+
+.bucket-bars__pct {
+    flex-shrink: 0;
+    width: 2.5rem;
+    text-align: right;
+    font-size: 0.8rem;
+    color: var(--color-muted);
+}
+
+@media (max-width: 720px) {
+    .bucket-bars__label {
+        width: 5rem;
+        font-size: 0.75rem;
+    }
+
+    .bucket-bars__pct {
+        width: 2rem;
+        font-size: 0.75rem;
+    }
+}
+
 .profile__table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The "Best & worst bucket" (`BucketCallouts`) and "Accuracy by bucket" (`BucketAccuracyBars`) cards on the profile page were not responsive. Both components used SVG elements with fixed `viewBox` dimensions (300×110 and 600×dynamic), which caused:

- Text becoming unreadably small on narrow viewports as the SVG scales uniformly
- Percentage labels clipping outside the visible area
- Labels and bars crowding or overlapping on mobile screens

## Solution

Replaced both SVG-based layouts with native HTML/CSS flexbox layouts that naturally reflow at any viewport width.

### BucketCallouts (Best & worst bucket)
- Replaced SVG with stacked `div` rows, each containing a text label and a CSS-based progress bar
- The bar track uses `flex: 1` so it stretches to fill all available width
- Percentage text remains visible without clipping at any size
- Fixed incorrect `aria-label` that referenced "price bucket" instead of just "bucket"

### BucketAccuracyBars (Accuracy by bucket)
- Replaced SVG horizontal bar chart with CSS flexbox rows
- Each row has: a fixed-width label, a flexible bar track, and a fixed-width percentage
- Labels truncate with ellipsis when the viewport is too narrow
- Added a `@media (max-width: 720px)` breakpoint to reduce label and percentage widths on mobile

## Files Changed

- `frontend/src/components/performance/BucketCallouts.tsx` — SVG → HTML/CSS
- `frontend/src/components/performance/BucketAccuracyBars.tsx` — SVG → HTML/CSS
- `frontend/src/styles/components/profile.css` — new CSS classes for both components
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-234a05af-be91-4440-aa75-29da267c0874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-234a05af-be91-4440-aa75-29da267c0874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

