### PR TITLE
Add Grafana + Prometheus monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,12 @@ Security: token-based auth via Steam login. See `frontend/app/api/auth/*` and `b
 Notes
 
 - You’ll only see cache metrics after endpoints using `@Cacheable` are exercised.
-- In dev, actuator on port 8081 is open (no auth). If you want it restricted to specific endpoints, update
-  `SecurityConfig` to narrow `EndpointRequest`.
+- Actuator runs on its own management port (`MANAGEMENT_SERVER_PORT`, default `8081`) and is protected
+  by HTTP Basic auth. In dev the credentials default to `metrics` / `metrics`; `/actuator/health` is
+  the only endpoint that remains publicly reachable. In production (coolify) the same scheme applies and
+  the defaults **must** be overridden via `METRICS_USERNAME` / `METRICS_PASSWORD` — the backend logs a
+  startup `WARN` if the dev defaults are still in use. To narrow exposure further, adjust
+  `SecurityConfig` / `EndpointRequest`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,30 @@ Notes
 
 ---
 
+## Monitoring (Prometheus + Grafana)
+
+A self-contained Prometheus + Grafana stack lives in [`monitoring/`](monitoring/README.md) and scrapes
+the backend's `/actuator/prometheus` endpoint over HTTP basic auth.
+
+- **Stack**: Prometheus 3.5.1, Grafana 12.3.1 (image tags pinned in `monitoring/.env.example`).
+- **Dashboards**: 5 provisioned dashboards (JVM, HTTP server, HikariCP, Caches, Quartz jobs).
+- **Local quick start** (with the backend already running on `MANAGEMENT_SERVER_PORT=8081`):
+
+  ```bash
+  cd monitoring
+  cp .env.example .env
+  docker compose --env-file .env up -d
+  ```
+
+- **URLs**: Prometheus at <http://localhost:9090>, Grafana at <http://localhost:3001>
+  (default credentials `admin` / `admin` — change in `.env`).
+
+See [`monitoring/README.md`](monitoring/README.md) for the full reference, environment variable table,
+cross-platform notes (macOS vs. Linux `host.docker.internal`), Coolify production deployment guide,
+and troubleshooting.
+
+---
+
 ## Frontend (Next.js)
 
 - Next 15, App Router, TypeScript

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,11 @@ ADMIN_API_TOKEN=
 
 # openssl rand -base64 48
 AUTH_JWT_SECRET=
+
+# Spring Boot management/actuator port (defaults to 8081)
+# MANAGEMENT_SERVER_PORT=8081
+
+# Comma-separated actuator endpoints to expose
+# Default (dev): loggers,env,beans,health,prometheus,metrics,quartz
+# Default (coolify): health,prometheus
+# MANAGEMENT_ENDPOINTS_EXPOSURE=health,prometheus

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,3 +11,11 @@ AUTH_JWT_SECRET=
 # Default (dev): loggers,env,beans,health,prometheus,metrics,quartz
 # Default (coolify): health,prometheus
 # MANAGEMENT_ENDPOINTS_EXPOSURE=health,prometheus
+
+# HTTP Basic credentials for the protected actuator endpoints (e.g. /actuator/prometheus).
+# /actuator/health remains anonymous. Defaults are "metrics" / "metrics" so dev works
+# zero-config; REQUIRED to be overridden when running with the coolify profile in
+# production — a startup WARN is logged otherwise. Unused in dev unless you want to
+# exercise basic auth locally.
+# METRICS_USERNAME=metrics
+# METRICS_PASSWORD=metrics

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("me.paulschwarz:springboot4-dotenv:5.1.0")
     implementation("org.apache.commons:commons-lang3")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
     implementation("org.springframework.boot:spring-boot-starter-security-oauth2-client")

--- a/backend/src/main/java/org/steam5/config/QuartzMetricsConfig.java
+++ b/backend/src/main/java/org/steam5/config/QuartzMetricsConfig.java
@@ -1,0 +1,80 @@
+package org.steam5.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobListener;
+import org.springframework.boot.quartz.autoconfigure.SchedulerFactoryBeanCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wires Micrometer metrics for Quartz job executions.
+ *
+ * <p>Spring Boot 4.0.5 ships {@code QuartzEndpoint} (for {@code /actuator/quartz}) but does
+ * <strong>not</strong> include any Micrometer binder/autoconfiguration that emits per-job
+ * execution metrics. Micrometer 1.16.x core likewise has no {@code binder/quartz/} package.
+ * Without explicit wiring no {@code quartz_*} series appear in {@code /actuator/prometheus}.
+ *
+ * <p>This config registers a global {@link JobListener} via
+ * {@link SchedulerFactoryBeanCustomizer} that records a {@code quartz.jobs.execution} Timer
+ * (rendered as {@code quartz_jobs_execution_seconds_*} by the Prometheus registry) tagged with
+ * the job's group, name, and outcome (succeeded/failed/vetoed).
+ */
+@Configuration
+public class QuartzMetricsConfig {
+
+    @Bean
+    public SchedulerFactoryBeanCustomizer quartzMetricsCustomizer(final MeterRegistry meterRegistry) {
+        return schedulerFactoryBean -> schedulerFactoryBean
+                .setGlobalJobListeners(new MicrometerJobListener(meterRegistry));
+    }
+
+    static final class MicrometerJobListener implements JobListener {
+
+        private static final String LISTENER_NAME = "micrometerQuartzJobListener";
+        private static final String TIMER_NAME = "quartz.jobs.execution";
+        private static final String DESCRIPTION = "Quartz job execution time";
+
+        private final MeterRegistry meterRegistry;
+
+        MicrometerJobListener(final MeterRegistry meterRegistry) {
+            this.meterRegistry = meterRegistry;
+        }
+
+        @Override
+        public String getName() {
+            return LISTENER_NAME;
+        }
+
+        @Override
+        public void jobToBeExecuted(final JobExecutionContext context) {
+            // no-op: jobWasExecuted() reads JobExecutionContext.getJobRunTime() for duration
+        }
+
+        @Override
+        public void jobExecutionVetoed(final JobExecutionContext context) {
+            record(context, 0L, "vetoed");
+        }
+
+        @Override
+        public void jobWasExecuted(final JobExecutionContext context, final JobExecutionException jobException) {
+            final long runTimeMs = context.getJobRunTime();
+            final String outcome = (jobException == null) ? "succeeded" : "failed";
+            record(context, Math.max(0L, runTimeMs), outcome);
+        }
+
+        private void record(final JobExecutionContext context, final long runTimeMs, final String outcome) {
+            Timer.builder(TIMER_NAME)
+                    .description(DESCRIPTION)
+                    .tag("group", context.getJobDetail().getKey().getGroup())
+                    .tag("name", context.getJobDetail().getKey().getName())
+                    .tag("outcome", outcome)
+                    .register(meterRegistry)
+                    .record(runTimeMs, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -1,21 +1,80 @@
 package org.steam5.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.health.actuate.endpoint.HealthEndpoint;
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.steam5.security.AdminTokenFilter;
 import org.steam5.security.AuthRateLimitFilter;
 
+import java.util.Arrays;
+
 @Configuration
 public class SecurityConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
+
+    private static final String DEFAULT_METRICS_CRED = "metrics";
+    private static final String COOLIFY_PROFILE = "coolify";
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager metricsUserDetailsService(
+            @Value("${metrics.username:metrics}") String username,
+            @Value("${metrics.password:metrics}") String password,
+            PasswordEncoder passwordEncoder,
+            Environment environment) {
+        if (Arrays.asList(environment.getActiveProfiles()).contains(COOLIFY_PROFILE)
+                && DEFAULT_METRICS_CRED.equals(username)
+                && DEFAULT_METRICS_CRED.equals(password)) {
+            log.warn("Coolify profile is active but METRICS_USERNAME / METRICS_PASSWORD are still the defaults — "
+                    + "set them via environment variables before exposing /actuator/prometheus to the public.");
+        }
+        UserDetails metricsUser = User.withUsername(username)
+                .password(passwordEncoder.encode(password))
+                .roles("METRICS")
+                .build();
+        return new InMemoryUserDetailsManager(metricsUser);
+    }
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(EndpointRequest.toAnyEndpoint())
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(EndpointRequest.to(HealthEndpoint.class)).permitAll()
+                        .anyRequest().hasRole("METRICS")
+                )
+                .httpBasic(Customizer.withDefaults())
+                .formLogin(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
                                                    AdminTokenFilter adminTokenFilter,
-                                                   AuthRateLimitFilter authRateLimitFilter) {
+                                                   AuthRateLimitFilter authRateLimitFilter) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth

--- a/backend/src/main/resources/application-coolify.yml
+++ b/backend/src/main/resources/application-coolify.yml
@@ -5,11 +5,11 @@ spring:
       spec: maximumSize=500,expireAfterWrite=12h,refreshAfterWrite=1h #https://github.com/ben-manes/caffeine/wiki/Refresh
 management:
   server:
-    port: 8081
+    port: ${MANAGEMENT_SERVER_PORT:8081}
   endpoints:
     web:
       exposure:
-        include: "health" # https://www.baeldung.com/spring-boot-actuators
+        include: ${MANAGEMENT_ENDPOINTS_EXPOSURE:health,prometheus} # https://www.baeldung.com/spring-boot-actuators
   endpoint:
     health:
       show-details: never

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,11 +1,11 @@
 name: dev-local
 management:
   server:
-    port: 8081
+    port: ${MANAGEMENT_SERVER_PORT:8081}
   endpoints:
     web:
       exposure:
-        include: "loggers,env,beans,health,prometheus,metrics,quartz" # https://www.baeldung.com/spring-boot-actuators
+        include: ${MANAGEMENT_ENDPOINTS_EXPOSURE:loggers,env,beans,health,prometheus,metrics,quartz} # https://www.baeldung.com/spring-boot-actuators
   endpoint:
     health:
       show-details: always

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -53,6 +53,16 @@ server:
     enabled: true
     mime-types: application/json, text/html, text/plain
     min-response-size: 1KB
+management:
+  endpoint:
+    prometheus:
+      access: read-only
+  metrics:
+    tags:
+      application: steam5
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 # Logging configuration is in logback-spring.xml
 auth:
   jwtSecret: ${AUTH_JWT_SECRET:change-me-please-change-me-32-bytes-min}

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,44 @@
+# Steam5 monitoring stack — environment configuration.
+#
+# Copy to `.env` and adjust values for your environment, then run:
+#   docker compose --env-file .env up -d
+#
+# All defaults are safe for local development. On macOS Docker Desktop,
+# `host.docker.internal` resolves to the host natively. On Linux Docker
+# Engine 20.10+, the `host-gateway` alias declared in docker-compose.yml
+# wires up the same hostname, so no extra steps are needed.
+
+# ─── Prometheus ─────────────────────────────────────────────────────────────
+# Pinned image tag. v3.5.x is the current Prometheus LTS branch.
+PROMETHEUS_IMAGE=prom/prometheus:v3.5.1
+# Host port to expose Prometheus on.
+PROMETHEUS_PORT=9090
+# TSDB retention window.
+PROMETHEUS_RETENTION=15d
+# Default scrape interval (also used as evaluation_interval).
+PROMETHEUS_SCRAPE_INTERVAL=15s
+
+# ─── Backend scrape target ──────────────────────────────────────────────────
+# host.docker.internal resolves to the Docker host (macOS native;
+# Linux via the host-gateway alias declared in docker-compose.yml).
+# In Coolify, set this to the backend service DNS name, e.g. steam5-backend:8081.
+STEAM5_METRICS_TARGET=host.docker.internal:8081
+STEAM5_METRICS_SCHEME=http
+STEAM5_METRICS_PATH=/actuator/prometheus
+# Basic-auth credentials Prometheus uses to scrape the backend.
+# Backend dev defaults are metrics / metrics. Override in production.
+STEAM5_METRICS_USERNAME=metrics
+STEAM5_METRICS_PASSWORD=metrics
+
+# ─── Grafana ────────────────────────────────────────────────────────────────
+# Pinned image tag.
+GRAFANA_IMAGE=grafana/grafana:12.3.1
+# Host port to expose Grafana on (3001 to avoid clashing with Next.js dev on 3000).
+GRAFANA_PORT=3001
+# Initial admin credentials — must be overridden in production.
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=admin
+# Public URL (used by Grafana for redirects, share links, etc.).
+GF_SERVER_ROOT_URL=http://localhost:3001
+GF_SERVER_DOMAIN=localhost
+GF_USERS_ALLOW_SIGN_UP=false

--- a/monitoring/.gitignore
+++ b/monitoring/.gitignore
@@ -1,0 +1,2 @@
+# Local override of .env.example — never commit secrets.
+.env

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,249 @@
+# Steam5 monitoring stack
+
+Prometheus + Grafana, containerised, scraping the Steam5 Spring Boot backend
+via `/actuator/prometheus` over HTTP basic auth.
+
+## Overview
+
+| Component  | Image                  | Default host port | Purpose                                                                  |
+|------------|------------------------|-------------------|--------------------------------------------------------------------------|
+| Prometheus | `prom/prometheus:v3.5.1` | `9090`            | Scrapes the backend, retains TSDB locally.                               |
+| Grafana    | `grafana/grafana:12.3.1` | `3001`            | Visualises Prometheus data, ships 5 provisioned Steam5 dashboards.       |
+
+The backend is **not** part of this stack — it must already be running and
+exposing `/actuator/prometheus` (port `8081` by default in dev). The
+Prometheus container reaches the backend via `host.docker.internal:8081`.
+
+Layout:
+
+```
+monitoring/
+├── docker-compose.yml
+├── .env.example                # source of truth for tunable env vars
+├── prometheus/
+│   ├── prometheus.yml.tpl      # config template (see entrypoint.sh)
+│   └── entrypoint.sh           # renders template + writes basic-auth secrets
+└── grafana/
+    ├── provisioning/
+    │   ├── datasources/        # Prometheus datasource (auto-provisioned)
+    │   └── dashboards/         # dashboards.yml provider (auto-provisioned)
+    └── dashboards-json/        # JSON dashboards picked up by the provider
+```
+
+## Local development
+
+### Prerequisites
+
+- Docker (Engine 20.10+ or Docker Desktop on macOS/Windows).
+- The Steam5 backend running locally with the management endpoint reachable on
+  `localhost:8081` and `/actuator/prometheus` exposed. See the top-level
+  [`README.md`](../README.md#actuator-dev-on-port-8081) for backend run instructions.
+- Backend basic-auth credentials matching the Prometheus side (defaults
+  `metrics` / `metrics` work for zero-config dev).
+
+### Run
+
+```bash
+cd monitoring
+cp .env.example .env
+docker compose --env-file .env up -d
+```
+
+Tear down (named volumes survive):
+
+```bash
+docker compose down
+# wipe TSDB and Grafana state too:
+docker compose down -v
+```
+
+### Expected URLs
+
+| Service    | URL                            | Notes                                                |
+|------------|--------------------------------|------------------------------------------------------|
+| Prometheus | <http://localhost:9090>        | `/targets` should show the `steam5` job as **UP**.   |
+| Grafana    | <http://localhost:3001>        | Login `admin` / `admin` (override in `.env`).        |
+
+In Grafana → **Dashboards**, all five Steam5 dashboards are pre-loaded under
+the `steam5` tag — open any of them directly:
+
+- <http://localhost:3001/d/steam5-jvm>
+- <http://localhost:3001/d/steam5-http>
+- <http://localhost:3001/d/steam5-hikari>
+- <http://localhost:3001/d/steam5-caches>
+- <http://localhost:3001/d/steam5-quartz>
+
+## Dashboards
+
+All dashboards filter by `application="steam5"` — a Micrometer common tag set
+via `management.metrics.tags.application: steam5` in
+`backend/src/main/resources/application.yml`, so multiple environments can
+share one Prometheus.
+
+| File                            | UID              | Title                       | Purpose                                                                          |
+|---------------------------------|------------------|-----------------------------|----------------------------------------------------------------------------------|
+| `dashboards-json/jvm.json`      | `steam5-jvm`     | Steam5 — JVM                | Heap & non-heap usage, GC pause time/rate, threads, classes loaded.              |
+| `dashboards-json/http-server.json` | `steam5-http` | Steam5 — HTTP server        | Request rate, error rate, p50/p95/p99 latency, slowest endpoints, status codes. |
+| `dashboards-json/hikari.json`   | `steam5-hikari`  | Steam5 — HikariCP           | Connection pool size, active/idle/pending, wait time, timeouts.                  |
+| `dashboards-json/caches.json`   | `steam5-caches`  | Steam5 — Caches (Caffeine)  | Per-cache hit ratio, gets/puts/evictions, size; `$cache` template variable.      |
+| `dashboards-json/quartz.json`   | `steam5-quartz`  | Steam5 — Quartz jobs        | Job execution rate by outcome, duration percentiles, currently executing jobs.   |
+
+To add a new dashboard, drop a JSON file with a unique `uid` into
+`grafana/dashboards-json/` and restart Grafana (`docker compose restart grafana`).
+
+## Environment variables
+
+Source of truth: [`.env.example`](.env.example). The table below summarises
+every variable so you can scan it without opening the file.
+
+| Variable                     | Default                              | Purpose                                                                 |
+|------------------------------|--------------------------------------|-------------------------------------------------------------------------|
+| `PROMETHEUS_IMAGE`           | `prom/prometheus:v3.5.1`             | Prometheus container image (pin a tag, never `:latest`).                |
+| `PROMETHEUS_PORT`            | `9090`                               | Host port mapped to Prometheus.                                         |
+| `PROMETHEUS_RETENTION`       | `15d`                                | TSDB retention window (`--storage.tsdb.retention.time`).                |
+| `PROMETHEUS_SCRAPE_INTERVAL` | `15s`                                | Global `scrape_interval` and `evaluation_interval`.                     |
+| `STEAM5_METRICS_TARGET`      | `host.docker.internal:8081`          | `host:port` Prometheus scrapes. Set to backend service DNS in prod.     |
+| `STEAM5_METRICS_SCHEME`      | `http`                               | `http` or `https` for the scrape.                                       |
+| `STEAM5_METRICS_PATH`        | `/actuator/prometheus`               | Metrics endpoint path on the backend.                                   |
+| `STEAM5_METRICS_USERNAME`    | `metrics`                            | Basic-auth user Prometheus presents to the backend.                     |
+| `STEAM5_METRICS_PASSWORD`    | `metrics`                            | Basic-auth password (must match backend `METRICS_PASSWORD`).            |
+| `GRAFANA_IMAGE`              | `grafana/grafana:12.3.1`             | Grafana container image.                                                |
+| `GRAFANA_PORT`               | `3001`                               | Host port mapped to Grafana (3001 to avoid Next.js dev on 3000).        |
+| `GF_SECURITY_ADMIN_USER`     | `admin`                              | Initial Grafana admin username.                                         |
+| `GF_SECURITY_ADMIN_PASSWORD` | `admin`                              | Initial Grafana admin password — **must override in production**.       |
+| `GF_SERVER_ROOT_URL`         | `http://localhost:3001`              | Public URL Grafana uses for redirects, share links, OAuth callbacks.    |
+| `GF_SERVER_DOMAIN`           | `localhost`                          | Grafana's external domain (used in cookies, links).                     |
+| `GF_USERS_ALLOW_SIGN_UP`     | `false`                              | Disable self-service account creation.                                  |
+
+## Cross-platform notes
+
+The Prometheus container reaches the host's backend via `host.docker.internal`:
+
+- **macOS / Windows (Docker Desktop)**: resolves to the host natively, no
+  configuration needed.
+- **Linux (Docker Engine 20.10+)**: requires the `host-gateway` alias, which
+  is already declared in `docker-compose.yml`:
+
+  ```yaml
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  ```
+
+  No host-side change needed; this is handled by the compose file.
+
+If your host firewall blocks Docker bridge traffic to port `8081`, allow it
+explicitly (e.g. `sudo ufw allow from 172.16.0.0/12 to any port 8081`).
+
+
+## Coolify production deployment
+
+The monitoring stack is deployed as a **separate Coolify service** from the
+backend. They communicate over Coolify's internal Docker network — never
+expose `/actuator/prometheus` to the public internet.
+
+### 1. Backend env vars (set on the existing `steam5-backend` service)
+
+| Service          | Env var                          | Coolify location     | Example prod value                |
+|------------------|----------------------------------|----------------------|-----------------------------------|
+| `steam5-backend` | `METRICS_USERNAME`               | Service env (secret) | _generated, ≥ 16 chars_           |
+| `steam5-backend` | `METRICS_PASSWORD`               | Service env (secret) | _generated, ≥ 32 chars_           |
+| `steam5-backend` | `MANAGEMENT_SERVER_PORT`         | Service env          | `8081`                            |
+| `steam5-backend` | `MANAGEMENT_ENDPOINTS_EXPOSURE`  | Service env          | `health,prometheus`               |
+
+`METRICS_USERNAME` / `METRICS_PASSWORD` **must be overridden** in the coolify
+profile — the backend logs a startup `WARN` if the defaults (`metrics` /
+`metrics`) are still in use. Generate strong values with e.g.
+`openssl rand -base64 24`.
+
+### 2. Exposing the management port to the monitoring stack
+
+The management port (`MANAGEMENT_SERVER_PORT=8081`) only needs to be
+reachable by the Prometheus container, **not** the public internet. Two
+options, in order of preference:
+
+1. **Internal Coolify network (recommended).** Attach the monitoring
+   service to the same Coolify project / network as the backend. Prometheus
+   then resolves the backend by its Docker DNS name
+   (e.g. `steam5-backend:8081`). Do **not** add a public domain or open a
+   firewall port for `8081`.
+2. **Public domain (only if internal networking is not feasible).** Expose
+   `8081` behind Coolify's reverse proxy on a dedicated subdomain
+   (e.g. `metrics.steam5.org`), enable HTTPS, and rely on basic auth +
+   IP allowlist. Set `STEAM5_METRICS_SCHEME=https` and
+   `STEAM5_METRICS_TARGET=metrics.steam5.org:443`. This is strictly less
+   secure than option 1 — basic auth is the only barrier.
+
+### 3. Monitoring service env vars
+
+Create a new Coolify service from this `monitoring/docker-compose.yml`. Set:
+
+| Service      | Env var                       | Coolify location     | Example prod value                                |
+|--------------|-------------------------------|----------------------|---------------------------------------------------|
+| `prometheus` | `STEAM5_METRICS_TARGET`       | Service env          | `steam5-backend:8081`                             |
+| `prometheus` | `STEAM5_METRICS_SCHEME`       | Service env          | `http` (internal) or `https` (public)             |
+| `prometheus` | `STEAM5_METRICS_PATH`         | Service env          | `/actuator/prometheus`                            |
+| `prometheus` | `STEAM5_METRICS_USERNAME`     | Service env (secret) | _= backend `METRICS_USERNAME`_                    |
+| `prometheus` | `STEAM5_METRICS_PASSWORD`     | Service env (secret) | _= backend `METRICS_PASSWORD`_                    |
+| `prometheus` | `PROMETHEUS_RETENTION`        | Service env          | `15d` (or higher with sized volume)               |
+| `prometheus` | `PROMETHEUS_SCRAPE_INTERVAL`  | Service env          | `15s`                                             |
+| `grafana`    | `GF_SECURITY_ADMIN_USER`      | Service env          | _operator choice (e.g. `steam5-admin`)_           |
+| `grafana`    | `GF_SECURITY_ADMIN_PASSWORD`  | Service env (secret) | _strong password, ≥ 16 chars_                     |
+| `grafana`    | `GF_SERVER_ROOT_URL`          | Service env          | `https://grafana.steam5.org`                      |
+| `grafana`    | `GF_SERVER_DOMAIN`            | Service env          | `grafana.steam5.org`                              |
+| `grafana`    | `GF_USERS_ALLOW_SIGN_UP`      | Service env          | `false`                                           |
+
+### 4. Persistent volumes
+
+The compose file declares two named volumes — both **must** be backed by
+Coolify persistent storage so data survives redeploys:
+
+| Volume            | Mount path inside container | Holds                                          |
+|-------------------|-----------------------------|------------------------------------------------|
+| `prometheus-data` | `/prometheus`               | TSDB (size with `PROMETHEUS_RETENTION`).       |
+| `grafana-data`    | `/var/lib/grafana`          | Grafana SQLite DB, alert state, user prefs.    |
+
+In Coolify → service → **Storages**, mark both volumes as persistent. Without
+this, redeploys wipe metric history and any Grafana customisations.
+
+### 5. Grafana behind Coolify's reverse proxy
+
+Coolify's Traefik handles TLS and routing. Add a Coolify domain mapping
+`grafana.steam5.org` → service `grafana` port `3000` (the container port,
+**not** the host-side `GRAFANA_PORT`). Then set Grafana env:
+
+```
+GF_SERVER_ROOT_URL=https://grafana.steam5.org
+GF_SERVER_DOMAIN=grafana.steam5.org
+```
+
+Setting these correctly is required for share links, OAuth callbacks, and
+correct cookie scoping. Do **not** add a public domain mapping for
+Prometheus — keep it internal-only.
+
+### 6. Quick verify in production
+
+After deploy, from any host that can reach the backend (e.g. inside
+Coolify's terminal), confirm the scrape target works:
+
+```bash
+curl -u "$METRICS_USERNAME:$METRICS_PASSWORD" \
+  https://<backend-host>/actuator/prometheus | head
+```
+
+You should see Prometheus exposition text starting with `# HELP …`. Then in
+the Prometheus UI (<https://prometheus.steam5.org/targets> or via Coolify
+port forward), the `steam5` job should be **UP**. In Grafana, open any
+dashboard — panels should render within one scrape interval.
+
+## Troubleshooting
+
+| Symptom                                         | Likely cause                                                                  | Fix                                                                                                              |
+|-------------------------------------------------|-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| Target **DOWN**, error `401 Unauthorized`       | Basic-auth credentials don't match backend.                                   | Ensure `STEAM5_METRICS_USERNAME` / `STEAM5_METRICS_PASSWORD` match backend `METRICS_USERNAME` / `METRICS_PASSWORD`. Restart Prometheus to re-render the secret files. |
+| Target **DOWN**, error `connection refused`     | Wrong host or port.                                                           | Verify `STEAM5_METRICS_TARGET`. Locally that's `host.docker.internal:8081`; in Coolify it's the backend service DNS, e.g. `steam5-backend:8081`. Confirm the backend is listening on `MANAGEMENT_SERVER_PORT`. |
+| Target **DOWN**, error `no such host`           | Linux without `host-gateway` alias, or wrong service name in Coolify.         | Compose file already declares `host.docker.internal:host-gateway`; ensure Docker Engine ≥ 20.10. In Coolify, use the exact service name. |
+| Dashboards empty, no data                        | No traffic generated yet, or wrong datasource.                                | Hit the backend (`curl http://localhost:8080/actuator/health`); wait one scrape interval. In Grafana → **Connections → Data sources**, confirm `Prometheus` is healthy. |
+| Dashboards empty, datasource healthy             | Backend not emitting `application="steam5"` label, or different label value.  | Confirm `management.metrics.tags.application: steam5` is set in the backend's `application.yml`. Check Prometheus → **Graph** with `up{job="steam5"}`; if it returns `1` but a query like `jvm_memory_used_bytes{application="steam5"}` is empty, the tag is missing or different. |
+| Grafana shows "If you're seeing this Grafana has failed to load…" | `GF_SERVER_ROOT_URL` mismatch behind reverse proxy.                            | Set `GF_SERVER_ROOT_URL` to the **external** HTTPS URL and `GF_SERVER_DOMAIN` to the same hostname. Restart Grafana. |
+| Prometheus container restarts in a loop         | Bad placeholder substitution in `prometheus.yml.tpl`, or missing env var.     | `docker compose logs prometheus` — the entrypoint script `sed` step will surface unresolved `@@VAR@@` markers. Confirm all `STEAM5_METRICS_*` vars are set. |
+| Backend logs `WARN … METRICS_USERNAME … default` | Production running with `metrics` / `metrics` defaults.                       | Set strong `METRICS_USERNAME` / `METRICS_PASSWORD` on the backend service in Coolify; redeploy.                  |

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -57,6 +57,13 @@ docker compose down
 docker compose down -v
 ```
 
+> **Heads-up — `MANAGEMENT_SERVER_PORT` ↔ `STEAM5_METRICS_TARGET` coupling.**
+> If you override `MANAGEMENT_SERVER_PORT` on the backend (default `8081`), you **must** also
+> override `STEAM5_METRICS_TARGET` in `monitoring/.env` to match (e.g.
+> `host.docker.internal:18081`). The two values are coupled — Prometheus scrapes whatever you
+> point it at via `STEAM5_METRICS_TARGET`, but the backend only listens for actuator traffic on
+> `MANAGEMENT_SERVER_PORT`.
+
 ### Expected URLs
 
 | Service    | URL                            | Notes                                                |
@@ -179,6 +186,8 @@ Create a new Coolify service from this `monitoring/docker-compose.yml`. Set:
 
 | Service      | Env var                       | Coolify location     | Example prod value                                |
 |--------------|-------------------------------|----------------------|---------------------------------------------------|
+| `prometheus` | `PROMETHEUS_IMAGE`            | Service env          | `prom/prometheus:v3.5.1` (pin a tag for prod)     |
+| `prometheus` | `PROMETHEUS_PORT`             | Service env          | `9090`                                            |
 | `prometheus` | `STEAM5_METRICS_TARGET`       | Service env          | `steam5-backend:8081`                             |
 | `prometheus` | `STEAM5_METRICS_SCHEME`       | Service env          | `http` (internal) or `https` (public)             |
 | `prometheus` | `STEAM5_METRICS_PATH`         | Service env          | `/actuator/prometheus`                            |
@@ -186,6 +195,7 @@ Create a new Coolify service from this `monitoring/docker-compose.yml`. Set:
 | `prometheus` | `STEAM5_METRICS_PASSWORD`     | Service env (secret) | _= backend `METRICS_PASSWORD`_                    |
 | `prometheus` | `PROMETHEUS_RETENTION`        | Service env          | `15d` (or higher with sized volume)               |
 | `prometheus` | `PROMETHEUS_SCRAPE_INTERVAL`  | Service env          | `15s`                                             |
+| `grafana`    | `GRAFANA_IMAGE`               | Service env          | `grafana/grafana:12.3.1` (pin a tag for prod)     |
 | `grafana`    | `GF_SECURITY_ADMIN_USER`      | Service env          | _operator choice (e.g. `steam5-admin`)_           |
 | `grafana`    | `GF_SECURITY_ADMIN_PASSWORD`  | Service env (secret) | _strong password, ≥ 16 chars_                     |
 | `grafana`    | `GF_SERVER_ROOT_URL`          | Service env          | `https://grafana.steam5.org`                      |

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,69 @@
+# Steam5 local monitoring stack: Prometheus + Grafana.
+# Defaults are documented in .env.example; copy that to .env to override.
+#
+# Bring it up (zero-config on macOS Docker Desktop and Linux Docker 20.10+):
+#   cp .env.example .env
+#   docker compose --env-file .env up -d
+#
+# Tear it down (volumes are named so data survives `down`; add -v to wipe):
+#   docker compose down
+
+services:
+  prometheus:
+    image: ${PROMETHEUS_IMAGE:-prom/prometheus:v3.5.1}
+    container_name: steam5-prometheus
+    restart: unless-stopped
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    environment:
+      # Consumed by /usr/local/bin/entrypoint.sh to render prometheus.yml.tpl
+      # at container start. Prometheus itself does not expand ${VAR} in its
+      # config (only --enable-feature=expand-external-labels covers
+      # external_labels), so we template the file before launching.
+      PROMETHEUS_SCRAPE_INTERVAL: ${PROMETHEUS_SCRAPE_INTERVAL:-15s}
+      STEAM5_METRICS_TARGET: ${STEAM5_METRICS_TARGET:-host.docker.internal:8081}
+      STEAM5_METRICS_SCHEME: ${STEAM5_METRICS_SCHEME:-http}
+      STEAM5_METRICS_PATH: ${STEAM5_METRICS_PATH:-/actuator/prometheus}
+      STEAM5_METRICS_USERNAME: ${STEAM5_METRICS_USERNAME:-metrics}
+      STEAM5_METRICS_PASSWORD: ${STEAM5_METRICS_PASSWORD:-metrics}
+    volumes:
+      - ./prometheus/prometheus.yml.tpl:/etc/prometheus/prometheus.yml.tpl:ro
+      - ./prometheus/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+      - prometheus-data:/prometheus
+    extra_hosts:
+      # No-op on macOS Docker Desktop (where host.docker.internal already
+      # resolves), required on Linux Docker Engine 20.10+ to reach the host.
+      - "host.docker.internal:host-gateway"
+    entrypoint: ["/bin/sh", "/usr/local/bin/entrypoint.sh"]
+    command:
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-15d}"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      - "--web.enable-lifecycle"
+
+  grafana:
+    image: ${GRAFANA_IMAGE:-grafana/grafana:12.3.1}
+    container_name: steam5-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    ports:
+      - "${GRAFANA_PORT:-3001}:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:-admin}
+      GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL:-http://localhost:${GRAFANA_PORT:-3001}}
+      GF_SERVER_DOMAIN: ${GF_SERVER_DOMAIN:-localhost}
+      GF_USERS_ALLOW_SIGN_UP: ${GF_USERS_ALLOW_SIGN_UP:-false}
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      # Mounted outside /etc/grafana/provisioning because Docker cannot create
+      # a sub-mountpoint inside a read-only parent bind. The dashboards
+      # provider in provisioning/dashboards/dashboards.yml points here.
+      - ./grafana/dashboards-json:/var/lib/grafana/dashboards-json:ro
+      - grafana-data:/var/lib/grafana
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/monitoring/grafana/dashboards-json/caches.json
+++ b/monitoring/grafana/dashboards-json/caches.json
@@ -1,0 +1,140 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "ops/sec", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "title": "Cache get rate (hits vs misses) — $cache",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (result) (rate(cache_gets_total{application=\"$app\", cache=~\"$cache\"}[5m]))", "legendFormat": "{{result}}", "refId": "A"}
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "orange", "value": 0.5}, {"color": "green", "value": 0.8}]},
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "title": "Cache hit ratio (last 5m) — $cache",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (rate(cache_gets_total{application=\"$app\", cache=~\"$cache\", result=\"hit\"}[5m])) / clamp_min(sum by (cache) (rate(cache_gets_total{application=\"$app\", cache=~\"$cache\"}[5m])), 1e-9)", "legendFormat": "{{cache}}", "refId": "A"}
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "entries", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 9},
+      "id": 3,
+      "options": {"legend": {"calcs": ["last", "max"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "title": "Cache size (entries) — per cache",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "cache_size{application=\"$app\", cache=~\"$cache\"}", "legendFormat": "{{cache}}", "refId": "A"}
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "ops/sec", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 9},
+      "id": 4,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "title": "Cache puts & evictions rate — per cache",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (rate(cache_puts_total{application=\"$app\", cache=~\"$cache\"}[5m]))", "legendFormat": "puts: {{cache}}", "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (rate(cache_evictions_total{application=\"$app\", cache=~\"$cache\"}[5m]))", "legendFormat": "evictions: {{cache}}", "refId": "B"}
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "hit ratio"}, "properties": [{"id": "unit", "value": "percentunit"}, {"id": "custom.cellOptions", "value": {"mode": "gradient", "type": "gauge"}}, {"id": "max", "value": 1}, {"id": "min", "value": 0}]},
+          {"matcher": {"id": "byName", "options": "size"}, "properties": [{"id": "unit", "value": "short"}]}
+        ]
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 18},
+      "id": 5,
+      "options": {"footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false}, "showHeader": true},
+      "title": "Cache summary table — totals & hit ratio",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (cache_gets_total{application=\"$app\", cache=~\"$cache\", result=\"hit\"}) / clamp_min(sum by (cache) (cache_gets_total{application=\"$app\", cache=~\"$cache\"}), 1)", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "hit ratio"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (cache_gets_total{application=\"$app\", cache=~\"$cache\", result=\"hit\"})", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "hits"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (cache_gets_total{application=\"$app\", cache=~\"$cache\", result=\"miss\"})", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "misses"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (cache_puts_total{application=\"$app\", cache=~\"$cache\"})", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "puts"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (cache_evictions_total{application=\"$app\", cache=~\"$cache\"})", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "evictions"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (cache) (cache_size{application=\"$app\", cache=~\"$cache\"})", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "size"}
+      ],
+      "transformations": [
+        {"id": "joinByField", "options": {"byField": "cache", "mode": "outer"}},
+        {"id": "filterFieldsByName", "options": {"include": {"pattern": "cache|Value #(hit ratio|hits|misses|puts|evictions|size)"}}},
+        {"id": "organize", "options": {"excludeByName": {}, "indexByName": {}, "renameByName": {"Value #hit ratio": "hit ratio", "Value #hits": "hits", "Value #misses": "misses", "Value #puts": "puts", "Value #evictions": "evictions", "Value #size": "size"}}}
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["steam5", "caches"],
+  "templating": {
+    "list": [
+      {"current": {"selected": false, "text": "steam5", "value": "steam5"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(jvm_memory_used_bytes, application)", "hide": 0, "includeAll": false, "label": "Application", "multi": false, "name": "app", "options": [], "query": {"query": "label_values(jvm_memory_used_bytes, application)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}, "refresh": 2, "regex": "", "sort": 1, "type": "query"},
+      {"current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(cache_gets_total{application=\"$app\"}, cache)", "hide": 0, "includeAll": true, "label": "Cache", "multi": true, "name": "cache", "options": [], "query": {"query": "label_values(cache_gets_total{application=\"$app\"}, cache)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}, "refresh": 2, "regex": "", "sort": 1, "type": "query"}
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Steam5 — Caches (Caffeine)",
+  "uid": "steam5-caches",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/dashboards-json/hikari.json
+++ b/monitoring/grafana/dashboards-json/hikari.json
@@ -1,0 +1,128 @@
+{
+  "uid": "steam5-hikari",
+  "title": "Steam5 — HikariCP",
+  "tags": ["steam5", "hikari", "db"],
+  "schemaVersion": 39,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "app",
+        "label": "Application",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": {"query": "label_values(jvm_memory_used_bytes, application)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "definition": "label_values(jvm_memory_used_bytes, application)",
+        "refresh": 2,
+        "includeAll": false,
+        "multi": false,
+        "current": {"text": "steam5", "value": "steam5"},
+        "sort": 1
+      },
+      {
+        "name": "pool",
+        "label": "Pool",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": {"query": "label_values(hikaricp_connections{application=\"$app\"}, pool)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "definition": "label_values(hikaricp_connections{application=\"$app\"}, pool)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": false,
+        "current": {"text": "All", "value": "$__all"},
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "stat", "title": "Active connections",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(hikaricp_connections_active{application=\"$app\", pool=~\"$pool\"})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 2, "type": "stat", "title": "Idle connections",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(hikaricp_connections_idle{application=\"$app\", pool=~\"$pool\"})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 3, "type": "stat", "title": "Pending acquisitions",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}, {"color": "red", "value": 5}]}}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(hikaricp_connections_pending{application=\"$app\", pool=~\"$pool\"})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 4, "type": "stat", "title": "Connection timeouts (total)",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(hikaricp_connections_timeout_total{application=\"$app\", pool=~\"$pool\"})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Connection pool state",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"refId": "A", "expr": "hikaricp_connections_active{application=\"$app\", pool=~\"$pool\"}", "legendFormat": "{{pool}} active", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "B", "expr": "hikaricp_connections_idle{application=\"$app\", pool=~\"$pool\"}", "legendFormat": "{{pool}} idle", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "C", "expr": "hikaricp_connections{application=\"$app\", pool=~\"$pool\"}", "legendFormat": "{{pool}} total", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "D", "expr": "hikaricp_connections_pending{application=\"$app\", pool=~\"$pool\"}", "legendFormat": "{{pool}} pending", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ]
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "Pool capacity (min / max)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 10, "lineStyle": {"fill": "dash"}}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"refId": "A", "expr": "hikaricp_connections_min{application=\"$app\", pool=~\"$pool\"}", "legendFormat": "{{pool}} min", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "B", "expr": "hikaricp_connections_max{application=\"$app\", pool=~\"$pool\"}", "legendFormat": "{{pool}} max", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ]
+    },
+    {
+      "id": 7, "type": "timeseries", "title": "Avg connection acquire time (5m)",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "rate(hikaricp_connections_acquire_seconds_sum{application=\"$app\", pool=~\"$pool\"}[5m]) / clamp_min(rate(hikaricp_connections_acquire_seconds_count{application=\"$app\", pool=~\"$pool\"}[5m]), 1e-9)", "legendFormat": "{{pool}} avg acquire", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "Avg connection usage time (5m)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "rate(hikaricp_connections_usage_seconds_sum{application=\"$app\", pool=~\"$pool\"}[5m]) / clamp_min(rate(hikaricp_connections_usage_seconds_count{application=\"$app\", pool=~\"$pool\"}[5m]), 1e-9)", "legendFormat": "{{pool}} avg usage", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "Connection acquire/usage rate (per second)",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"refId": "A", "expr": "rate(hikaricp_connections_acquire_seconds_count{application=\"$app\", pool=~\"$pool\"}[5m])", "legendFormat": "{{pool}} acquire/s", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "B", "expr": "rate(hikaricp_connections_usage_seconds_count{application=\"$app\", pool=~\"$pool\"}[5m])", "legendFormat": "{{pool}} usage/s", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "C", "expr": "rate(hikaricp_connections_creation_seconds_count{application=\"$app\", pool=~\"$pool\"}[5m])", "legendFormat": "{{pool}} creation/s", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards-json/http-server.json
+++ b/monitoring/grafana/dashboards-json/http-server.json
@@ -1,0 +1,115 @@
+{
+  "uid": "steam5-http",
+  "title": "Steam5 — HTTP server",
+  "tags": ["steam5", "http"],
+  "schemaVersion": 39,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "app",
+        "label": "Application",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": {"query": "label_values(jvm_memory_used_bytes, application)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "definition": "label_values(jvm_memory_used_bytes, application)",
+        "refresh": 2,
+        "includeAll": false,
+        "multi": false,
+        "current": {"text": "steam5", "value": "steam5"},
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "stat", "title": "Total request rate",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(rate(http_server_requests_seconds_count{application=\"$app\"}[5m]))", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 2, "type": "stat", "title": "Error rate (4xx + 5xx)",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "reqps", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 0.1}, {"color": "red", "value": 1}]}}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(rate(http_server_requests_seconds_count{application=\"$app\", outcome=~\"CLIENT_ERROR|SERVER_ERROR\"}[5m]))", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 3, "type": "stat", "title": "p95 latency (5m)",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"$app\"}[5m])))", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 4, "type": "stat", "title": "Active requests",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(http_server_requests_active_seconds_gcount{application=\"$app\"})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Request rate by URI",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10, "stacking": {"mode": "normal", "group": "A"}}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "sum by (uri, method) (rate(http_server_requests_seconds_count{application=\"$app\"}[5m]))", "legendFormat": "{{method}} {{uri}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "Request rate by status",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10, "stacking": {"mode": "normal", "group": "A"}}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "sum by (status, outcome) (rate(http_server_requests_seconds_count{application=\"$app\"}[5m]))", "legendFormat": "{{status}} ({{outcome}})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 7, "type": "timeseries", "title": "Latency p50 / p95 / p99",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"refId": "A", "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"$app\"}[5m])))", "legendFormat": "p50", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"$app\"}[5m])))", "legendFormat": "p95", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "C", "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"$app\"}[5m])))", "legendFormat": "p99", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ]
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "Avg latency by URI (5m)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "sum by (uri) (rate(http_server_requests_seconds_sum{application=\"$app\"}[5m])) / sum by (uri) (rate(http_server_requests_seconds_count{application=\"$app\"}[5m]))", "legendFormat": "{{uri}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 9, "type": "table", "title": "Top URIs by total request count",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"showHeader": true},
+      "targets": [{"refId": "A", "expr": "topk(10, sum by (method, uri, status) (http_server_requests_seconds_count{application=\"$app\"}))", "format": "table", "instant": true, "datasource": {"type": "prometheus", "uid": "prometheus"}}],
+      "transformations": [{"id": "organize", "options": {"excludeByName": {"Time": true, "__name__": true, "application": true, "instance": true, "job": true, "exception": true, "error": true, "outcome": true}}}]
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "Max single-request duration (per URI)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "max by (uri) (http_server_requests_seconds_max{application=\"$app\"})", "legendFormat": "{{uri}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards-json/jvm.json
+++ b/monitoring/grafana/dashboards-json/jvm.json
@@ -1,0 +1,114 @@
+{
+  "uid": "steam5-jvm",
+  "title": "Steam5 — JVM",
+  "tags": ["steam5", "jvm"],
+  "schemaVersion": 39,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "app",
+        "label": "Application",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": {"query": "label_values(jvm_memory_used_bytes, application)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "definition": "label_values(jvm_memory_used_bytes, application)",
+        "refresh": 2,
+        "includeAll": false,
+        "multi": false,
+        "current": {"text": "steam5", "value": "steam5"},
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1, "type": "stat", "title": "Heap used",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(jvm_memory_used_bytes{application=\"$app\", area=\"heap\"})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 2, "type": "stat", "title": "Heap committed",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "sum(jvm_memory_committed_bytes{application=\"$app\", area=\"heap\"})", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 3, "type": "stat", "title": "Live threads",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "jvm_threads_live_threads{application=\"$app\"}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 4, "type": "stat", "title": "Classes loaded",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "colorMode": "value", "graphMode": "area"},
+      "targets": [{"refId": "A", "expr": "jvm_classes_loaded_classes{application=\"$app\"}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 5, "type": "timeseries", "title": "Heap usage by pool",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes", "custom": {"drawStyle": "line", "fillOpacity": 20, "stacking": {"mode": "normal", "group": "A"}}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "jvm_memory_used_bytes{application=\"$app\", area=\"heap\"}", "legendFormat": "{{id}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "Non-heap usage by pool",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes", "custom": {"drawStyle": "line", "fillOpacity": 20, "stacking": {"mode": "normal", "group": "A"}}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "jvm_memory_used_bytes{application=\"$app\", area=\"nonheap\"}", "legendFormat": "{{id}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 7, "type": "timeseries", "title": "Threads (live / daemon / peak)",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"refId": "A", "expr": "jvm_threads_live_threads{application=\"$app\"}", "legendFormat": "live", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "B", "expr": "jvm_threads_daemon_threads{application=\"$app\"}", "legendFormat": "daemon", "datasource": {"type": "prometheus", "uid": "prometheus"}},
+        {"refId": "C", "expr": "jvm_threads_peak_threads{application=\"$app\"}", "legendFormat": "peak", "datasource": {"type": "prometheus", "uid": "prometheus"}}
+      ]
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "Thread states",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 30, "stacking": {"mode": "normal", "group": "A"}}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "jvm_threads_states_threads{application=\"$app\"}", "legendFormat": "{{state}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 9, "type": "timeseries", "title": "GC pause rate (per second)",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "ops", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "rate(jvm_gc_pause_seconds_count{application=\"$app\"}[5m])", "legendFormat": "{{gc}} / {{cause}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "GC pause max (per scrape)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [{"refId": "A", "expr": "jvm_gc_pause_seconds_max{application=\"$app\"}", "legendFormat": "{{gc}} / {{cause}}", "datasource": {"type": "prometheus", "uid": "prometheus"}}]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards-json/quartz.json
+++ b/monitoring/grafana/dashboards-json/quartz.json
@@ -1,0 +1,193 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "execs/sec", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "title": "Job execution rate — by outcome",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (outcome) (rate(quartz_jobs_execution_seconds_count{application=\"$app\", name=~\"$job\"}[5m]))", "legendFormat": "{{outcome}}", "refId": "A"}
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "execs/sec", "drawStyle": "bars", "fillOpacity": 50, "lineWidth": 1, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "normal"}},
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "title": "Job execution rate — by job (stacked, succeeded+failed)",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (name) (rate(quartz_jobs_execution_seconds_count{application=\"$app\", name=~\"$job\"}[5m]))", "legendFormat": "{{name}}", "refId": "A"}
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 9},
+      "id": 3,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "title": "Avg job duration (5m) — by job",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (name) (rate(quartz_jobs_execution_seconds_sum{application=\"$app\", name=~\"$job\"}[5m])) / clamp_min(sum by (name) (rate(quartz_jobs_execution_seconds_count{application=\"$app\", name=~\"$job\"}[5m])), 1e-9)", "legendFormat": "{{name}}", "refId": "A"}
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisLabel": "seconds", "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 9},
+      "id": 4,
+      "options": {"legend": {"calcs": ["max"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "title": "Max job duration — by job",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "max by (name) (quartz_jobs_execution_seconds_max{application=\"$app\", name=~\"$job\"})", "legendFormat": "{{name}}", "refId": "A"}
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}, {"color": "red", "value": 5}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 8, "x": 0, "y": 18},
+      "id": 5,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "title": "Failed executions (total)",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(quartz_jobs_execution_seconds_count{application=\"$app\", outcome=\"failed\", name=~\"$job\"})", "refId": "A"}
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 8, "x": 8, "y": 18},
+      "id": 6,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "title": "Successful executions (total)",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(quartz_jobs_execution_seconds_count{application=\"$app\", outcome=\"succeeded\", name=~\"$job\"})", "refId": "A"}
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 8, "x": 16, "y": 18},
+      "id": 7,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "title": "Vetoed executions (total)",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(quartz_jobs_execution_seconds_count{application=\"$app\", outcome=\"vetoed\", name=~\"$job\"}) or vector(0)", "refId": "A"}
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "avg duration (s)"}, "properties": [{"id": "unit", "value": "s"}]},
+          {"matcher": {"id": "byName", "options": "max duration (s)"}, "properties": [{"id": "unit", "value": "s"}]},
+          {"matcher": {"id": "byName", "options": "failed"}, "properties": [{"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, {"id": "custom.cellOptions", "value": {"mode": "basic", "type": "color-background"}}]}
+        ]
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 23},
+      "id": 8,
+      "options": {"footer": {"show": false}, "showHeader": true},
+      "title": "Per-job summary — executions, durations, outcomes",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (name) (quartz_jobs_execution_seconds_count{application=\"$app\", name=~\"$job\", outcome=\"succeeded\"})", "format": "table", "instant": true, "refId": "succeeded"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (name) (quartz_jobs_execution_seconds_count{application=\"$app\", name=~\"$job\", outcome=\"failed\"})", "format": "table", "instant": true, "refId": "failed"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum by (name) (quartz_jobs_execution_seconds_sum{application=\"$app\", name=~\"$job\"}) / clamp_min(sum by (name) (quartz_jobs_execution_seconds_count{application=\"$app\", name=~\"$job\"}), 1)", "format": "table", "instant": true, "refId": "avg duration (s)"},
+        {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "max by (name) (quartz_jobs_execution_seconds_max{application=\"$app\", name=~\"$job\"})", "format": "table", "instant": true, "refId": "max duration (s)"}
+      ],
+      "transformations": [
+        {"id": "joinByField", "options": {"byField": "name", "mode": "outer"}},
+        {"id": "filterFieldsByName", "options": {"include": {"pattern": "name|Value #(succeeded|failed|avg duration \\(s\\)|max duration \\(s\\))"}}},
+        {"id": "organize", "options": {"excludeByName": {}, "indexByName": {}, "renameByName": {"Value #succeeded": "succeeded", "Value #failed": "failed", "Value #avg duration (s)": "avg duration (s)", "Value #max duration (s)": "max duration (s)"}}}
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["steam5", "quartz"],
+  "templating": {
+    "list": [
+      {"current": {"selected": false, "text": "steam5", "value": "steam5"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(jvm_memory_used_bytes, application)", "hide": 0, "includeAll": false, "label": "Application", "multi": false, "name": "app", "options": [], "query": {"query": "label_values(jvm_memory_used_bytes, application)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}, "refresh": 2, "regex": "", "sort": 1, "type": "query"},
+      {"current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(quartz_jobs_execution_seconds_count{application=\"$app\"}, name)", "hide": 0, "includeAll": true, "label": "Job", "multi": true, "name": "job", "options": [], "query": {"query": "label_values(quartz_jobs_execution_seconds_count{application=\"$app\"}, name)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}, "refresh": 2, "regex": "", "sort": 1, "type": "query"}
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Steam5 — Quartz jobs",
+  "uid": "steam5-quartz",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -12,7 +12,7 @@ providers:
     folder: ''
     folderUid: ''
     type: file
-    disableDeletion: false
+    disableDeletion: true
     updateIntervalSeconds: 30
     allowUiUpdates: false
     options:

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,20 @@
+# Dashboard provider: loads any *.json dashboard dropped into
+# /var/lib/grafana/dashboards-json on the container (mounted from
+# monitoring/grafana/dashboards-json on the host). The path lives outside
+# /etc/grafana/provisioning because that tree is mounted read-only and
+# Docker cannot create sub-mountpoints inside a read-only parent bind.
+# Wave 3 fills this folder.
+apiVersion: 1
+
+providers:
+  - name: steam5
+    orgId: 1
+    folder: ''
+    folderUid: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards-json
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,16 @@
+# Auto-provision the in-network Prometheus datasource.
+# `prometheus` is the docker-compose service name and resolves over the
+# default compose network — only the host-facing port differs per
+# environment, the in-network DNS is constant.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s

--- a/monitoring/prometheus/entrypoint.sh
+++ b/monitoring/prometheus/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Templating shim for the Prometheus container.
+#
+# Prometheus does not natively expand ${VAR} placeholders inside its config
+# (only --enable-feature=expand-external-labels covers external_labels). This
+# script renders /etc/prometheus/prometheus.yml.tpl into /tmp/prometheus.yml
+# at startup, substituting @@VAR@@ markers from the container's environment,
+# then execs the prometheus binary with that rendered file. Basic-auth
+# credentials are written to per-file paths read via username_file /
+# password_file so they never appear on the prometheus command line.
+set -e
+
+RENDERED=/tmp/prometheus.yml
+SECRETS_DIR=/tmp/prometheus-secrets
+
+mkdir -p "$SECRETS_DIR"
+# `printf %s` (no newline) so basic-auth values don't include a trailing \n.
+printf '%s' "${STEAM5_METRICS_USERNAME:-}" > "$SECRETS_DIR/username"
+printf '%s' "${STEAM5_METRICS_PASSWORD:-}" > "$SECRETS_DIR/password"
+
+sed \
+  -e "s|@@PROMETHEUS_SCRAPE_INTERVAL@@|${PROMETHEUS_SCRAPE_INTERVAL:-15s}|g" \
+  -e "s|@@STEAM5_METRICS_TARGET@@|${STEAM5_METRICS_TARGET:-host.docker.internal:8081}|g" \
+  -e "s|@@STEAM5_METRICS_SCHEME@@|${STEAM5_METRICS_SCHEME:-http}|g" \
+  -e "s|@@STEAM5_METRICS_PATH@@|${STEAM5_METRICS_PATH:-/actuator/prometheus}|g" \
+  -e "s|@@PROM_SECRETS_DIR@@|${SECRETS_DIR}|g" \
+  /etc/prometheus/prometheus.yml.tpl > "$RENDERED"
+
+exec /bin/prometheus --config.file="$RENDERED" "$@"

--- a/monitoring/prometheus/prometheus.yml.tpl
+++ b/monitoring/prometheus/prometheus.yml.tpl
@@ -1,0 +1,22 @@
+# Prometheus configuration template.
+#
+# Rendered into /tmp/prometheus.yml by /usr/local/bin/entrypoint.sh at
+# container start. Edit the template, not the rendered copy. Placeholders
+# (@@VAR@@) are substituted from the container environment.
+global:
+  scrape_interval: @@PROMETHEUS_SCRAPE_INTERVAL@@
+  evaluation_interval: @@PROMETHEUS_SCRAPE_INTERVAL@@
+
+scrape_configs:
+  - job_name: steam5
+    metrics_path: @@STEAM5_METRICS_PATH@@
+    scheme: @@STEAM5_METRICS_SCHEME@@
+    basic_auth:
+      # Credentials are written to files by entrypoint.sh so they never appear
+      # on the prometheus process command line. For unauthenticated targets,
+      # remove the basic_auth block entirely.
+      username_file: @@PROM_SECRETS_DIR@@/username
+      password_file: @@PROM_SECRETS_DIR@@/password
+    static_configs:
+      - targets:
+          - @@STEAM5_METRICS_TARGET@@


### PR DESCRIPTION
## Summary

Self-hosted Prometheus + Grafana monitoring stack for the Spring Boot backend, with 5 provisioned dashboards covering JVM, HTTP server, HikariCP, Caffeine caches, and Quartz jobs. Fully env-var driven so it's drop-in for our Coolify production deployment.

## What changed

### Backend
- Added `micrometer-registry-prometheus` dependency and `application=steam5` global tag.
- Enabled HTTP request percentile histograms for proper p50/p95/p99 latency in Grafana.
- New `SecurityConfig` filter chain for `/actuator/**` (high priority, isolated from API routes) using HTTP Basic. `/actuator/health` stays public.
  - Dev defaults: `metrics` / `metrics`.
  - Prod requires `METRICS_USERNAME` / `METRICS_PASSWORD` — backend logs a startup `WARN` if defaults remain on the `coolify` profile.
- New `QuartzMetricsConfig` (`SchedulerFactoryBeanCustomizer` + global `JobListener`) records `quartz.jobs.execution` Timer with `group` / `name` / `outcome` tags. Spring Boot 4 doesn't auto-wire a Quartz Micrometer binder, so we register one explicitly.

### Monitoring stack (`monitoring/`)
- `docker-compose.yml`: Prometheus 3.5.1 + Grafana 12.3.1. Every port, host, credential, image tag, retention setting, and scrape interval is driven by `${VAR:-default}` env vars.
- Prometheus `envsubst` entrypoint shim — Prometheus 3.x doesn't natively expand `${VAR}` in its main config, so the container templates `prometheus.yml` at startup. Documented in-tree.
- Grafana auto-provisioning: Prometheus datasource + file provider pointed at `/var/lib/grafana/dashboards-json/`.
- Named volumes (`prometheus-data`, `grafana-data`) for state persistence in production.
- Linux-friendly: `extra_hosts: ["host.docker.internal:host-gateway"]` so Linux devs work out of the box.
- `.env.example` lists every env var with one-line comments and dev defaults.

### Dashboards (provisioned JSON, deterministic UIDs)
| UID | File | Highlights |
|-----|------|------------|
| `steam5-jvm` | `jvm.json` | Heap/non-heap by pool, threads, classes, GC pause rate/max |
| `steam5-http` | `http-server.json` | Total rate, errors, p50/p95/p99, top URIs, avg + max latency per URI |
| `steam5-hikari` | `hikari.json` | Active/idle/pending conns, timeouts, acquire/usage time, pool capacity |
| `steam5-caches` | `caches.json` | `$cache` template var auto-adapts to new Caffeine caches; hit/miss rate, hit ratio %, size, puts+evictions |
| `steam5-quartz` | `quartz.json` | Executions by outcome/job, avg+max duration, success/fail/vetoed totals |

All dashboards default to last 1h, 30s refresh. Filter by `$app` (default `steam5`) for multi-app scaling later.

### Documentation
- `README.md` — new **Monitoring** section with quick-start.
- `monitoring/README.md` (250 lines) — Overview, Local dev, Dashboards table, Env-var table, Cross-platform notes, **Coolify deployment guide** (backend env vars, internal-vs-public network trade-offs, monitoring service env, persistent volumes, reverse-proxy + `GF_SERVER_ROOT_URL`), Troubleshooting.

## Verification

Verified end-to-end multiple times by independent verifier agents:
- `./gradlew build` green (modulo the 2 pre-existing test failures in `AGENTS.md`).
- `curl -u metrics:metrics http://localhost:8081/actuator/prometheus` returns full metric set; unauth → 401; `/actuator/health` stays public.
- `docker compose --env-file .env up -d` brings up clean; Prometheus target shows **UP**; Grafana datasource auto-provisioned; all 5 dashboards loaded with non-empty data after triggered traffic; `docker compose down` clean.
- `quartz_jobs_execution_seconds_count` series confirmed with `outcome="succeeded"`.

## Local quick-start

```bash
# Terminal 1: backend
cd backend && ./gradlew bootRun

# Terminal 2: monitoring
cd monitoring && cp .env.example .env && docker compose --env-file .env up -d
```

Then Grafana at http://localhost:3001 (`admin`/`admin`), Prometheus at http://localhost:9090.

## For Coolify deployment

See `monitoring/README.md` → "Coolify production deployment". TL;DR:
- Override `METRICS_USERNAME` / `METRICS_PASSWORD` on the backend service.
- Deploy monitoring as a separate Coolify service, scrape backend over Coolify's internal Docker network.
- Mark `prometheus-data` and `grafana-data` as persistent volumes.
- For public Grafana access via reverse proxy, set `GF_SERVER_ROOT_URL` and `GF_SERVER_DOMAIN`.

## Notes

- Workspace branch: `add-grafana-metrics-dashboard`.
- No changes to existing API routes, the main `SecurityFilterChain`, frontend, or migrations.