### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2026-04-13
+
+### Fixed
+
+- Average points per round position chart on the profile page no longer starts at R2; fixed off-by-one error where the
+  already 1-based `roundIndex` was incorrectly incremented again in the frontend
+- Best & worst bucket callout and accuracy-by-bucket bar chart on the profile page are now fully responsive; replaced
+  fixed-size SVG layouts with native HTML/CSS flexbox that reflows correctly on narrow viewports
+- Improvement trend chart now shows concrete context: subtitle with round counts ("First 10 vs last 10 of 30 rounds"),
+  specific "First N" / "Last N" dot labels, and date ranges beneath each data point
+
+### Improved
+
+- Play activity heatmap legend now reads "Avg pts/round: 0 … 5" instead of the vague "Less / More"; added a subtitle
+  explaining color intensity and native hover tooltips showing the exact date and average on each cell
+
+### Removed
+
+- Perfect days card removed from the profile performance section (leaderboard achievement is unaffected)
+
 ## [1.4.0] - 2026-04-13
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "steam5",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "private": true,
     "homepage": "https://steam5.org",
     "scripts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release v1.4.1

Bumps `package.json` version from `1.4.0` → `1.4.1`, updates `CHANGELOG.md`, and tags `v1.4.1`.

### What's included (PRs #52–#56)

**Fixed**
- Avg points per round position chart no longer starts at R2 (off-by-one fix) — #52
- Best & worst bucket callout and accuracy bars are now responsive (SVG → HTML/CSS flexbox) — #55
- Improvement trend chart shows concrete context: round counts, specific labels, and date ranges — #54

**Improved**
- Play activity heatmap legend, subtitle, and hover tooltips for clarity — #53

**Removed**
- Perfect days card from the profile performance section (leaderboard achievement unaffected) — #56
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afff3fa3-3143-4a0e-8394-1a52ba50a6d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afff3fa3-3143-4a0e-8394-1a52ba50a6d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

