### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Architecture
+
+Steam5 is a monorepo with two independent sub-projects:
+
+- **Backend** (`backend/`): Spring Boot 4.0.5, Java 21, Gradle 9.4.1, PostgreSQL
+- **Frontend** (`frontend/`): Next.js 16, React 19, TypeScript, pnpm 10.15.1, Node 22
+
+Standard commands are documented in `README.md` and `.junie/guidelines.md`.
+
+### Services
+
+| Service | Port | Start command |
+|---------|------|---------------|
+| PostgreSQL | 5432 | `pg_ctlcluster 16 main start` |
+| Backend | 8080 | `cd backend && ./gradlew bootRun` |
+| Frontend | 3000 | `cd frontend && pnpm dev` |
+| Actuator (dev) | 8081 | Starts automatically with backend |
+
+### Database setup (one-time)
+
+PostgreSQL must be running before the backend starts. Database `steam5_db` with user `steam5_user` / password `steam5_password` must exist. See `backend/setup-local-db.sql` or run:
+
+```
+sudo -u postgres psql -c "CREATE DATABASE steam5_db;"
+sudo -u postgres psql -c "CREATE ROLE steam5_user WITH LOGIN PASSWORD 'steam5_password' CREATEDB SUPERUSER;"
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE steam5_db TO steam5_user;"
+sudo -u postgres psql -d steam5_db -c "GRANT ALL ON SCHEMA public TO steam5_user;"
+```
+
+### Backend `.env` file
+
+The backend loads env vars from `backend/.env` via spring-dotenv. Copy from `backend/.env.example` and fill in values. For local dev without Steam API access, dummy values work (Steam API jobs will fail gracefully but the app runs):
+
+```
+STEAM_API_KEY=dummy-dev-key
+ADMIN_API_TOKEN=dev-admin-token
+AUTH_JWT_SECRET=dev-jwt-secret-change-me-32-bytes-minimum-length
+```
+
+### Gotchas
+
+- The frontend redirects `/` to `/review-guesser/1` (HTTP 308). Use `curl -L` when testing.
+- Actuator (port 8081) requires authentication via Spring Security in the dev profile.
+- All Quartz jobs are enabled in the `dev` profile (`application-dev.yml`). Jobs that call the Steam API will log errors with a dummy API key but do not block startup.
+- Backend tests: 2 tests (`AuthControllerTest.validate_token_ok_and_invalid` and `LeaderboardControllerTest.allTime_returnsAggregatedLeaders`) are pre-existing failures due to test/production code drift. The remaining 17 tests pass.
+- Flyway migrations and Hibernate `ddl-auto: update` both run on startup. Schema is auto-managed.
+- No ESLint config exists for the frontend; use `pnpm build` as the lint/type check.
+- Node 22 is installed via nvm. Source nvm before running frontend commands: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development environment instructions for future agents.

### What's included

- Architecture overview (backend: Spring Boot 4.0.5 / Java 21, frontend: Next.js 16 / React 19)
- Service table with ports and start commands
- Database setup instructions (PostgreSQL 16, `steam5_db`)
- Backend `.env` configuration guidance
- Known gotchas (pre-existing test failures, nvm sourcing, actuator auth, Quartz job behavior)

### Environment verification

All services verified working:

| Service | Status | Command |
|---------|--------|---------|
| Backend API (`:8080`) | Working | `./gradlew bootRun` |
| Frontend dev (`:3000`) | Working | `pnpm dev` |
| PostgreSQL (`:5432`) | Working | `pg_ctlcluster 16 main start` |
| Backend tests | 17/19 pass (2 pre-existing failures) | `./gradlew test` |
| Frontend build | Pass | `pnpm build` |

### Demo

[steam5_app_demo.mp4](https://cursor.com/agents/bc-1c6095c7-b229-4c00-9646-d7b265cfdd04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsteam5_app_demo.mp4)

Game page, leaderboard, and seasons pages all rendering correctly.

[Game page](https://cursor.com/agents/bc-1c6095c7-b229-4c00-9646-d7b265cfdd04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgame_page.webp)
[Leaderboard page](https://cursor.com/agents/bc-1c6095c7-b229-4c00-9646-d7b265cfdd04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fleaderboard_page.webp)
[Seasons page](https://cursor.com/agents/bc-1c6095c7-b229-4c00-9646-d7b265cfdd04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseasons_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c6095c7-b229-4c00-9646-d7b265cfdd04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c6095c7-b229-4c00-9646-d7b265cfdd04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

