### PR TITLE
Player Spotlight: daily good-vibes box with 8 insight tiers

### DIFF
--- a/backend/src/main/java/org/steam5/config/CacheConfig.java
+++ b/backend/src/main/java/org/steam5/config/CacheConfig.java
@@ -150,6 +150,15 @@ public class CacheConfig {
                         .build()
         );
 
+        final CaffeineCache playerSpotlights = new CaffeineCache(
+                "player-spotlights",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(1, TimeUnit.HOURS)
+                        .maximumSize(500)
+                        .recordStats()
+                        .build()
+        );
+
         final SimpleCacheManager cacheManager = new SimpleCacheManager();
         cacheManager.setCaches(List.of(
                 cacheOneHour,
@@ -166,7 +175,8 @@ public class CacheConfig {
                 seasonAwardsResponse,
                 seasonDetailResponse,
                 seasonAwards,
-                playerAwards
+                playerAwards,
+                playerSpotlights
         ));
         return cacheManager;
     }

--- a/backend/src/main/java/org/steam5/config/QuartzConfig.java
+++ b/backend/src/main/java/org/steam5/config/QuartzConfig.java
@@ -107,4 +107,17 @@ public class QuartzConfig {
                 )
                 .build();
     }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "jobs.player-spotlight", name = "enabled", havingValue = "true", matchIfMissing = false)
+    public Trigger triggerPlayerSpotlightJob(@Qualifier("PlayerSpotlightJob") JobDetail job) {
+        return TriggerBuilder.newTrigger().forJob(job)
+                .withIdentity("PlayerSpotlightJob_Trigger")
+                // daily at 00:15, after season backfill/finalizer have settled streak data
+                .withSchedule(
+                        CronScheduleBuilder.cronSchedule("0 15 0 * * ?")
+                                .inTimeZone(TimeZone.getTimeZone("UTC"))
+                )
+                .build();
+    }
 }

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlight.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlight.java
@@ -1,0 +1,47 @@
+package org.steam5.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * The "good vibes" player of the day, computed once nightly by PlayerSpotlightJob
+ * and read back for round 1 of the following day. One row per game date.
+ */
+@Entity
+@Table(name = "player_spotlights")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlayerSpotlight {
+
+    @Id
+    @Column(name = "game_date", nullable = false)
+    private LocalDate gameDate;
+
+    @Column(name = "steam_id", nullable = false, length = 32)
+    private String steamId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "insight_type", nullable = false, length = 32)
+    private PlayerSpotlightInsightType insightType;
+
+    @Column(name = "headline", nullable = false, length = 255)
+    private String headline;
+
+    @Column(name = "detail", nullable = false, length = 500)
+    private String detail;
+
+    @Column(name = "stat_label", length = 64)
+    private String statLabel;
+
+    @Column(name = "stat_value")
+    private Double statValue;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+}

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
@@ -8,6 +8,7 @@ public enum PlayerSpotlightInsightType {
     DAY_STREAK,
     BEST_DAY_EVER,
     BEAT_THE_ODDS,
+    WELCOME_BACK,
     WEEKLY_ACHIEVEMENT,
     HOT_STREAK,
     MILESTONE

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
@@ -1,8 +1,34 @@
 package org.steam5.domain;
 
 /**
- * Ordered by "how good a story is this" — index 0 is the most notable.
- * PlayerSpotlightService picks the best-populated tier each day.
+ * The first six values (DAY_STREAK, BEST_DAY_EVER, BEAT_THE_ODDS, WELCOME_BACK,
+ * MOST_IMPROVED, HOT_STREAK) form {@link org.steam5.service.PlayerSpotlightService}'s "competitive
+ * pool": every one of them that has at least one qualifying candidate on a
+ * given day is entered into a uniform-random lottery (NOT a priority ladder —
+ * the enum declaration order only matters as the fixed order in which each
+ * tier's qualification is evaluated, not as a preference ranking).
+ * WEEKLY_ACHIEVEMENT and MILESTONE are sequential fallbacks used only when
+ * the competitive pool has zero qualifying tiers for the day.
+ * <p>
+ * <b>Production-readiness warning for future maintainers:</b> this enum is
+ * persisted via {@code @Enumerated(EnumType.STRING)} on
+ * {@link PlayerSpotlight#getInsightType()}. Hibernate auto-generates a
+ * Postgres {@code CHECK} constraint on {@code player_spotlights.insight_type}
+ * listing this enum's values AT TABLE-CREATION TIME, and this codebase's
+ * {@code ddl-auto: update} setting does NOT widen that constraint when this
+ * enum grows later (the same limitation affects the enum-backed
+ * {@code season_award_results} and {@code seasons} tables). If you add a new
+ * value here, you MUST run, in every already-provisioned environment after
+ * deploying:
+ * <pre>
+ * ALTER TABLE player_spotlights DROP CONSTRAINT player_spotlights_insight_type_check;
+ * </pre>
+ * (or an equivalent widening {@code ALTER}). Skipping this will not fail
+ * loudly: {@link org.steam5.job.PlayerSpotlightJob#execute()} catches and
+ * merely logs persistence failures, so on any day the new tier wins the
+ * lottery, the INSERT will throw a CHECK-constraint violation and the
+ * spotlight box will simply disappear from the site that day with no
+ * visible error.
  */
 public enum PlayerSpotlightInsightType {
     DAY_STREAK,

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
@@ -9,6 +9,7 @@ public enum PlayerSpotlightInsightType {
     BEST_DAY_EVER,
     BEAT_THE_ODDS,
     WELCOME_BACK,
+    MOST_IMPROVED,
     WEEKLY_ACHIEVEMENT,
     HOT_STREAK,
     MILESTONE

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
@@ -1,0 +1,12 @@
+package org.steam5.domain;
+
+/**
+ * Ordered by "how good a story is this" — index 0 is the most notable.
+ * PlayerSpotlightService picks the best-populated tier each day.
+ */
+public enum PlayerSpotlightInsightType {
+    DAY_STREAK,
+    WEEKLY_ACHIEVEMENT,
+    HOT_STREAK,
+    MILESTONE
+}

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
@@ -36,7 +36,7 @@ public enum PlayerSpotlightInsightType {
     BEAT_THE_ODDS,
     WELCOME_BACK,
     MOST_IMPROVED,
-    WEEKLY_ACHIEVEMENT,
     HOT_STREAK,
+    WEEKLY_ACHIEVEMENT,
     MILESTONE
 }

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
@@ -7,6 +7,7 @@ package org.steam5.domain;
 public enum PlayerSpotlightInsightType {
     DAY_STREAK,
     BEST_DAY_EVER,
+    BEAT_THE_ODDS,
     WEEKLY_ACHIEVEMENT,
     HOT_STREAK,
     MILESTONE

--- a/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
+++ b/backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java
@@ -6,6 +6,7 @@ package org.steam5.domain;
  */
 public enum PlayerSpotlightInsightType {
     DAY_STREAK,
+    BEST_DAY_EVER,
     WEEKLY_ACHIEVEMENT,
     HOT_STREAK,
     MILESTONE

--- a/backend/src/main/java/org/steam5/job/PlayerSpotlightJob.java
+++ b/backend/src/main/java/org/steam5/job/PlayerSpotlightJob.java
@@ -1,0 +1,45 @@
+package org.steam5.job;
+
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.steam5.service.PlayerSpotlightService;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+@DisallowConcurrentExecution
+public class PlayerSpotlightJob implements Job {
+
+    private final PlayerSpotlightService playerSpotlightService;
+
+    public PlayerSpotlightJob(PlayerSpotlightService playerSpotlightService) {
+        this.playerSpotlightService = playerSpotlightService;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        final long start = System.nanoTime();
+        log.info("PlayerSpotlightJob fired at {}", context.getFireTime());
+        try {
+            playerSpotlightService.computeAndPersistForToday();
+        } catch (Exception ex) {
+            log.error("PlayerSpotlight computation failed", ex);
+        } finally {
+            long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+            log.info("PlayerSpotlightJob completed in {}ms; next fire {}",
+                    durationMs,
+                    context.getTrigger() != null ? context.getTrigger().getNextFireTime() : null);
+        }
+    }
+
+    @Bean("PlayerSpotlightJob")
+    public JobDetail jobDetail() {
+        return JobBuilder.newJob().ofType(PlayerSpotlightJob.class)
+                .storeDurably()
+                .withIdentity("PlayerSpotlightJob")
+                .build();
+    }
+}

--- a/backend/src/main/java/org/steam5/repository/GuessRepository.java
+++ b/backend/src/main/java/org/steam5/repository/GuessRepository.java
@@ -18,6 +18,20 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
      */
     List<Guess> findBySteamIdOrderByGameDateDescRoundIndexAsc(String steamId);
 
+    /**
+     * Batched form of {@link #findBySteamIdOrderByGameDateDescRoundIndexAsc(String)} for a
+     * whole candidate pool at once (e.g. PlayerSpotlightService), avoiding an N+1 pattern
+     * across per-tier per-candidate lookups. Callers group the result by steamId in memory.
+     */
+    List<Guess> findBySteamIdIn(List<String> steamIds);
+
+    /**
+     * All players' guesses for one specific (date, round) pair in a single query — used to
+     * check every eligible candidate's result on a single shared round (e.g. "yesterday's
+     * hardest round") without querying per candidate.
+     */
+    List<Guess> findByGameDateAndRoundIndex(LocalDate gameDate, int roundIndex);
+
     @Query("select g from Guess g where g.steamId = :steamId and g.gameDate = :date order by g.roundIndex asc")
     List<Guess> findAllForDay(@Param("steamId") String steamId, @Param("date") LocalDate date);
 

--- a/backend/src/main/java/org/steam5/repository/PlayerSpotlightRepository.java
+++ b/backend/src/main/java/org/steam5/repository/PlayerSpotlightRepository.java
@@ -1,0 +1,9 @@
+package org.steam5.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.steam5.domain.PlayerSpotlight;
+
+import java.time.LocalDate;
+
+public interface PlayerSpotlightRepository extends JpaRepository<PlayerSpotlight, LocalDate> {
+}

--- a/backend/src/main/java/org/steam5/repository/PlayerSpotlightRepository.java
+++ b/backend/src/main/java/org/steam5/repository/PlayerSpotlightRepository.java
@@ -4,6 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.steam5.domain.PlayerSpotlight;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface PlayerSpotlightRepository extends JpaRepository<PlayerSpotlight, LocalDate> {
+
+    /** Most recent spotlights for a player, newest first, capped for a "condensed" profile list. */
+    List<PlayerSpotlight> findTop10BySteamIdOrderByGameDateDesc(String steamId);
 }

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -101,24 +101,34 @@ public class PlayerSpotlightService {
             return Optional.empty();
         }
 
-        final List<Tiered> dayStreakTier = evaluateDayStreakTier(eligible, today);
-        if (!dayStreakTier.isEmpty()) {
-            return Optional.of(toEntity(today, pickOne(dayStreakTier, today)));
+        // "Competitive pool": every tier here that has >=1 qualifying candidate goes
+        // into a lottery, so no single ambient tier (e.g. DAY_STREAK) can dominate
+        // just because it's the easiest to qualify for on any given day.
+        final List<QualifyingTier> qualifying = new ArrayList<>();
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
+
+        if (!qualifying.isEmpty()) {
+            final Random random = new Random(today.toEpochDay());
+            final QualifyingTier chosen = qualifying.get(random.nextInt(qualifying.size()));
+            return Optional.of(toEntity(today, pickOne(chosen.candidates(), random)));
         }
 
         final List<Tiered> achievementTier = evaluateWeeklyAchievementTier(eligible);
         if (!achievementTier.isEmpty()) {
-            return Optional.of(toEntity(today, pickOne(achievementTier, today)));
-        }
-
-        final List<Tiered> hotStreakTier = evaluateHotStreakTier(eligible, today);
-        if (!hotStreakTier.isEmpty()) {
-            return Optional.of(toEntity(today, pickOne(hotStreakTier, today)));
+            return Optional.of(toEntity(today, pickOne(achievementTier, new Random(today.toEpochDay()))));
         }
 
         // Guaranteed fallback: always show someone among the eligible pool.
         final List<Tiered> milestoneTier = evaluateMilestoneTier(eligible);
-        return Optional.of(toEntity(today, pickOne(milestoneTier, today)));
+        return Optional.of(toEntity(today, pickOne(milestoneTier, new Random(today.toEpochDay()))));
+    }
+
+    private void addIfQualifying(final List<QualifyingTier> qualifying, final PlayerSpotlightInsightType type,
+                                  final List<Tiered> candidates) {
+        if (!candidates.isEmpty()) {
+            qualifying.add(new QualifyingTier(type, candidates));
+        }
     }
 
     private List<Candidate> findEligibleCandidates(final LocalDate today) {
@@ -247,12 +257,11 @@ public class PlayerSpotlightService {
         };
     }
 
-    /** Stable-for-the-day, rotating-by-date pick among candidates tied in the same tier. */
-    private Tiered pickOne(final List<Tiered> tier, final LocalDate today) {
+    /** Stable-for-the-day pick among candidates tied in the same tier, using the caller's Random. */
+    private Tiered pickOne(final List<Tiered> tier, final Random random) {
         final List<Tiered> sorted = tier.stream()
                 .sorted(Comparator.comparing(Tiered::steamId))
                 .toList();
-        final Random random = new Random(today.toEpochDay());
         return sorted.get(random.nextInt(sorted.size()));
     }
 
@@ -273,6 +282,9 @@ public class PlayerSpotlightService {
 
     private record Tiered(String steamId, PlayerSpotlightInsightType insightType, String headline, String detail,
                            String statLabel, Double statValue) {
+    }
+
+    private record QualifyingTier(PlayerSpotlightInsightType type, List<Tiered> candidates) {
     }
 
     private record AchievementText(String headline, String detail, String statLabel, Double statValue) {

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -2,6 +2,7 @@ package org.steam5.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.steam5.domain.GameDate;
@@ -101,6 +102,16 @@ public class PlayerSpotlightService {
 
     public Optional<SpotlightResponse> getTodaySpotlight() {
         return playerSpotlightRepository.findById(GameDate.todayUtc()).map(this::toResponse);
+    }
+
+    /** Condensed history (most recent 10) of spotlights a player has been featured in, for their profile page. */
+    @Transactional(readOnly = true)
+    @Cacheable(value = "player-spotlights", key = "#steamId")
+    public List<SpotlightHistoryEntry> listSpotlightsForPlayer(final String steamId) {
+        return playerSpotlightRepository.findTop10BySteamIdOrderByGameDateDesc(steamId).stream()
+                .map(s -> new SpotlightHistoryEntry(s.getGameDate(), s.getInsightType(), s.getHeadline(),
+                        s.getDetail(), s.getStatLabel(), s.getStatValue()))
+                .toList();
     }
 
     private SpotlightResponse toResponse(final PlayerSpotlight spotlight) {
@@ -437,6 +448,16 @@ public class PlayerSpotlightService {
     }
 
     private record AchievementText(String headline, String detail, String statLabel, Double statValue) {
+    }
+
+    public record SpotlightHistoryEntry(
+            LocalDate gameDate,
+            PlayerSpotlightInsightType insightType,
+            String headline,
+            String detail,
+            String statLabel,
+            Double statValue
+    ) {
     }
 
     public record SpotlightResponse(

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -45,6 +45,7 @@ public class PlayerSpotlightService {
     private static final int MIN_TOTAL_ROUNDS = 70;
     private static final int RECENCY_WINDOW_DAYS = 14;
     private static final int MIN_DAY_STREAK = 5;
+    private static final int MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER = 2;
     private static final int HOT_STREAK_WINDOW_DAYS = 14;
     private static final int MIN_RECENT_ROUNDS_FOR_HOT_STREAK = 5;
     private static final double HOT_STREAK_RELATIVE_THRESHOLD = 1.2; // recent avg must be >= 20% above all-time avg
@@ -104,8 +105,10 @@ public class PlayerSpotlightService {
         // "Competitive pool": every tier here that has >=1 qualifying candidate goes
         // into a lottery, so no single ambient tier (e.g. DAY_STREAK) can dominate
         // just because it's the easiest to qualify for on any given day.
+        final LocalDate yesterday = today.minusDays(1);
         final List<QualifyingTier> qualifying = new ArrayList<>();
         addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
 
         if (!qualifying.isEmpty()) {
@@ -178,6 +181,34 @@ public class PlayerSpotlightService {
                     : String.format("On a %d-day streak of playing every day.", currentStreak);
             tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.DAY_STREAK,
                     "On a hot streak!", detail, "Day streak", (double) currentStreak));
+        }
+        return tier;
+    }
+
+    private List<Tiered> evaluateBestDayEverTier(final List<Candidate> eligible, final LocalDate yesterday) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final List<Guess> history = guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(c.steamId());
+            final Map<LocalDate, Integer> dailyTotals = history.stream()
+                    .collect(Collectors.groupingBy(Guess::getGameDate, Collectors.summingInt(Guess::getPoints)));
+
+            final Integer yesterdayTotal = dailyTotals.get(yesterday);
+            if (yesterdayTotal == null) continue;
+
+            final List<Integer> priorTotals = dailyTotals.entrySet().stream()
+                    .filter(e -> !e.getKey().equals(yesterday))
+                    .map(Map.Entry::getValue)
+                    .toList();
+            if (priorTotals.size() < MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER) continue;
+
+            final int previousBest = Collections.max(priorTotals);
+            if (yesterdayTotal <= previousBest) continue;
+
+            final String detail = String.format(
+                    "Scored %d points yesterday — a new personal best, beating their previous high of %d.",
+                    yesterdayTotal, previousBest);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.BEST_DAY_EVER,
+                    "Best day ever!", detail, "Yesterday's points", (double) yesterdayTotal));
         }
         return tier;
     }

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -15,6 +15,7 @@ import org.steam5.repository.PlayerSpotlightRepository;
 import org.steam5.repository.UserRepository;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -48,6 +49,8 @@ public class PlayerSpotlightService {
     private static final int MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER = 2;
     private static final double HARD_ROUND_MAX_AVG_SCORE = 2.0;
     private static final int BEAT_THE_ODDS_MIN_POINTS = 4;
+    private static final int WELCOME_BACK_MIN_GAP_DAYS = 4;
+    private static final double WELCOME_BACK_MIN_RETURN_DAY_AVG = 3.0;
     private static final int HOT_STREAK_WINDOW_DAYS = 14;
     private static final int MIN_RECENT_ROUNDS_FOR_HOT_STREAK = 5;
     private static final double HOT_STREAK_RELATIVE_THRESHOLD = 1.2; // recent avg must be >= 20% above all-time avg
@@ -112,6 +115,7 @@ public class PlayerSpotlightService {
         addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.BEAT_THE_ODDS, evaluateBeatTheOddsTier(eligible, yesterday));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.WELCOME_BACK, evaluateWelcomeBackTier(eligible));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
 
         if (!qualifying.isEmpty()) {
@@ -238,6 +242,30 @@ public class PlayerSpotlightService {
                     roundIndex, hardAvg, theirGuess.get().getPoints());
             tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.BEAT_THE_ODDS,
                     "Beat the odds!", detail, "Round points", (double) theirGuess.get().getPoints()));
+        }
+        return tier;
+    }
+
+    private List<Tiered> evaluateWelcomeBackTier(final List<Candidate> eligible) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final List<LocalDate> datesDesc = c.datesDesc();
+            if (datesDesc.size() < 2) continue;
+
+            final LocalDate mostRecent = datesDesc.get(0);
+            final LocalDate previous = datesDesc.get(1);
+            final long gapDays = ChronoUnit.DAYS.between(previous, mostRecent);
+            if (gapDays < WELCOME_BACK_MIN_GAP_DAYS) continue;
+
+            final List<Guess> returnDayGuesses = guessRepository.findAllForDay(c.steamId(), mostRecent);
+            final double returnDayAvg = returnDayGuesses.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            if (returnDayAvg < WELCOME_BACK_MIN_RETURN_DAY_AVG) continue;
+
+            final String detail = String.format(
+                    "Took a %d-day break and came back strong, averaging %.1f pts/round on their return.",
+                    gapDays, returnDayAvg);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.WELCOME_BACK,
+                    "Welcome back!", detail, "Days away", (double) gapDays));
         }
         return tier;
     }

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -59,6 +59,9 @@ public class PlayerSpotlightService {
     private static final int MIN_RECENT_ROUNDS_FOR_HOT_STREAK = 5;
     private static final double HOT_STREAK_RELATIVE_THRESHOLD = 1.2; // recent avg must be >= 20% above all-time avg
     private static final double HOT_STREAK_ABSOLUTE_DELTA = 0.3;    // ...and at least this many points better
+    private static final List<Long> ROUND_MILESTONES = List.of(100L, 250L, 500L, 1000L);
+    private static final List<Long> POINTS_MILESTONES = List.of(1000L, 5000L, 10000L);
+    private static final long MILESTONE_TRAILING_WINDOW = 5;
 
     private final GuessRepository guessRepository;
     private final UserRepository userRepository;
@@ -345,14 +348,28 @@ public class PlayerSpotlightService {
     private List<Tiered> evaluateMilestoneTier(final List<Candidate> eligible) {
         final List<Tiered> tier = new ArrayList<>();
         for (final Candidate c : eligible) {
+            final long rounds = c.allTime().getRounds();
+            final long totalPoints = c.allTime().getTotalPoints() != null ? c.allTime().getTotalPoints() : 0L;
             final double avgPoints = c.allTime().getAvgPoints() != null ? c.allTime().getAvgPoints() : 0.0;
-            final String detail = String.format(
-                    "Has played %d rounds and counting, averaging %.1f pts/round.",
-                    c.allTime().getRounds(), avgPoints);
+
+            final String detail = nearestMilestoneDetail(rounds, ROUND_MILESTONES, "rounds")
+                    .or(() -> nearestMilestoneDetail(totalPoints, POINTS_MILESTONES, "lifetime points"))
+                    .orElseGet(() -> String.format("Has played %d rounds and counting, averaging %.1f pts/round.",
+                            rounds, avgPoints));
+
             tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.MILESTONE,
-                    "A steady presence!", detail, "Rounds played", (double) c.allTime().getRounds()));
+                    "A steady presence!", detail, "Rounds played", (double) rounds));
         }
         return tier;
+    }
+
+    private Optional<String> nearestMilestoneDetail(final long value, final List<Long> milestones, final String unitLabel) {
+        return milestones.stream()
+                .filter(milestone -> Math.abs(value - milestone) <= MILESTONE_TRAILING_WINDOW)
+                .findFirst()
+                .map(milestone -> value >= milestone
+                        ? String.format("Just crossed %,d %s — now at %,d!", milestone, unitLabel, value)
+                        : String.format("Closing in on %,d %s — only %,d away!", milestone, unitLabel, milestone - value));
     }
 
     private AchievementText describeAchievement(final StatisticsService.UserLabel label) {

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -46,6 +46,8 @@ public class PlayerSpotlightService {
     private static final int RECENCY_WINDOW_DAYS = 14;
     private static final int MIN_DAY_STREAK = 5;
     private static final int MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER = 2;
+    private static final double HARD_ROUND_MAX_AVG_SCORE = 2.0;
+    private static final int BEAT_THE_ODDS_MIN_POINTS = 4;
     private static final int HOT_STREAK_WINDOW_DAYS = 14;
     private static final int MIN_RECENT_ROUNDS_FOR_HOT_STREAK = 5;
     private static final double HOT_STREAK_RELATIVE_THRESHOLD = 1.2; // recent avg must be >= 20% above all-time avg
@@ -109,6 +111,7 @@ public class PlayerSpotlightService {
         final List<QualifyingTier> qualifying = new ArrayList<>();
         addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEAT_THE_ODDS, evaluateBeatTheOddsTier(eligible, yesterday));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
 
         if (!qualifying.isEmpty()) {
@@ -209,6 +212,32 @@ public class PlayerSpotlightService {
                     yesterdayTotal, previousBest);
             tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.BEST_DAY_EVER,
                     "Best day ever!", detail, "Yesterday's points", (double) yesterdayTotal));
+        }
+        return tier;
+    }
+
+    private List<Tiered> evaluateBeatTheOddsTier(final List<Candidate> eligible, final LocalDate yesterday) {
+        final List<GuessRepository.RoundAvgScoreRow> rows = guessRepository.findRoundAvgScoresInRange(yesterday, yesterday);
+        final Optional<GuessRepository.RoundAvgScoreRow> hardestRound = rows.stream()
+                .min(Comparator.comparing(GuessRepository.RoundAvgScoreRow::getAvgScore));
+        if (hardestRound.isEmpty() || hardestRound.get().getAvgScore() >= HARD_ROUND_MAX_AVG_SCORE) {
+            return List.of();
+        }
+
+        final int roundIndex = hardestRound.get().getRoundIndex();
+        final double hardAvg = hardestRound.get().getAvgScore();
+
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final Optional<Guess> theirGuess =
+                    guessRepository.findBySteamIdAndGameDateAndRoundIndex(c.steamId(), yesterday, roundIndex);
+            if (theirGuess.isEmpty() || theirGuess.get().getPoints() < BEAT_THE_ODDS_MIN_POINTS) continue;
+
+            final String detail = String.format(
+                    "Nailed yesterday's toughest round (round %d, %.1f avg pts across all players) with %d points.",
+                    roundIndex, hardAvg, theirGuess.get().getPoints());
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.BEAT_THE_ODDS,
+                    "Beat the odds!", detail, "Round points", (double) theirGuess.get().getPoints()));
         }
         return tier;
     }

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -1,0 +1,292 @@
+package org.steam5.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.steam5.domain.GameDate;
+import org.steam5.domain.Guess;
+import org.steam5.domain.PlayerSpotlight;
+import org.steam5.domain.PlayerSpotlightInsightType;
+import org.steam5.domain.StreakCalculator;
+import org.steam5.domain.User;
+import org.steam5.repository.GuessRepository;
+import org.steam5.repository.PlayerSpotlightRepository;
+import org.steam5.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Picks one eligible player each day to feature in a "good vibes" box shown on
+ * round 1. Eligibility requires an established, currently-active player (min
+ * rounds all-time, played recently) so the spotlight never features a fluke.
+ * <p>
+ * Selection is "best story wins": the highest-priority tier
+ * ({@link PlayerSpotlightInsightType}) that has at least one qualifying
+ * candidate is used, with a date-seeded random pick among ties so the same
+ * story holds for the whole day but rotates daily.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PlayerSpotlightService {
+
+    private static final int MIN_TOTAL_ROUNDS = 70;
+    private static final int RECENCY_WINDOW_DAYS = 14;
+    private static final int MIN_DAY_STREAK = 5;
+    private static final int HOT_STREAK_WINDOW_DAYS = 14;
+    private static final int MIN_RECENT_ROUNDS_FOR_HOT_STREAK = 5;
+    private static final double HOT_STREAK_RELATIVE_THRESHOLD = 1.2; // recent avg must be >= 20% above all-time avg
+    private static final double HOT_STREAK_ABSOLUTE_DELTA = 0.3;    // ...and at least this many points better
+
+    private final GuessRepository guessRepository;
+    private final UserRepository userRepository;
+    private final StatisticsService statisticsService;
+    private final PlayerSpotlightRepository playerSpotlightRepository;
+
+    /**
+     * Computes and persists today's spotlight, if one doesn't already exist.
+     * Intended to be called once nightly by PlayerSpotlightJob.
+     */
+    @Transactional
+    public void computeAndPersistForToday() {
+        final LocalDate today = GameDate.todayUtc();
+        if (playerSpotlightRepository.existsById(today)) {
+            log.info("PlayerSpotlight already computed for {}", today);
+            return;
+        }
+
+        final Optional<PlayerSpotlight> spotlight = compute(today);
+        if (spotlight.isPresent()) {
+            playerSpotlightRepository.save(spotlight.get());
+            log.info("PlayerSpotlight computed for {}: steamId={} insight={}",
+                    today, spotlight.get().getSteamId(), spotlight.get().getInsightType());
+        } else {
+            log.info("No eligible PlayerSpotlight candidate for {}", today);
+        }
+    }
+
+    public Optional<SpotlightResponse> getTodaySpotlight() {
+        return playerSpotlightRepository.findById(GameDate.todayUtc()).map(this::toResponse);
+    }
+
+    private SpotlightResponse toResponse(final PlayerSpotlight spotlight) {
+        final User user = userRepository.findById(spotlight.getSteamId()).orElse(null);
+        return new SpotlightResponse(
+                spotlight.getSteamId(),
+                user != null && user.getPersonaName() != null ? user.getPersonaName() : spotlight.getSteamId(),
+                user != null ? user.getAvatar() : null,
+                spotlight.getInsightType(),
+                spotlight.getHeadline(),
+                spotlight.getDetail(),
+                spotlight.getStatLabel(),
+                spotlight.getStatValue()
+        );
+    }
+
+    private Optional<PlayerSpotlight> compute(final LocalDate today) {
+        final List<Candidate> eligible = findEligibleCandidates(today);
+        if (eligible.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final List<Tiered> dayStreakTier = evaluateDayStreakTier(eligible, today);
+        if (!dayStreakTier.isEmpty()) {
+            return Optional.of(toEntity(today, pickOne(dayStreakTier, today)));
+        }
+
+        final List<Tiered> achievementTier = evaluateWeeklyAchievementTier(eligible);
+        if (!achievementTier.isEmpty()) {
+            return Optional.of(toEntity(today, pickOne(achievementTier, today)));
+        }
+
+        final List<Tiered> hotStreakTier = evaluateHotStreakTier(eligible, today);
+        if (!hotStreakTier.isEmpty()) {
+            return Optional.of(toEntity(today, pickOne(hotStreakTier, today)));
+        }
+
+        // Guaranteed fallback: always show someone among the eligible pool.
+        final List<Tiered> milestoneTier = evaluateMilestoneTier(eligible);
+        return Optional.of(toEntity(today, pickOne(milestoneTier, today)));
+    }
+
+    private List<Candidate> findEligibleCandidates(final LocalDate today) {
+        final Map<String, GuessRepository.AllTimeStatsRow> eligibleAllTime = guessRepository.aggregateAllTimeStats()
+                .stream()
+                .filter(row -> row.getRounds() != null && row.getRounds() >= MIN_TOTAL_ROUNDS)
+                .collect(Collectors.toMap(GuessRepository.AllTimeStatsRow::getSteamId, Function.identity()));
+
+        if (eligibleAllTime.isEmpty()) {
+            return List.of();
+        }
+
+        final List<String> candidateIds = new ArrayList<>(eligibleAllTime.keySet());
+        final Map<String, List<LocalDate>> datesByUser = guessRepository
+                .findDistinctDatesUpToForUsers(candidateIds, today).stream()
+                .collect(Collectors.groupingBy(
+                        GuessRepository.UserDateRow::getSteamId,
+                        LinkedHashMap::new,
+                        Collectors.mapping(GuessRepository.UserDateRow::getGameDate, Collectors.toList())
+                ));
+
+        final LocalDate recencyCutoff = today.minusDays(RECENCY_WINDOW_DAYS);
+        final List<Candidate> eligible = new ArrayList<>();
+        for (final String steamId : candidateIds) {
+            final List<LocalDate> datesDesc = datesByUser.getOrDefault(steamId, List.of());
+            if (datesDesc.isEmpty() || datesDesc.get(0).isBefore(recencyCutoff)) {
+                continue;
+            }
+            eligible.add(new Candidate(steamId, eligibleAllTime.get(steamId), datesDesc));
+        }
+        return eligible;
+    }
+
+    private List<Tiered> evaluateDayStreakTier(final List<Candidate> eligible, final LocalDate today) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final int currentStreak = StreakCalculator.currentStreak(c.datesDesc(), today);
+            if (currentStreak < MIN_DAY_STREAK) continue;
+
+            final List<LocalDate> datesAsc = new ArrayList<>(c.datesDesc());
+            Collections.reverse(datesAsc);
+            final long longest = StreakCalculator.longestStreak(datesAsc);
+            final boolean isPersonalBest = currentStreak >= longest;
+
+            final String detail = isPersonalBest
+                    ? String.format("Riding a personal-best %d-day streak — playing every single day!", currentStreak)
+                    : String.format("On a %d-day streak of playing every day.", currentStreak);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.DAY_STREAK,
+                    "On a hot streak!", detail, "Day streak", (double) currentStreak));
+        }
+        return tier;
+    }
+
+    private List<Tiered> evaluateWeeklyAchievementTier(final List<Candidate> eligible) {
+        final Set<String> eligibleIds = eligible.stream().map(Candidate::steamId).collect(Collectors.toSet());
+        final List<Tiered> tier = new ArrayList<>();
+        for (final StatisticsService.UserLabel label : statisticsService.getUserAchievementsWeekly()) {
+            if (!eligibleIds.contains(label.steamId())) continue;
+            final AchievementText text = describeAchievement(label);
+            if (text == null) continue;
+            tier.add(new Tiered(label.steamId(), PlayerSpotlightInsightType.WEEKLY_ACHIEVEMENT,
+                    text.headline(), text.detail(), text.statLabel(), text.statValue()));
+        }
+        return tier;
+    }
+
+    private List<Tiered> evaluateHotStreakTier(final List<Candidate> eligible, final LocalDate today) {
+        final LocalDate windowStart = today.minusDays(HOT_STREAK_WINDOW_DAYS - 1L);
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final List<Guess> recent = guessRepository.findBySteamIdBetween(c.steamId(), windowStart, today);
+            if (recent.size() < MIN_RECENT_ROUNDS_FOR_HOT_STREAK) continue;
+
+            final double allTimeAvg = c.allTime().getAvgPoints() != null ? c.allTime().getAvgPoints() : 0.0;
+            if (allTimeAvg <= 0) continue;
+
+            final double recentAvg = recent.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            final boolean qualifies = recentAvg >= allTimeAvg * HOT_STREAK_RELATIVE_THRESHOLD
+                    && (recentAvg - allTimeAvg) >= HOT_STREAK_ABSOLUTE_DELTA;
+            if (!qualifies) continue;
+
+            final String detail = String.format(
+                    "Averaging %.1f pts/round over the last %d days — well above their usual %.1f.",
+                    recentAvg, HOT_STREAK_WINDOW_DAYS, allTimeAvg);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.HOT_STREAK,
+                    "In red-hot form!", detail, "Recent avg", recentAvg));
+        }
+        return tier;
+    }
+
+    private List<Tiered> evaluateMilestoneTier(final List<Candidate> eligible) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final double avgPoints = c.allTime().getAvgPoints() != null ? c.allTime().getAvgPoints() : 0.0;
+            final String detail = String.format(
+                    "Has played %d rounds and counting, averaging %.1f pts/round.",
+                    c.allTime().getRounds(), avgPoints);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.MILESTONE,
+                    "A steady presence!", detail, "Rounds played", (double) c.allTime().getRounds()));
+        }
+        return tier;
+    }
+
+    private AchievementText describeAchievement(final StatisticsService.UserLabel label) {
+        return switch (label.userAchievement()) {
+            case EARLY_BIRD -> new AchievementText("Early bird of the week!",
+                    "Plays earlier in the day than anyone else this week.", "Avg time", label.avgMinutes());
+            case NIGHT_OWL -> new AchievementText("Night owl of the week!",
+                    "Plays later in the day than anyone else this week.", "Avg time", label.avgMinutes());
+            case SHARPSHOOTER -> new AchievementText("Sharpshooter of the week!",
+                    String.format("Highest average score this week — %.1f pts/round.", label.avgPoints()),
+                    "Avg points", label.avgPoints());
+            case BULLSEYE -> new AchievementText("Bullseye streak!",
+                    String.format("Landed %d perfect round%s this week.", label.perfectRounds(),
+                            label.perfectRounds() != null && label.perfectRounds() == 1 ? "" : "s"),
+                    "Perfect rounds", label.perfectRounds() != null ? label.perfectRounds().doubleValue() : null);
+            case PERFECT_DAY -> new AchievementText("Flawless days!",
+                    String.format("Notched %d perfect day%s this week.", label.perfectDays(),
+                            label.perfectDays() != null && label.perfectDays() == 1 ? "" : "s"),
+                    "Perfect days", label.perfectDays() != null ? label.perfectDays().doubleValue() : null);
+            case CHEETAH -> new AchievementText("Quickest hands this week!",
+                    "Blazed through rounds faster than anyone else this week.", "Total seconds",
+                    label.totalSeconds() != null ? label.totalSeconds().doubleValue() : null);
+            // SLOTH ("slowest player") isn't a good-vibes framing — skip it.
+            case SLOTH -> null;
+        };
+    }
+
+    /** Stable-for-the-day, rotating-by-date pick among candidates tied in the same tier. */
+    private Tiered pickOne(final List<Tiered> tier, final LocalDate today) {
+        final List<Tiered> sorted = tier.stream()
+                .sorted(Comparator.comparing(Tiered::steamId))
+                .toList();
+        final Random random = new Random(today.toEpochDay());
+        return sorted.get(random.nextInt(sorted.size()));
+    }
+
+    private PlayerSpotlight toEntity(final LocalDate today, final Tiered tiered) {
+        final PlayerSpotlight entity = new PlayerSpotlight();
+        entity.setGameDate(today);
+        entity.setSteamId(tiered.steamId());
+        entity.setInsightType(tiered.insightType());
+        entity.setHeadline(tiered.headline());
+        entity.setDetail(tiered.detail());
+        entity.setStatLabel(tiered.statLabel());
+        entity.setStatValue(tiered.statValue());
+        return entity;
+    }
+
+    private record Candidate(String steamId, GuessRepository.AllTimeStatsRow allTime, List<LocalDate> datesDesc) {
+    }
+
+    private record Tiered(String steamId, PlayerSpotlightInsightType insightType, String headline, String detail,
+                           String statLabel, Double statValue) {
+    }
+
+    private record AchievementText(String headline, String detail, String statLabel, Double statValue) {
+    }
+
+    public record SpotlightResponse(
+            String steamId,
+            String personaName,
+            String avatar,
+            PlayerSpotlightInsightType insightType,
+            String headline,
+            String detail,
+            String statLabel,
+            Double statValue
+    ) {
+    }
+}

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -33,10 +33,19 @@ import java.util.stream.Collectors;
  * round 1. Eligibility requires an established, currently-active player (min
  * rounds all-time, played recently) so the spotlight never features a fluke.
  * <p>
- * Selection is "best story wins": the highest-priority tier
- * ({@link PlayerSpotlightInsightType}) that has at least one qualifying
- * candidate is used, with a date-seeded random pick among ties so the same
- * story holds for the whole day but rotates daily.
+ * Selection is a lottery, not a priority ladder: every tier in the fixed-order
+ * "competitive pool" (DAY_STREAK, BEST_DAY_EVER, BEAT_THE_ODDS, WELCOME_BACK,
+ * MOST_IMPROVED, HOT_STREAK) that has at least one qualifying candidate is
+ * added to a list, and one entry is drawn uniformly at random via
+ * {@code new Random(today.toEpochDay())}. This means no single ambient tier
+ * (e.g. DAY_STREAK, which is easy to qualify for) can dominate just because
+ * it's evaluated first — it only gets an edge if it's the ONLY tier that
+ * qualifies. When the competitive pool has zero qualifying tiers, two
+ * sequential fallbacks are tried in order: WEEKLY_ACHIEVEMENT, then
+ * MILESTONE (which always has at least one candidate among the eligible
+ * pool, guaranteeing a spotlight is always produced). Ties within a chosen
+ * tier are broken by the same date-seeded {@link Random}, so the result is
+ * stable for the whole day but rotates daily.
  */
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -134,17 +134,26 @@ public class PlayerSpotlightService {
             return Optional.empty();
         }
 
+        // Batch-prefetch every eligible candidate's guess history in one query, instead of
+        // each tier evaluator querying per-candidate — BEST_DAY_EVER, WELCOME_BACK,
+        // MOST_IMPROVED, and HOT_STREAK all just filter/aggregate this same in-memory map
+        // to their own date window, eliminating what was an N+1 (and 2N for MOST_IMPROVED)
+        // pattern across those four tiers.
+        final List<String> eligibleIds = eligible.stream().map(Candidate::steamId).toList();
+        final Map<String, List<Guess>> historyByPlayer = guessRepository.findBySteamIdIn(eligibleIds).stream()
+                .collect(Collectors.groupingBy(Guess::getSteamId));
+
         // "Competitive pool": every tier here that has >=1 qualifying candidate goes
         // into a lottery, so no single ambient tier (e.g. DAY_STREAK) can dominate
         // just because it's the easiest to qualify for on any given day.
         final LocalDate yesterday = today.minusDays(1);
         final List<QualifyingTier> qualifying = new ArrayList<>();
         addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
-        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday, historyByPlayer));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.BEAT_THE_ODDS, evaluateBeatTheOddsTier(eligible, yesterday));
-        addIfQualifying(qualifying, PlayerSpotlightInsightType.WELCOME_BACK, evaluateWelcomeBackTier(eligible));
-        addIfQualifying(qualifying, PlayerSpotlightInsightType.MOST_IMPROVED, evaluateMostImprovedTier(eligible, today));
-        addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.WELCOME_BACK, evaluateWelcomeBackTier(eligible, historyByPlayer));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.MOST_IMPROVED, evaluateMostImprovedTier(eligible, today, historyByPlayer));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today, historyByPlayer));
 
         if (!qualifying.isEmpty()) {
             final Random random = new Random(today.toEpochDay());
@@ -220,10 +229,11 @@ public class PlayerSpotlightService {
         return tier;
     }
 
-    private List<Tiered> evaluateBestDayEverTier(final List<Candidate> eligible, final LocalDate yesterday) {
+    private List<Tiered> evaluateBestDayEverTier(final List<Candidate> eligible, final LocalDate yesterday,
+                                                  final Map<String, List<Guess>> historyByPlayer) {
         final List<Tiered> tier = new ArrayList<>();
         for (final Candidate c : eligible) {
-            final List<Guess> history = guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(c.steamId());
+            final List<Guess> history = historyByPlayer.getOrDefault(c.steamId(), List.of());
             final Map<LocalDate, Integer> dailyTotals = history.stream()
                     .collect(Collectors.groupingBy(Guess::getGameDate, Collectors.summingInt(Guess::getPoints)));
 
@@ -259,22 +269,28 @@ public class PlayerSpotlightService {
         final int roundIndex = hardestRound.get().getRoundIndex();
         final double hardAvg = hardestRound.get().getAvgScore();
 
+        // One query for everyone's guess on the hardest round, instead of one query per
+        // candidate for findBySteamIdAndGameDateAndRoundIndex.
+        final Map<String, Guess> guessByPlayer = guessRepository.findByGameDateAndRoundIndex(yesterday, roundIndex)
+                .stream()
+                .collect(Collectors.toMap(Guess::getSteamId, Function.identity(), (a, b) -> a));
+
         final List<Tiered> tier = new ArrayList<>();
         for (final Candidate c : eligible) {
-            final Optional<Guess> theirGuess =
-                    guessRepository.findBySteamIdAndGameDateAndRoundIndex(c.steamId(), yesterday, roundIndex);
-            if (theirGuess.isEmpty() || theirGuess.get().getPoints() < BEAT_THE_ODDS_MIN_POINTS) continue;
+            final Guess theirGuess = guessByPlayer.get(c.steamId());
+            if (theirGuess == null || theirGuess.getPoints() < BEAT_THE_ODDS_MIN_POINTS) continue;
 
             final String detail = String.format(
                     "Nailed yesterday's toughest round (round %d, %.1f avg pts across all players) with %d points.",
-                    roundIndex, hardAvg, theirGuess.get().getPoints());
+                    roundIndex, hardAvg, theirGuess.getPoints());
             tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.BEAT_THE_ODDS,
-                    "Beat the odds!", detail, "Round points", (double) theirGuess.get().getPoints()));
+                    "Beat the odds!", detail, "Round points", (double) theirGuess.getPoints()));
         }
         return tier;
     }
 
-    private List<Tiered> evaluateWelcomeBackTier(final List<Candidate> eligible) {
+    private List<Tiered> evaluateWelcomeBackTier(final List<Candidate> eligible,
+                                                  final Map<String, List<Guess>> historyByPlayer) {
         final List<Tiered> tier = new ArrayList<>();
         for (final Candidate c : eligible) {
             final List<LocalDate> datesDesc = c.datesDesc();
@@ -285,8 +301,12 @@ public class PlayerSpotlightService {
             final long gapDays = ChronoUnit.DAYS.between(previous, mostRecent);
             if (gapDays < WELCOME_BACK_MIN_GAP_DAYS) continue;
 
-            final List<Guess> returnDayGuesses = guessRepository.findAllForDay(c.steamId(), mostRecent);
-            final double returnDayAvg = returnDayGuesses.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            final List<Guess> history = historyByPlayer.getOrDefault(c.steamId(), List.of());
+            final double returnDayAvg = history.stream()
+                    .filter(g -> g.getGameDate().equals(mostRecent))
+                    .mapToInt(Guess::getPoints)
+                    .average()
+                    .orElse(0.0);
             if (returnDayAvg < WELCOME_BACK_MIN_RETURN_DAY_AVG) continue;
 
             final String detail = String.format(
@@ -298,7 +318,8 @@ public class PlayerSpotlightService {
         return tier;
     }
 
-    private List<Tiered> evaluateMostImprovedTier(final List<Candidate> eligible, final LocalDate today) {
+    private List<Tiered> evaluateMostImprovedTier(final List<Candidate> eligible, final LocalDate today,
+                                                   final Map<String, List<Guess>> historyByPlayer) {
         final LocalDate last30Start = today.minusDays(MOST_IMPROVED_WINDOW_DAYS);
         final LocalDate last30End = today.minusDays(1);
         final LocalDate prior30Start = today.minusDays(2L * MOST_IMPROVED_WINDOW_DAYS);
@@ -306,8 +327,13 @@ public class PlayerSpotlightService {
 
         final List<Tiered> tier = new ArrayList<>();
         for (final Candidate c : eligible) {
-            final List<Guess> last30 = guessRepository.findBySteamIdBetween(c.steamId(), last30Start, last30End);
-            final List<Guess> prior30 = guessRepository.findBySteamIdBetween(c.steamId(), prior30Start, prior30End);
+            final List<Guess> history = historyByPlayer.getOrDefault(c.steamId(), List.of());
+            final List<Guess> last30 = history.stream()
+                    .filter(g -> !g.getGameDate().isBefore(last30Start) && !g.getGameDate().isAfter(last30End))
+                    .toList();
+            final List<Guess> prior30 = history.stream()
+                    .filter(g -> !g.getGameDate().isBefore(prior30Start) && !g.getGameDate().isAfter(prior30End))
+                    .toList();
             if (last30.size() < MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW
                     || prior30.size() < MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW) {
                 continue;
@@ -341,11 +367,15 @@ public class PlayerSpotlightService {
         return tier;
     }
 
-    private List<Tiered> evaluateHotStreakTier(final List<Candidate> eligible, final LocalDate today) {
+    private List<Tiered> evaluateHotStreakTier(final List<Candidate> eligible, final LocalDate today,
+                                                final Map<String, List<Guess>> historyByPlayer) {
         final LocalDate windowStart = today.minusDays(HOT_STREAK_WINDOW_DAYS - 1L);
         final List<Tiered> tier = new ArrayList<>();
         for (final Candidate c : eligible) {
-            final List<Guess> recent = guessRepository.findBySteamIdBetween(c.steamId(), windowStart, today);
+            final List<Guess> history = historyByPlayer.getOrDefault(c.steamId(), List.of());
+            final List<Guess> recent = history.stream()
+                    .filter(g -> !g.getGameDate().isBefore(windowStart) && !g.getGameDate().isAfter(today))
+                    .toList();
             if (recent.size() < MIN_RECENT_ROUNDS_FOR_HOT_STREAK) continue;
 
             final double allTimeAvg = c.allTime().getAvgPoints() != null ? c.allTime().getAvgPoints() : 0.0;

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -51,6 +51,10 @@ public class PlayerSpotlightService {
     private static final int BEAT_THE_ODDS_MIN_POINTS = 4;
     private static final int WELCOME_BACK_MIN_GAP_DAYS = 4;
     private static final double WELCOME_BACK_MIN_RETURN_DAY_AVG = 3.0;
+    private static final int MOST_IMPROVED_WINDOW_DAYS = 30;
+    private static final int MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW = 10;
+    private static final double MOST_IMPROVED_RELATIVE_THRESHOLD = 1.15;
+    private static final double MOST_IMPROVED_ABSOLUTE_DELTA = 0.3;
     private static final int HOT_STREAK_WINDOW_DAYS = 14;
     private static final int MIN_RECENT_ROUNDS_FOR_HOT_STREAK = 5;
     private static final double HOT_STREAK_RELATIVE_THRESHOLD = 1.2; // recent avg must be >= 20% above all-time avg
@@ -116,6 +120,7 @@ public class PlayerSpotlightService {
         addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.BEAT_THE_ODDS, evaluateBeatTheOddsTier(eligible, yesterday));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.WELCOME_BACK, evaluateWelcomeBackTier(eligible));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.MOST_IMPROVED, evaluateMostImprovedTier(eligible, today));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
 
         if (!qualifying.isEmpty()) {
@@ -266,6 +271,36 @@ public class PlayerSpotlightService {
                     gapDays, returnDayAvg);
             tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.WELCOME_BACK,
                     "Welcome back!", detail, "Days away", (double) gapDays));
+        }
+        return tier;
+    }
+
+    private List<Tiered> evaluateMostImprovedTier(final List<Candidate> eligible, final LocalDate today) {
+        final LocalDate last30Start = today.minusDays(MOST_IMPROVED_WINDOW_DAYS);
+        final LocalDate last30End = today.minusDays(1);
+        final LocalDate prior30Start = today.minusDays(2L * MOST_IMPROVED_WINDOW_DAYS);
+        final LocalDate prior30End = today.minusDays(MOST_IMPROVED_WINDOW_DAYS + 1L);
+
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final List<Guess> last30 = guessRepository.findBySteamIdBetween(c.steamId(), last30Start, last30End);
+            final List<Guess> prior30 = guessRepository.findBySteamIdBetween(c.steamId(), prior30Start, prior30End);
+            if (last30.size() < MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW
+                    || prior30.size() < MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW) {
+                continue;
+            }
+
+            final double last30Avg = last30.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            final double prior30Avg = prior30.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            final boolean qualifies = last30Avg >= prior30Avg * MOST_IMPROVED_RELATIVE_THRESHOLD
+                    && (last30Avg - prior30Avg) >= MOST_IMPROVED_ABSOLUTE_DELTA;
+            if (!qualifies) continue;
+
+            final String detail = String.format(
+                    "Leveled up: averaging %.1f pts/round over the last %d days, up from %.1f the month before.",
+                    last30Avg, MOST_IMPROVED_WINDOW_DAYS, prior30Avg);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.MOST_IMPROVED,
+                    "Most improved!", detail, "Last-30d avg", last30Avg));
         }
         return tier;
     }

--- a/backend/src/main/java/org/steam5/web/ProfileController.java
+++ b/backend/src/main/java/org/steam5/web/ProfileController.java
@@ -15,6 +15,7 @@ import org.steam5.domain.User;
 import org.steam5.repository.GuessRepository;
 import org.steam5.repository.UserRepository;
 import org.steam5.repository.SteamAppIndexRepository;
+import org.steam5.service.PlayerSpotlightService;
 import org.steam5.service.SeasonService;
 
 import java.time.LocalDate;
@@ -34,6 +35,7 @@ public class ProfileController {
     private final GuessRepository guessRepository;
     private final SteamAppIndexRepository appIndexRepository;
     private final SeasonService seasonService;
+    private final PlayerSpotlightService playerSpotlightService;
 
     @GetMapping("/{steamId}")
     public ResponseEntity<?> getProfile(@PathVariable("steamId") String steamId) {
@@ -109,6 +111,19 @@ public class ProfileController {
                         "placementLevel", result.getPlacementLevel(),
                         "metricValue", result.getMetricValue(),
                         "tiebreakRoll", result.getTiebreakRoll()
+                ))
+                .toList());
+
+        final List<PlayerSpotlightService.SpotlightHistoryEntry> spotlights =
+                playerSpotlightService.listSpotlightsForPlayer(steamId);
+        out.put("spotlights", spotlights.stream()
+                .map(s -> Map.of(
+                        "gameDate", s.gameDate().toString(),
+                        "insightType", s.insightType().name(),
+                        "headline", s.headline(),
+                        "detail", s.detail(),
+                        "statLabel", s.statLabel(),
+                        "statValue", s.statValue()
                 ))
                 .toList());
 

--- a/backend/src/main/java/org/steam5/web/StatisticsController.java
+++ b/backend/src/main/java/org/steam5/web/StatisticsController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.steam5.service.PlayerSpotlightService;
 import org.steam5.service.StatisticsService;
 
 import java.util.LinkedHashMap;
@@ -22,6 +23,7 @@ import java.util.Map;
 public class StatisticsController {
 
     private final StatisticsService statisticsService;
+    private final PlayerSpotlightService playerSpotlightService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, String>> indexJson() {
@@ -32,7 +34,17 @@ public class StatisticsController {
         links.put("reviewBuckets", "/api/stats/reviews/buckets");
         links.put("userAchievements", "/api/stats/users/achievements");
         links.put("gameStatistics", "/api/stats/game");
+        links.put("spotlight", "/api/stats/spotlight/today");
         return ResponseEntity.ok(links);
+    }
+
+    @GetMapping(value = "/spotlight/today", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<PlayerSpotlightService.SpotlightResponse> spotlightToday() {
+        return playerSpotlightService.getTodaySpotlight()
+                .map(spotlight -> ResponseEntity.ok()
+                        .header("Cache-Control", "public, s-maxage=3600, max-age=300")
+                        .body(spotlight))
+                .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     @GetMapping(value = "/genres", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -32,3 +32,5 @@ jobs:
     enabled: true
   seasons-backfill:
     enabled: true
+  player-spotlight:
+    enabled: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -117,4 +117,6 @@ jobs:
     enabled: ${JOB_SEASONS_FINALIZER:true}
   seasons-backfill:
     enabled: ${JOB_SEASONS_BACKFILL:false}
+  player-spotlight:
+    enabled: ${JOB_PLAYER_SPOTLIGHT:false}
 

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -372,6 +372,26 @@ class PlayerSpotlightServiceTest {
     }
 
     @Test
+    void fallsBackToWeeklyAchievementWhenNoCompetitiveTierQualifies() {
+        final GuessRepository.AllTimeStatsRow achiever = allTimeRow("achiever", 100, 2.0);
+        stubAllTimeStats(achiever);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("achiever", today, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        final StatisticsService.UserLabel label = new StatisticsService.UserLabel(
+                "achiever", StatisticsService.UserAchievement.SHARPSHOOTER, null, 4.2, null, null, null);
+        when(statisticsService.getUserAchievementsWeekly()).thenReturn(List.of(label));
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("achiever", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.WEEKLY_ACHIEVEMENT, captor.getValue().getInsightType());
+    }
+
+    @Test
     void milestoneTierUsesNiceNumberFramingWhenRoundsAreCloseToAMilestone() {
         final GuessRepository.AllTimeStatsRow almostCentury = mock(GuessRepository.AllTimeStatsRow.class);
         when(almostCentury.getSteamId()).thenReturn("almostCentury");
@@ -390,5 +410,29 @@ class PlayerSpotlightServiceTest {
         verify(playerSpotlightRepository).save(captor.capture());
         assertEquals(PlayerSpotlightInsightType.MILESTONE, captor.getValue().getInsightType());
         assertEquals("Closing in on 100 rounds — only 2 away!", captor.getValue().getDetail());
+    }
+
+    @Test
+    void milestoneTierUsesNiceNumberFramingWhenLifetimePointsAreCloseToAMilestone() {
+        // Rounds (150) sit far from any ROUND_MILESTONES entry, so this only passes
+        // if the lifetime-points branch (checked via .or(...) after the rounds check)
+        // is actually reached and correctly formatted.
+        final GuessRepository.AllTimeStatsRow almostThousandPoints = mock(GuessRepository.AllTimeStatsRow.class);
+        when(almostThousandPoints.getSteamId()).thenReturn("almostThousandPoints");
+        when(almostThousandPoints.getRounds()).thenReturn(150L);
+        when(almostThousandPoints.getAvgPoints()).thenReturn(2.0);
+        when(almostThousandPoints.getTotalPoints()).thenReturn(995L);
+        stubAllTimeStats(almostThousandPoints);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("almostThousandPoints", today, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today)))
+                .thenReturn(dates);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals(PlayerSpotlightInsightType.MILESTONE, captor.getValue().getInsightType());
+        assertEquals("Closing in on 1,000 lifetime points — only 5 away!", captor.getValue().getDetail());
     }
 }

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -14,7 +14,6 @@ import org.steam5.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,9 +43,9 @@ class PlayerSpotlightServiceTest {
         when(playerSpotlightRepository.existsById(any())).thenReturn(false);
         when(statisticsService.getUserAchievementsWeekly()).thenReturn(List.of());
         when(guessRepository.findBySteamIdBetween(anyString(), any(), any())).thenReturn(List.of());
-        when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(anyString())).thenReturn(List.of());
+        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(List.of());
         when(guessRepository.findRoundAvgScoresInRange(any(), any())).thenReturn(List.of());
-        when(guessRepository.findAllForDay(anyString(), any())).thenReturn(List.of());
+        when(guessRepository.findByGameDateAndRoundIndex(any(), anyInt())).thenReturn(List.of());
     }
 
     // NOTE: mocks referenced by an outer when(...).thenReturn(...) must be fully built
@@ -216,7 +215,7 @@ class PlayerSpotlightServiceTest {
                 guess("recordBreaker", yesterday.minusDays(5), 12),
                 guess("recordBreaker", yesterday, 24)
         );
-        when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc("recordBreaker")).thenReturn(history);
+        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(history);
 
         service.computeAndPersistForToday();
 
@@ -244,8 +243,7 @@ class PlayerSpotlightServiceTest {
 
         final Guess theirGuess = guess("oddsBeater", yesterday, 5);
         theirGuess.setRoundIndex(3);
-        when(guessRepository.findBySteamIdAndGameDateAndRoundIndex("oddsBeater", yesterday, 3))
-                .thenReturn(Optional.of(theirGuess));
+        when(guessRepository.findByGameDateAndRoundIndex(yesterday, 3)).thenReturn(List.of(theirGuess));
 
         service.computeAndPersistForToday();
 
@@ -268,7 +266,7 @@ class PlayerSpotlightServiceTest {
         dates.add(dateRow("returner", beforeGap));
         when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
 
-        when(guessRepository.findAllForDay("returner", mostRecent)).thenReturn(List.of(
+        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(List.of(
                 guess("returner", mostRecent, 4),
                 guess("returner", mostRecent, 3)
         ));
@@ -291,17 +289,12 @@ class PlayerSpotlightServiceTest {
                 .thenReturn(dates);
 
         final LocalDate last30Start = today.minusDays(30);
-        final LocalDate last30End = today.minusDays(1);
         final LocalDate prior30Start = today.minusDays(60);
-        final LocalDate prior30End = today.minusDays(31);
 
-        final List<Guess> last30 = new ArrayList<>();
-        for (int i = 0; i < 15; i++) last30.add(guess("improver", last30Start.plusDays(i), 4));
-        final List<Guess> prior30 = new ArrayList<>();
-        for (int i = 0; i < 15; i++) prior30.add(guess("improver", prior30Start.plusDays(i), 2));
-
-        when(guessRepository.findBySteamIdBetween("improver", last30Start, last30End)).thenReturn(last30);
-        when(guessRepository.findBySteamIdBetween("improver", prior30Start, prior30End)).thenReturn(prior30);
+        final List<Guess> history = new ArrayList<>();
+        for (int i = 0; i < 15; i++) history.add(guess("improver", last30Start.plusDays(i), 4));
+        for (int i = 0; i < 15; i++) history.add(guess("improver", prior30Start.plusDays(i), 2));
+        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(history);
 
         service.computeAndPersistForToday();
 
@@ -331,27 +324,23 @@ class PlayerSpotlightServiceTest {
         when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(allDates);
 
         final LocalDate last30Start = today.minusDays(30);
-        final LocalDate last30End = today.minusDays(1);
         final LocalDate prior30Start = today.minusDays(60);
-        final LocalDate prior30End = today.minusDays(31);
 
-        final List<Guess> last30 = new ArrayList<>();
-        for (int i = 0; i < 15; i++) last30.add(guess("improver", last30Start.plusDays(i), 4));
-        final List<Guess> prior30 = new ArrayList<>();
-        for (int i = 0; i < 15; i++) prior30.add(guess("improver", prior30Start.plusDays(i), 2));
-
-        when(guessRepository.findBySteamIdBetween("improver", last30Start, last30End)).thenReturn(last30);
-        when(guessRepository.findBySteamIdBetween("improver", prior30Start, prior30End)).thenReturn(prior30);
+        final List<Guess> history = new ArrayList<>();
+        for (int i = 0; i < 15; i++) history.add(guess("improver", last30Start.plusDays(i), 4));
+        for (int i = 0; i < 15; i++) history.add(guess("improver", prior30Start.plusDays(i), 2));
+        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(history);
 
         // Neither candidate spuriously qualifies for the other's tier or for
         // BEST_DAY_EVER / BEAT_THE_ODDS / WELCOME_BACK / HOT_STREAK:
-        // - "streaker" has only 1 all-time-window guess stubbed (the setUp() default
-        //   empty list for findBySteamIdBetween), so it never clears the
-        //   MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW/HOT_STREAK round-count floors.
+        // - "streaker" has no entries in the stubbed findBySteamIdIn(...) result (only
+        //   "improver" does), so historyByPlayer.getOrDefault("streaker", ...) is always
+        //   empty — it never clears any tier's round-count floor.
         // - "improver" has only a single date in datesDesc, so its current streak is
-        //   1 (< MIN_DAY_STREAK) and it has no second date for WELCOME_BACK's gap check.
-        // - BEST_DAY_EVER and BEAT_THE_ODDS rely on findBySteamIdOrderByGameDateDescRoundIndexAsc
-        //   / findRoundAvgScoresInRange, both left at setUp()'s default empty-list stubs.
+        //   1 (< MIN_DAY_STREAK) and it has no second date for WELCOME_BACK's gap check;
+        //   its stubbed history also falls entirely outside HOT_STREAK's 14-day window.
+        // - BEAT_THE_ODDS relies on findRoundAvgScoresInRange, left at setUp()'s default
+        //   empty-list stub.
         service.computeAndPersistForToday();
 
         final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -46,6 +46,7 @@ class PlayerSpotlightServiceTest {
         when(guessRepository.findBySteamIdBetween(anyString(), any(), any())).thenReturn(List.of());
         when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(anyString())).thenReturn(List.of());
         when(guessRepository.findRoundAvgScoresInRange(any(), any())).thenReturn(List.of());
+        when(guessRepository.findAllForDay(anyString(), any())).thenReturn(List.of());
     }
 
     // NOTE: mocks referenced by an outer when(...).thenReturn(...) must be fully built
@@ -252,5 +253,31 @@ class PlayerSpotlightServiceTest {
         verify(playerSpotlightRepository).save(captor.capture());
         assertEquals("oddsBeater", captor.getValue().getSteamId());
         assertEquals(PlayerSpotlightInsightType.BEAT_THE_ODDS, captor.getValue().getInsightType());
+    }
+
+    @Test
+    void welcomeBackTierWinsWhenCandidateReturnedAfterAGapAndPlayedWell() {
+        final LocalDate mostRecent = today.minusDays(1);
+        final LocalDate beforeGap = mostRecent.minusDays(6); // gap of 6 days, >= the 4-day threshold
+
+        final GuessRepository.AllTimeStatsRow returner = allTimeRow("returner", 100, 2.0);
+        stubAllTimeStats(returner);
+
+        final List<GuessRepository.UserDateRow> dates = new ArrayList<>();
+        dates.add(dateRow("returner", mostRecent));
+        dates.add(dateRow("returner", beforeGap));
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        when(guessRepository.findAllForDay("returner", mostRecent)).thenReturn(List.of(
+                guess("returner", mostRecent, 4),
+                guess("returner", mostRecent, 3)
+        ));
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("returner", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.WELCOME_BACK, captor.getValue().getInsightType());
     }
 }

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.steam5.domain.GameDate;
+import org.steam5.domain.Guess;
 import org.steam5.domain.PlayerSpotlight;
 import org.steam5.domain.PlayerSpotlightInsightType;
 import org.steam5.repository.GuessRepository;
@@ -42,6 +43,7 @@ class PlayerSpotlightServiceTest {
         when(playerSpotlightRepository.existsById(any())).thenReturn(false);
         when(statisticsService.getUserAchievementsWeekly()).thenReturn(List.of());
         when(guessRepository.findBySteamIdBetween(anyString(), any(), any())).thenReturn(List.of());
+        when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(anyString())).thenReturn(List.of());
     }
 
     // NOTE: mocks referenced by an outer when(...).thenReturn(...) must be fully built
@@ -69,6 +71,14 @@ class PlayerSpotlightServiceTest {
             rows.add(dateRow(steamId, lastDate.minusDays(i)));
         }
         return rows;
+    }
+
+    private Guess guess(String steamId, LocalDate date, int points) {
+        final Guess g = new Guess();
+        g.setSteamId(steamId);
+        g.setGameDate(date);
+        g.setPoints(points);
+        return g;
     }
 
     private void stubAllTimeStats(GuessRepository.AllTimeStatsRow... rows) {
@@ -187,5 +197,29 @@ class PlayerSpotlightServiceTest {
         final List<String> sorted = List.of("playerA", "playerB").stream().sorted().toList();
         final int expectedIndex = new Random(today.toEpochDay()).nextInt(sorted.size());
         assertEquals(sorted.get(expectedIndex), picked);
+    }
+
+    @Test
+    void bestDayEverTierWinsWhenYesterdayIsANewPersonalRecord() {
+        final LocalDate yesterday = today.minusDays(1);
+        final GuessRepository.AllTimeStatsRow recordBreaker = allTimeRow("recordBreaker", 100, 2.0);
+        stubAllTimeStats(recordBreaker);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("recordBreaker", yesterday, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        final List<Guess> history = List.of(
+                guess("recordBreaker", yesterday.minusDays(10), 8),
+                guess("recordBreaker", yesterday.minusDays(5), 12),
+                guess("recordBreaker", yesterday, 24)
+        );
+        when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc("recordBreaker")).thenReturn(history);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("recordBreaker", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.BEST_DAY_EVER, captor.getValue().getInsightType());
     }
 }

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -14,6 +14,7 @@ import org.steam5.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,6 +45,7 @@ class PlayerSpotlightServiceTest {
         when(statisticsService.getUserAchievementsWeekly()).thenReturn(List.of());
         when(guessRepository.findBySteamIdBetween(anyString(), any(), any())).thenReturn(List.of());
         when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(anyString())).thenReturn(List.of());
+        when(guessRepository.findRoundAvgScoresInRange(any(), any())).thenReturn(List.of());
     }
 
     // NOTE: mocks referenced by an outer when(...).thenReturn(...) must be fully built
@@ -221,5 +223,34 @@ class PlayerSpotlightServiceTest {
         verify(playerSpotlightRepository).save(captor.capture());
         assertEquals("recordBreaker", captor.getValue().getSteamId());
         assertEquals(PlayerSpotlightInsightType.BEST_DAY_EVER, captor.getValue().getInsightType());
+    }
+
+    @Test
+    void beatTheOddsTierWinsWhenCandidateAcedTheHardestRoundOfTheDay() {
+        final LocalDate yesterday = today.minusDays(1);
+        final GuessRepository.AllTimeStatsRow oddsBeater = allTimeRow("oddsBeater", 100, 2.0);
+        stubAllTimeStats(oddsBeater);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("oddsBeater", yesterday, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        final GuessRepository.RoundAvgScoreRow hardRound = mock(GuessRepository.RoundAvgScoreRow.class);
+        when(hardRound.getGameDate()).thenReturn(yesterday);
+        when(hardRound.getRoundIndex()).thenReturn(3);
+        when(hardRound.getAvgScore()).thenReturn(1.2);
+        when(hardRound.getPlayerCount()).thenReturn(20L);
+        when(guessRepository.findRoundAvgScoresInRange(yesterday, yesterday)).thenReturn(List.of(hardRound));
+
+        final Guess theirGuess = guess("oddsBeater", yesterday, 5);
+        theirGuess.setRoundIndex(3);
+        when(guessRepository.findBySteamIdAndGameDateAndRoundIndex("oddsBeater", yesterday, 3))
+                .thenReturn(Optional.of(theirGuess));
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("oddsBeater", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.BEAT_THE_ODDS, captor.getValue().getInsightType());
     }
 }

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -372,6 +372,31 @@ class PlayerSpotlightServiceTest {
     }
 
     @Test
+    void listSpotlightsForPlayerMapsPersistedEntitiesToHistoryEntries() {
+        final PlayerSpotlight yesterday = new PlayerSpotlight();
+        yesterday.setGameDate(today.minusDays(1));
+        yesterday.setSteamId("historyPlayer");
+        yesterday.setInsightType(PlayerSpotlightInsightType.HOT_STREAK);
+        yesterday.setHeadline("In red-hot form!");
+        yesterday.setDetail("Averaging 4.0 pts/round over the last 14 days — well above their usual 2.0.");
+        yesterday.setStatLabel("Recent avg");
+        yesterday.setStatValue(4.0);
+
+        when(playerSpotlightRepository.findTop10BySteamIdOrderByGameDateDesc("historyPlayer"))
+                .thenReturn(List.of(yesterday));
+
+        final List<PlayerSpotlightService.SpotlightHistoryEntry> history =
+                service.listSpotlightsForPlayer("historyPlayer");
+
+        assertEquals(1, history.size());
+        final PlayerSpotlightService.SpotlightHistoryEntry entry = history.get(0);
+        assertEquals(today.minusDays(1), entry.gameDate());
+        assertEquals(PlayerSpotlightInsightType.HOT_STREAK, entry.insightType());
+        assertEquals("In red-hot form!", entry.headline());
+        assertEquals(4.0, entry.statValue());
+    }
+
+    @Test
     void fallsBackToWeeklyAchievementWhenNoCompetitiveTierQualifies() {
         final GuessRepository.AllTimeStatsRow achiever = allTimeRow("achiever", 100, 2.0);
         stubAllTimeStats(achiever);

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -312,6 +312,66 @@ class PlayerSpotlightServiceTest {
     }
 
     @Test
+    void lotteryPicksAmongMultipleQualifyingCompetitiveTiers() {
+        // Two candidates, each qualifying for a *different* competitive tier at the
+        // same time: "streaker" qualifies for DAY_STREAK (reusing the fixture from
+        // dayStreakTierOutranksMilestoneFallback) and "improver" qualifies for
+        // MOST_IMPROVED (reusing the fixture from
+        // mostImprovedTierWinsWhenRecentFormIsClearlyBetterThanBefore). This is the
+        // first test in the suite where qualifying.size() > 1, so it's the first to
+        // actually exercise the random draw in compute() rather than the
+        // single-candidate short-circuit every other tier test relies on.
+        final GuessRepository.AllTimeStatsRow streaker = allTimeRow("streaker", 100, 2.0);
+        final GuessRepository.AllTimeStatsRow improver = allTimeRow("improver", 100, 2.0);
+        stubAllTimeStats(streaker, improver);
+
+        final List<GuessRepository.UserDateRow> allDates = new ArrayList<>();
+        allDates.addAll(consecutiveDaysEnding("streaker", today, 6)); // active 6-day streak, >= MIN_DAY_STREAK
+        allDates.addAll(consecutiveDaysEnding("improver", today, 1)); // only played today — too short for DAY_STREAK
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(allDates);
+
+        final LocalDate last30Start = today.minusDays(30);
+        final LocalDate last30End = today.minusDays(1);
+        final LocalDate prior30Start = today.minusDays(60);
+        final LocalDate prior30End = today.minusDays(31);
+
+        final List<Guess> last30 = new ArrayList<>();
+        for (int i = 0; i < 15; i++) last30.add(guess("improver", last30Start.plusDays(i), 4));
+        final List<Guess> prior30 = new ArrayList<>();
+        for (int i = 0; i < 15; i++) prior30.add(guess("improver", prior30Start.plusDays(i), 2));
+
+        when(guessRepository.findBySteamIdBetween("improver", last30Start, last30End)).thenReturn(last30);
+        when(guessRepository.findBySteamIdBetween("improver", prior30Start, prior30End)).thenReturn(prior30);
+
+        // Neither candidate spuriously qualifies for the other's tier or for
+        // BEST_DAY_EVER / BEAT_THE_ODDS / WELCOME_BACK / HOT_STREAK:
+        // - "streaker" has only 1 all-time-window guess stubbed (the setUp() default
+        //   empty list for findBySteamIdBetween), so it never clears the
+        //   MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW/HOT_STREAK round-count floors.
+        // - "improver" has only a single date in datesDesc, so its current streak is
+        //   1 (< MIN_DAY_STREAK) and it has no second date for WELCOME_BACK's gap check.
+        // - BEST_DAY_EVER and BEAT_THE_ODDS rely on findBySteamIdOrderByGameDateDescRoundIndexAsc
+        //   / findRoundAvgScoresInRange, both left at setUp()'s default empty-list stubs.
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+
+        // Independently reproduce the documented lottery: qualifying tiers are collected
+        // in compute()'s fixed evaluation order (DAY_STREAK before MOST_IMPROVED here),
+        // then one is drawn via new Random(today.toEpochDay()).nextInt(qualifying.size()).
+        final List<PlayerSpotlightInsightType> qualifyingInOrder =
+                List.of(PlayerSpotlightInsightType.DAY_STREAK, PlayerSpotlightInsightType.MOST_IMPROVED);
+        final int expectedIndex = new Random(today.toEpochDay()).nextInt(qualifyingInOrder.size());
+        final PlayerSpotlightInsightType expectedType = qualifyingInOrder.get(expectedIndex);
+        final String expectedSteamId =
+                expectedType == PlayerSpotlightInsightType.DAY_STREAK ? "streaker" : "improver";
+
+        assertEquals(expectedType, captor.getValue().getInsightType());
+        assertEquals(expectedSteamId, captor.getValue().getSteamId());
+    }
+
+    @Test
     void milestoneTierUsesNiceNumberFramingWhenRoundsAreCloseToAMilestone() {
         final GuessRepository.AllTimeStatsRow almostCentury = mock(GuessRepository.AllTimeStatsRow.class);
         when(almostCentury.getSteamId()).thenReturn("almostCentury");

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -280,4 +280,34 @@ class PlayerSpotlightServiceTest {
         assertEquals("returner", captor.getValue().getSteamId());
         assertEquals(PlayerSpotlightInsightType.WELCOME_BACK, captor.getValue().getInsightType());
     }
+
+    @Test
+    void mostImprovedTierWinsWhenRecentFormIsClearlyBetterThanBefore() {
+        final GuessRepository.AllTimeStatsRow improver = allTimeRow("improver", 100, 2.0);
+        stubAllTimeStats(improver);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("improver", today, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today)))
+                .thenReturn(dates);
+
+        final LocalDate last30Start = today.minusDays(30);
+        final LocalDate last30End = today.minusDays(1);
+        final LocalDate prior30Start = today.minusDays(60);
+        final LocalDate prior30End = today.minusDays(31);
+
+        final List<Guess> last30 = new ArrayList<>();
+        for (int i = 0; i < 15; i++) last30.add(guess("improver", last30Start.plusDays(i), 4));
+        final List<Guess> prior30 = new ArrayList<>();
+        for (int i = 0; i < 15; i++) prior30.add(guess("improver", prior30Start.plusDays(i), 2));
+
+        when(guessRepository.findBySteamIdBetween("improver", last30Start, last30End)).thenReturn(last30);
+        when(guessRepository.findBySteamIdBetween("improver", prior30Start, prior30End)).thenReturn(prior30);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("improver", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.MOST_IMPROVED, captor.getValue().getInsightType());
+    }
 }

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -1,0 +1,191 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.steam5.domain.GameDate;
+import org.steam5.domain.PlayerSpotlight;
+import org.steam5.domain.PlayerSpotlightInsightType;
+import org.steam5.repository.GuessRepository;
+import org.steam5.repository.PlayerSpotlightRepository;
+import org.steam5.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class PlayerSpotlightServiceTest {
+
+    private GuessRepository guessRepository;
+    private UserRepository userRepository;
+    private StatisticsService statisticsService;
+    private PlayerSpotlightRepository playerSpotlightRepository;
+    private PlayerSpotlightService service;
+
+    private final LocalDate today = GameDate.todayUtc();
+
+    @BeforeEach
+    void setUp() {
+        guessRepository = mock(GuessRepository.class);
+        userRepository = mock(UserRepository.class);
+        statisticsService = mock(StatisticsService.class);
+        playerSpotlightRepository = mock(PlayerSpotlightRepository.class);
+
+        service = new PlayerSpotlightService(guessRepository, userRepository, statisticsService, playerSpotlightRepository);
+
+        // Safe defaults so tiers below the one under test don't NPE on unstubbed mocks.
+        when(playerSpotlightRepository.existsById(any())).thenReturn(false);
+        when(statisticsService.getUserAchievementsWeekly()).thenReturn(List.of());
+        when(guessRepository.findBySteamIdBetween(anyString(), any(), any())).thenReturn(List.of());
+    }
+
+    // NOTE: mocks referenced by an outer when(...).thenReturn(...) must be fully built
+    // *before* that call — building them inline as constructor/method arguments corrupts
+    // Mockito's ongoing-stubbing state (the outer when()'s target gets lost).
+    private GuessRepository.AllTimeStatsRow allTimeRow(String steamId, long rounds, double avgPoints) {
+        final GuessRepository.AllTimeStatsRow row = mock(GuessRepository.AllTimeStatsRow.class);
+        when(row.getSteamId()).thenReturn(steamId);
+        when(row.getRounds()).thenReturn(rounds);
+        when(row.getAvgPoints()).thenReturn(avgPoints);
+        return row;
+    }
+
+    private GuessRepository.UserDateRow dateRow(String steamId, LocalDate date) {
+        final GuessRepository.UserDateRow row = mock(GuessRepository.UserDateRow.class);
+        when(row.getSteamId()).thenReturn(steamId);
+        when(row.getGameDate()).thenReturn(date);
+        return row;
+    }
+
+    /** dates descending, most recent first — matches findDistinctDatesUpToForUsers ordering. */
+    private List<GuessRepository.UserDateRow> consecutiveDaysEnding(String steamId, LocalDate lastDate, int count) {
+        final List<GuessRepository.UserDateRow> rows = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            rows.add(dateRow(steamId, lastDate.minusDays(i)));
+        }
+        return rows;
+    }
+
+    private void stubAllTimeStats(GuessRepository.AllTimeStatsRow... rows) {
+        when(guessRepository.aggregateAllTimeStats()).thenReturn(List.of(rows));
+    }
+
+    @Test
+    void excludesPlayersBelowRoundThreshold() {
+        final GuessRepository.AllTimeStatsRow belowThreshold = allTimeRow("belowThreshold", 60, 2.0);
+        final GuessRepository.AllTimeStatsRow eligible = allTimeRow("eligible", 100, 2.0);
+        stubAllTimeStats(belowThreshold, eligible);
+
+        final List<GuessRepository.UserDateRow> allDates = new ArrayList<>();
+        allDates.addAll(consecutiveDaysEnding("belowThreshold", today, 1));
+        allDates.addAll(consecutiveDaysEnding("eligible", today, 1));
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(allDates);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("eligible", captor.getValue().getSteamId());
+    }
+
+    @Test
+    void excludesPlayersNotActiveInLastTwoWeeks() {
+        final GuessRepository.AllTimeStatsRow stale = allTimeRow("stale", 200, 2.0);
+        final GuessRepository.AllTimeStatsRow active = allTimeRow("active", 100, 2.0);
+        stubAllTimeStats(stale, active);
+
+        final List<GuessRepository.UserDateRow> allDates = new ArrayList<>();
+        allDates.addAll(consecutiveDaysEnding("stale", today.minusDays(20), 1)); // last played 20 days ago
+        allDates.addAll(consecutiveDaysEnding("active", today, 1));
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(allDates);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("active", captor.getValue().getSteamId());
+    }
+
+    @Test
+    void dayStreakTierOutranksMilestoneFallback() {
+        final GuessRepository.AllTimeStatsRow streaker = allTimeRow("streaker", 100, 2.0);
+        final GuessRepository.AllTimeStatsRow oneAndDone = allTimeRow("oneAndDone", 100, 2.0);
+        stubAllTimeStats(streaker, oneAndDone);
+
+        final List<GuessRepository.UserDateRow> allDates = new ArrayList<>();
+        allDates.addAll(consecutiveDaysEnding("streaker", today, 6)); // active 6-day streak, >= MIN_DAY_STREAK
+        allDates.addAll(consecutiveDaysEnding("oneAndDone", today, 1)); // only played today — milestone tier only
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(allDates);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("streaker", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.DAY_STREAK, captor.getValue().getInsightType());
+    }
+
+    @Test
+    void fallsBackToMilestoneWhenNoOneHasANotableStory() {
+        final GuessRepository.AllTimeStatsRow onlySteadyPlayer = allTimeRow("onlySteadyPlayer", 90, 2.5);
+        stubAllTimeStats(onlySteadyPlayer);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("onlySteadyPlayer", today, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("onlySteadyPlayer", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.MILESTONE, captor.getValue().getInsightType());
+    }
+
+    @Test
+    void doesNothingWhenNoOneIsEligible() {
+        final GuessRepository.AllTimeStatsRow tooFewRounds = allTimeRow("tooFewRounds", 10, 2.0);
+        stubAllTimeStats(tooFewRounds);
+
+        service.computeAndPersistForToday();
+
+        verify(playerSpotlightRepository, never()).save(any());
+    }
+
+    @Test
+    void skipsRecomputeWhenAlreadyPersistedForToday() {
+        when(playerSpotlightRepository.existsById(today)).thenReturn(true);
+
+        service.computeAndPersistForToday();
+
+        verify(guessRepository, never()).aggregateAllTimeStats();
+        verify(playerSpotlightRepository, never()).save(any());
+    }
+
+    @Test
+    void tieBreakAmongEqualTierCandidatesIsDeterministicForTheDay() {
+        final GuessRepository.AllTimeStatsRow playerA = allTimeRow("playerA", 90, 2.0);
+        final GuessRepository.AllTimeStatsRow playerB = allTimeRow("playerB", 90, 2.0);
+        stubAllTimeStats(playerA, playerB);
+
+        final List<GuessRepository.UserDateRow> allDates = new ArrayList<>();
+        allDates.addAll(consecutiveDaysEnding("playerA", today, 1));
+        allDates.addAll(consecutiveDaysEnding("playerB", today, 1));
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(allDates);
+
+        service.computeAndPersistForToday();
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        final String picked = captor.getValue().getSteamId();
+
+        // Both candidates are tied in the MILESTONE tier — the winner must match the
+        // documented tie-break: sort by steamId, then a Random seeded by the epoch day.
+        final List<String> sorted = List.of("playerA", "playerB").stream().sorted().toList();
+        final int expectedIndex = new Random(today.toEpochDay()).nextInt(sorted.size());
+        assertEquals(sorted.get(expectedIndex), picked);
+    }
+}

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -310,4 +310,25 @@ class PlayerSpotlightServiceTest {
         assertEquals("improver", captor.getValue().getSteamId());
         assertEquals(PlayerSpotlightInsightType.MOST_IMPROVED, captor.getValue().getInsightType());
     }
+
+    @Test
+    void milestoneTierUsesNiceNumberFramingWhenRoundsAreCloseToAMilestone() {
+        final GuessRepository.AllTimeStatsRow almostCentury = mock(GuessRepository.AllTimeStatsRow.class);
+        when(almostCentury.getSteamId()).thenReturn("almostCentury");
+        when(almostCentury.getRounds()).thenReturn(98L);
+        when(almostCentury.getAvgPoints()).thenReturn(2.0);
+        when(almostCentury.getTotalPoints()).thenReturn(400L);
+        stubAllTimeStats(almostCentury);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("almostCentury", today, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today)))
+                .thenReturn(dates);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals(PlayerSpotlightInsightType.MILESTONE, captor.getValue().getInsightType());
+        assertEquals("Closing in on 100 rounds — only 2 away!", captor.getValue().getDetail());
+    }
 }

--- a/docs/superpowers/plans/2026-07-02-spotlight-insights.md
+++ b/docs/superpowers/plans/2026-07-02-spotlight-insights.md
@@ -1,0 +1,1106 @@
+# Player Spotlight: Expanded Insights Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four new Player Spotlight insight tiers (`BEST_DAY_EVER`, `BEAT_THE_ODDS`, `WELCOME_BACK`, `MOST_IMPROVED`) and replace the current strict priority ladder with a lottery among the "competitive" tiers so the ambient `DAY_STREAK` tier stops dominating the daily pick.
+
+**Architecture:** `PlayerSpotlightService.compute()` gathers every tier in a fixed "competitive pool" that has ≥1 qualifying candidate that day, then draws one tier uniformly at random (date-seeded) before picking a candidate within it (existing tie-break, same `Random` instance). If no competitive tier qualifies, it falls through to the existing `WEEKLY_ACHIEVEMENT` then `MILESTONE` fallbacks, unchanged. All new tiers reuse existing `GuessRepository` queries — no schema changes.
+
+**Tech Stack:** Spring Boot / Java 21 backend (Gradle), JUnit 5 + Mockito for tests, Next.js/TypeScript frontend.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-02-spotlight-insights-design.md` — read it before starting if anything below is ambiguous.
+- Competitive pool, in the fixed evaluation order used for the lottery's deterministic tier list: `DAY_STREAK`, `BEST_DAY_EVER`, `BEAT_THE_ODDS`, `WELCOME_BACK`, `MOST_IMPROVED`, `HOT_STREAK`.
+- Fallbacks below the pool, unchanged order: `WEEKLY_ACHIEVEMENT`, then `MILESTONE`.
+- Lottery mechanism: build the list of qualifying tiers in the fixed order above; if non-empty, `final Random random = new Random(today.toEpochDay());` then `random.nextInt(qualifying.size())` picks the tier, and the **same** `random` instance is then passed into `pickOne(...)` to pick the candidate. `WEEKLY_ACHIEVEMENT`/`MILESTONE` each get their own fresh `new Random(today.toEpochDay())` when used (matches current behavior — they're not part of the lottery).
+- "Yesterday"-based tiers use `today.minusDays(1)`, never `today` — the nightly job runs at 00:15 UTC, before any of today's rounds exist.
+- Thresholds (exact values, from the spec):
+  - `BEST_DAY_EVER`: yesterday's point total > every prior day's total; requires ≥2 prior days played.
+  - `BEAT_THE_ODDS`: yesterday's hardest round (lowest avg score across all players, min 5 players, from `findRoundAvgScoresInRange`) must have avg score < 2.0; candidate qualifies if their own points on that round were ≥4.
+  - `WELCOME_BACK`: gap between the two most recent distinct play-dates ≥4 days; average points on the return day ≥3.0.
+  - `MOST_IMPROVED`: last-30-day avg ≥15% relatively higher AND ≥0.3 points higher than the prior-30-day avg (days 31–60 back); requires ≥10 rounds in each window.
+  - `MILESTONE` text polish: round-count milestones `{100, 250, 500, 1000}`, lifetime-point milestones `{1000, 5000, 10000}`, "close enough" window = within 5.
+- **Mockito trap (applies to every test step in this plan):** never build a mock (or call `when(...)` on one) as an inline argument to another pending `when(...).thenReturn(...)` call — it corrupts Mockito's ongoing-stubbing state and throws `UnfinishedStubbingException`. Always assign mocks to a local variable first, complete their stubbing, and only then pass the variable into an outer `when(...).thenReturn(...)`.
+- Test command: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest"` for the fast loop, `sh gradlew test` for full regression.
+
+---
+
+### Task 1: Refactor selection to a lottery (no new tiers yet)
+
+**Files:**
+- Modify: `backend/src/main/java/org/steam5/service/PlayerSpotlightService.java`
+
+**Interfaces:**
+- Produces: `pickOne(List<Tiered> tier, Random random)` (signature change from `pickOne(List<Tiered> tier, LocalDate today)`) — later tasks call this with an externally-supplied `Random`.
+- Produces: `private record QualifyingTier(PlayerSpotlightInsightType type, List<Tiered> candidates)` and `private void addIfQualifying(List<QualifyingTier> qualifying, PlayerSpotlightInsightType type, List<Tiered> candidates)` — later tasks call `addIfQualifying` once per new tier.
+- Consumes: nothing new; `evaluateDayStreakTier`, `evaluateHotStreakTier`, `evaluateWeeklyAchievementTier`, `evaluateMilestoneTier` keep their current signatures for this task.
+
+This task only changes *how* the existing three real tiers (`DAY_STREAK`, `HOT_STREAK`, `WEEKLY_ACHIEVEMENT`) and the `MILESTONE` fallback are wired together. No new insight types yet — this isolates the riskiest structural change so it can be verified against the full existing test suite before adding new tiers on top.
+
+- [ ] **Step 1: Replace `pickOne` to accept an external `Random`**
+
+Find this method in `PlayerSpotlightService.java`:
+
+```java
+    /** Stable-for-the-day, rotating-by-date pick among candidates tied in the same tier. */
+    private Tiered pickOne(final List<Tiered> tier, final LocalDate today) {
+        final List<Tiered> sorted = tier.stream()
+                .sorted(Comparator.comparing(Tiered::steamId))
+                .toList();
+        final Random random = new Random(today.toEpochDay());
+        return sorted.get(random.nextInt(sorted.size()));
+    }
+```
+
+Replace it with:
+
+```java
+    /** Stable-for-the-day pick among candidates tied in the same tier, using the caller's Random. */
+    private Tiered pickOne(final List<Tiered> tier, final Random random) {
+        final List<Tiered> sorted = tier.stream()
+                .sorted(Comparator.comparing(Tiered::steamId))
+                .toList();
+        return sorted.get(random.nextInt(sorted.size()));
+    }
+```
+
+- [ ] **Step 2: Replace `compute()` with the lottery-driven version**
+
+Find this method:
+
+```java
+    private Optional<PlayerSpotlight> compute(final LocalDate today) {
+        final List<Candidate> eligible = findEligibleCandidates(today);
+        if (eligible.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final List<Tiered> dayStreakTier = evaluateDayStreakTier(eligible, today);
+        if (!dayStreakTier.isEmpty()) {
+            return Optional.of(toEntity(today, pickOne(dayStreakTier, today)));
+        }
+
+        final List<Tiered> achievementTier = evaluateWeeklyAchievementTier(eligible);
+        if (!achievementTier.isEmpty()) {
+            return Optional.of(toEntity(today, pickOne(achievementTier, today)));
+        }
+
+        final List<Tiered> hotStreakTier = evaluateHotStreakTier(eligible, today);
+        if (!hotStreakTier.isEmpty()) {
+            return Optional.of(toEntity(today, pickOne(hotStreakTier, today)));
+        }
+
+        // Guaranteed fallback: always show someone among the eligible pool.
+        final List<Tiered> milestoneTier = evaluateMilestoneTier(eligible);
+        return Optional.of(toEntity(today, pickOne(milestoneTier, today)));
+    }
+```
+
+Replace it with:
+
+```java
+    private Optional<PlayerSpotlight> compute(final LocalDate today) {
+        final List<Candidate> eligible = findEligibleCandidates(today);
+        if (eligible.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // "Competitive pool": every tier here that has >=1 qualifying candidate goes
+        // into a lottery, so no single ambient tier (e.g. DAY_STREAK) can dominate
+        // just because it's the easiest to qualify for on any given day.
+        final List<QualifyingTier> qualifying = new ArrayList<>();
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
+
+        if (!qualifying.isEmpty()) {
+            final Random random = new Random(today.toEpochDay());
+            final QualifyingTier chosen = qualifying.get(random.nextInt(qualifying.size()));
+            return Optional.of(toEntity(today, pickOne(chosen.candidates(), random)));
+        }
+
+        final List<Tiered> achievementTier = evaluateWeeklyAchievementTier(eligible);
+        if (!achievementTier.isEmpty()) {
+            return Optional.of(toEntity(today, pickOne(achievementTier, new Random(today.toEpochDay()))));
+        }
+
+        // Guaranteed fallback: always show someone among the eligible pool.
+        final List<Tiered> milestoneTier = evaluateMilestoneTier(eligible);
+        return Optional.of(toEntity(today, pickOne(milestoneTier, new Random(today.toEpochDay()))));
+    }
+
+    private void addIfQualifying(final List<QualifyingTier> qualifying, final PlayerSpotlightInsightType type,
+                                  final List<Tiered> candidates) {
+        if (!candidates.isEmpty()) {
+            qualifying.add(new QualifyingTier(type, candidates));
+        }
+    }
+```
+
+- [ ] **Step 3: Add the `QualifyingTier` record**
+
+Find the `Tiered` record near the bottom of the file:
+
+```java
+    private record Tiered(String steamId, PlayerSpotlightInsightType insightType, String headline, String detail,
+                           String statLabel, Double statValue) {
+    }
+```
+
+Add this new record directly after it:
+
+```java
+
+    private record QualifyingTier(PlayerSpotlightInsightType type, List<Tiered> candidates) {
+    }
+```
+
+- [ ] **Step 4: Run the existing test suite to confirm no regression**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest"`
+Expected: `BUILD SUCCESSFUL`, all 7 existing tests pass unchanged. (They pass because in every existing test's fixture, at most one of `DAY_STREAK`/`HOT_STREAK` ever qualifies for a given eligible pool, so the lottery has ≤1 entry and picks it deterministically — see the spec's "Edge cases" section.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+git commit -m "$(cat <<'EOF'
+refactor(spotlight): switch competitive tiers to a date-seeded lottery
+
+DAY_STREAK sat at priority #1 and qualified for any player on an active
+streak, so it would win on most days since regulars tend to maintain
+one. Competitive tiers now go into a lottery instead of a strict
+ladder; WEEKLY_ACHIEVEMENT and MILESTONE remain sequential fallbacks
+below it, unchanged. No new tiers yet — mechanical refactor only.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add the `BEST_DAY_EVER` tier
+
+**Files:**
+- Modify: `backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java`
+- Modify: `backend/src/main/java/org/steam5/service/PlayerSpotlightService.java`
+- Modify: `backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java`
+
+**Interfaces:**
+- Consumes: `Candidate` record (`steamId()`, `allTime()`, `datesDesc()`) from Task 1's file; `GuessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(String steamId)` (existing repo method, returns `List<Guess>`).
+- Produces: `private List<Tiered> evaluateBestDayEverTier(List<Candidate> eligible, LocalDate yesterday)` — called from `compute()`.
+
+- [ ] **Step 1: Add the enum constant**
+
+In `PlayerSpotlightInsightType.java`, change:
+
+```java
+public enum PlayerSpotlightInsightType {
+    DAY_STREAK,
+    WEEKLY_ACHIEVEMENT,
+    HOT_STREAK,
+    MILESTONE
+}
+```
+
+to:
+
+```java
+public enum PlayerSpotlightInsightType {
+    DAY_STREAK,
+    BEST_DAY_EVER,
+    WEEKLY_ACHIEVEMENT,
+    HOT_STREAK,
+    MILESTONE
+}
+```
+
+- [ ] **Step 2: Add a `Guess` builder helper and a default repository stub to the test**
+
+In `PlayerSpotlightServiceTest.java`, add this import alongside the existing ones:
+
+```java
+import org.steam5.domain.Guess;
+```
+
+In `setUp()`, add one more default stub after the existing `findBySteamIdBetween` line:
+
+```java
+        when(guessRepository.findBySteamIdBetween(anyString(), any(), any())).thenReturn(List.of());
+        when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(anyString())).thenReturn(List.of());
+```
+
+Add this helper method next to `dateRow`/`consecutiveDaysEnding`:
+
+```java
+    private Guess guess(String steamId, LocalDate date, int points) {
+        final Guess g = new Guess();
+        g.setSteamId(steamId);
+        g.setGameDate(date);
+        g.setPoints(points);
+        return g;
+    }
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Add to `PlayerSpotlightServiceTest.java`:
+
+```java
+    @Test
+    void bestDayEverTierWinsWhenYesterdayIsANewPersonalRecord() {
+        final LocalDate yesterday = today.minusDays(1);
+        final GuessRepository.AllTimeStatsRow recordBreaker = allTimeRow("recordBreaker", 100, 2.0);
+        stubAllTimeStats(recordBreaker);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("recordBreaker", yesterday, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        final List<Guess> history = List.of(
+                guess("recordBreaker", yesterday.minusDays(10), 8),
+                guess("recordBreaker", yesterday.minusDays(5), 12),
+                guess("recordBreaker", yesterday, 24)
+        );
+        when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc("recordBreaker")).thenReturn(history);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("recordBreaker", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.BEST_DAY_EVER, captor.getValue().getInsightType());
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest.bestDayEverTierWinsWhenYesterdayIsANewPersonalRecord"`
+Expected: FAIL — falls through to `MILESTONE` instead (`BEST_DAY_EVER` doesn't exist as a code path yet), so `assertEquals(PlayerSpotlightInsightType.BEST_DAY_EVER, ...)` fails.
+
+- [ ] **Step 5: Implement `evaluateBestDayEverTier` and wire it into `compute()`**
+
+In `PlayerSpotlightService.java`, add this constant next to the other tier constants near the top of the class:
+
+```java
+    private static final int MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER = 2;
+```
+
+Add the new method next to `evaluateDayStreakTier`:
+
+```java
+    private List<Tiered> evaluateBestDayEverTier(final List<Candidate> eligible, final LocalDate yesterday) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final List<Guess> history = guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(c.steamId());
+            final Map<LocalDate, Integer> dailyTotals = history.stream()
+                    .collect(Collectors.groupingBy(Guess::getGameDate, Collectors.summingInt(Guess::getPoints)));
+
+            final Integer yesterdayTotal = dailyTotals.get(yesterday);
+            if (yesterdayTotal == null) continue;
+
+            final List<Integer> priorTotals = dailyTotals.entrySet().stream()
+                    .filter(e -> !e.getKey().equals(yesterday))
+                    .map(Map.Entry::getValue)
+                    .toList();
+            if (priorTotals.size() < MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER) continue;
+
+            final int previousBest = Collections.max(priorTotals);
+            if (yesterdayTotal <= previousBest) continue;
+
+            final String detail = String.format(
+                    "Scored %d points yesterday — a new personal best, beating their previous high of %d.",
+                    yesterdayTotal, previousBest);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.BEST_DAY_EVER,
+                    "Best day ever!", detail, "Yesterday's points", (double) yesterdayTotal));
+        }
+        return tier;
+    }
+```
+
+In `compute()`, add a `yesterday` local and one more `addIfQualifying` call. Change:
+
+```java
+        final List<QualifyingTier> qualifying = new ArrayList<>();
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
+```
+
+to:
+
+```java
+        final LocalDate yesterday = today.minusDays(1);
+        final List<QualifyingTier> qualifying = new ArrayList<>();
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.HOT_STREAK, evaluateHotStreakTier(eligible, today));
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest"`
+Expected: `BUILD SUCCESSFUL`, all 8 tests pass (7 existing + the new one).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java \
+        backend/src/main/java/org/steam5/service/PlayerSpotlightService.java \
+        backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+git commit -m "$(cat <<'EOF'
+feat(spotlight): add BEST_DAY_EVER insight tier
+
+Fires when yesterday's point total beats every one of the player's
+prior days, using their full guess history.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add the `BEAT_THE_ODDS` tier
+
+**Files:**
+- Modify: `backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java`
+- Modify: `backend/src/main/java/org/steam5/service/PlayerSpotlightService.java`
+- Modify: `backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java`
+
+**Interfaces:**
+- Consumes: `GuessRepository.findRoundAvgScoresInRange(LocalDate start, LocalDate end)` → `List<RoundAvgScoreRow>` (fields: `getGameDate()`, `getRoundIndex()`, `getAppId()`, `getAvgScore()`, `getPlayerCount()`, `getAppName()`); `GuessRepository.findBySteamIdAndGameDateAndRoundIndex(String steamId, LocalDate date, int roundIndex)` → `Optional<Guess>` (both existing repo methods).
+- Produces: `private List<Tiered> evaluateBeatTheOddsTier(List<Candidate> eligible, LocalDate yesterday)` — called from `compute()`.
+
+- [ ] **Step 1: Add the enum constant**
+
+In `PlayerSpotlightInsightType.java`, add `BEAT_THE_ODDS` after `BEST_DAY_EVER`:
+
+```java
+public enum PlayerSpotlightInsightType {
+    DAY_STREAK,
+    BEST_DAY_EVER,
+    BEAT_THE_ODDS,
+    WEEKLY_ACHIEVEMENT,
+    HOT_STREAK,
+    MILESTONE
+}
+```
+
+- [ ] **Step 2: Add a default repository stub**
+
+In `PlayerSpotlightServiceTest.java`'s `setUp()`, add:
+
+```java
+        when(guessRepository.findRoundAvgScoresInRange(any(), any())).thenReturn(List.of());
+```
+
+Add this import if not already present: `import java.util.Optional;`
+
+- [ ] **Step 3: Write the failing test**
+
+```java
+    @Test
+    void beatTheOddsTierWinsWhenCandidateAcedTheHardestRoundOfTheDay() {
+        final LocalDate yesterday = today.minusDays(1);
+        final GuessRepository.AllTimeStatsRow oddsBeater = allTimeRow("oddsBeater", 100, 2.0);
+        stubAllTimeStats(oddsBeater);
+
+        final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("oddsBeater", yesterday, 1);
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        final GuessRepository.RoundAvgScoreRow hardRound = mock(GuessRepository.RoundAvgScoreRow.class);
+        when(hardRound.getGameDate()).thenReturn(yesterday);
+        when(hardRound.getRoundIndex()).thenReturn(3);
+        when(hardRound.getAvgScore()).thenReturn(1.2);
+        when(hardRound.getPlayerCount()).thenReturn(20L);
+        when(guessRepository.findRoundAvgScoresInRange(yesterday, yesterday)).thenReturn(List.of(hardRound));
+
+        final Guess theirGuess = guess("oddsBeater", yesterday, 5);
+        theirGuess.setRoundIndex(3);
+        when(guessRepository.findBySteamIdAndGameDateAndRoundIndex("oddsBeater", yesterday, 3))
+                .thenReturn(Optional.of(theirGuess));
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("oddsBeater", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.BEAT_THE_ODDS, captor.getValue().getInsightType());
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest.beatTheOddsTierWinsWhenCandidateAcedTheHardestRoundOfTheDay"`
+Expected: FAIL — falls through to `MILESTONE` since `BEAT_THE_ODDS` isn't wired up yet.
+
+- [ ] **Step 5: Implement `evaluateBeatTheOddsTier` and wire it into `compute()`**
+
+Add these constants next to `MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER`:
+
+```java
+    private static final double HARD_ROUND_MAX_AVG_SCORE = 2.0;
+    private static final int BEAT_THE_ODDS_MIN_POINTS = 4;
+```
+
+Add the method next to `evaluateBestDayEverTier`:
+
+```java
+    private List<Tiered> evaluateBeatTheOddsTier(final List<Candidate> eligible, final LocalDate yesterday) {
+        final List<GuessRepository.RoundAvgScoreRow> rows = guessRepository.findRoundAvgScoresInRange(yesterday, yesterday);
+        final Optional<GuessRepository.RoundAvgScoreRow> hardestRound = rows.stream()
+                .min(Comparator.comparing(GuessRepository.RoundAvgScoreRow::getAvgScore));
+        if (hardestRound.isEmpty() || hardestRound.get().getAvgScore() >= HARD_ROUND_MAX_AVG_SCORE) {
+            return List.of();
+        }
+
+        final int roundIndex = hardestRound.get().getRoundIndex();
+        final double hardAvg = hardestRound.get().getAvgScore();
+
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final Optional<Guess> theirGuess =
+                    guessRepository.findBySteamIdAndGameDateAndRoundIndex(c.steamId(), yesterday, roundIndex);
+            if (theirGuess.isEmpty() || theirGuess.get().getPoints() < BEAT_THE_ODDS_MIN_POINTS) continue;
+
+            final String detail = String.format(
+                    "Nailed yesterday's toughest round (round %d, %.1f avg pts across all players) with %d points.",
+                    roundIndex, hardAvg, theirGuess.get().getPoints());
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.BEAT_THE_ODDS,
+                    "Beat the odds!", detail, "Round points", (double) theirGuess.get().getPoints()));
+        }
+        return tier;
+    }
+```
+
+In `compute()`, add one more `addIfQualifying` call, right after the `BEST_DAY_EVER` line:
+
+```java
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEAT_THE_ODDS, evaluateBeatTheOddsTier(eligible, yesterday));
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest"`
+Expected: `BUILD SUCCESSFUL`, all 9 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java \
+        backend/src/main/java/org/steam5/service/PlayerSpotlightService.java \
+        backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+git commit -m "$(cat <<'EOF'
+feat(spotlight): add BEAT_THE_ODDS insight tier
+
+Fires when a player scored >=4 points on yesterday's hardest round
+(lowest game-wide average, <2.0/5) across all players.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add the `WELCOME_BACK` tier
+
+**Files:**
+- Modify: `backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java`
+- Modify: `backend/src/main/java/org/steam5/service/PlayerSpotlightService.java`
+- Modify: `backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java`
+
+**Interfaces:**
+- Consumes: `Candidate.datesDesc()` (already fetched, unbounded history) and `GuessRepository.findAllForDay(String steamId, LocalDate date)` → `List<Guess>` (existing repo method).
+- Produces: `private List<Tiered> evaluateWelcomeBackTier(List<Candidate> eligible)` — called from `compute()`.
+
+- [ ] **Step 1: Add the enum constant**
+
+```java
+public enum PlayerSpotlightInsightType {
+    DAY_STREAK,
+    BEST_DAY_EVER,
+    BEAT_THE_ODDS,
+    WELCOME_BACK,
+    WEEKLY_ACHIEVEMENT,
+    HOT_STREAK,
+    MILESTONE
+}
+```
+
+- [ ] **Step 2: Add a default repository stub**
+
+In `setUp()`:
+
+```java
+        when(guessRepository.findAllForDay(anyString(), any())).thenReturn(List.of());
+```
+
+- [ ] **Step 3: Write the failing test**
+
+```java
+    @Test
+    void welcomeBackTierWinsWhenCandidateReturnedAfterAGapAndPlayedWell() {
+        final LocalDate mostRecent = today.minusDays(1);
+        final LocalDate beforeGap = mostRecent.minusDays(6); // gap of 6 days, >= the 4-day threshold
+
+        final GuessRepository.AllTimeStatsRow returner = allTimeRow("returner", 100, 2.0);
+        stubAllTimeStats(returner);
+
+        final List<GuessRepository.UserDateRow> dates = new ArrayList<>();
+        dates.add(dateRow("returner", mostRecent));
+        dates.add(dateRow("returner", beforeGap));
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
+
+        when(guessRepository.findAllForDay("returner", mostRecent)).thenReturn(List.of(
+                guess("returner", mostRecent, 4),
+                guess("returner", mostRecent, 3)
+        ));
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("returner", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.WELCOME_BACK, captor.getValue().getInsightType());
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest.welcomeBackTierWinsWhenCandidateReturnedAfterAGapAndPlayedWell"`
+Expected: FAIL — falls through to `MILESTONE`.
+
+- [ ] **Step 5: Implement `evaluateWelcomeBackTier` and wire it into `compute()`**
+
+Add this import to `PlayerSpotlightService.java`:
+
+```java
+import java.time.temporal.ChronoUnit;
+```
+
+Add these constants:
+
+```java
+    private static final int WELCOME_BACK_MIN_GAP_DAYS = 4;
+    private static final double WELCOME_BACK_MIN_RETURN_DAY_AVG = 3.0;
+```
+
+Add the method next to `evaluateBeatTheOddsTier`:
+
+```java
+    private List<Tiered> evaluateWelcomeBackTier(final List<Candidate> eligible) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final List<LocalDate> datesDesc = c.datesDesc();
+            if (datesDesc.size() < 2) continue;
+
+            final LocalDate mostRecent = datesDesc.get(0);
+            final LocalDate previous = datesDesc.get(1);
+            final long gapDays = ChronoUnit.DAYS.between(previous, mostRecent);
+            if (gapDays < WELCOME_BACK_MIN_GAP_DAYS) continue;
+
+            final List<Guess> returnDayGuesses = guessRepository.findAllForDay(c.steamId(), mostRecent);
+            final double returnDayAvg = returnDayGuesses.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            if (returnDayAvg < WELCOME_BACK_MIN_RETURN_DAY_AVG) continue;
+
+            final String detail = String.format(
+                    "Took a %d-day break and came back strong, averaging %.1f pts/round on their return.",
+                    gapDays, returnDayAvg);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.WELCOME_BACK,
+                    "Welcome back!", detail, "Days away", (double) gapDays));
+        }
+        return tier;
+    }
+```
+
+In `compute()`, add one more `addIfQualifying` call, right after the `BEAT_THE_ODDS` line:
+
+```java
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.WELCOME_BACK, evaluateWelcomeBackTier(eligible));
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest"`
+Expected: `BUILD SUCCESSFUL`, all 10 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java \
+        backend/src/main/java/org/steam5/service/PlayerSpotlightService.java \
+        backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+git commit -m "$(cat <<'EOF'
+feat(spotlight): add WELCOME_BACK insight tier
+
+Fires when a player's two most recent play-dates have a >=4 day gap
+and they averaged >=3.0 pts/round on their return day.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Add the `MOST_IMPROVED` tier
+
+**Files:**
+- Modify: `backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java`
+- Modify: `backend/src/main/java/org/steam5/service/PlayerSpotlightService.java`
+- Modify: `backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java`
+
+**Interfaces:**
+- Consumes: `GuessRepository.findBySteamIdBetween(String steamId, LocalDate start, LocalDate end)` (existing, already used by `evaluateHotStreakTier`).
+- Produces: `private List<Tiered> evaluateMostImprovedTier(List<Candidate> eligible, LocalDate today)` — called from `compute()`.
+
+- [ ] **Step 1: Add the enum constant**
+
+```java
+public enum PlayerSpotlightInsightType {
+    DAY_STREAK,
+    BEST_DAY_EVER,
+    BEAT_THE_ODDS,
+    WELCOME_BACK,
+    MOST_IMPROVED,
+    WEEKLY_ACHIEVEMENT,
+    HOT_STREAK,
+    MILESTONE
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+No new default stub needed — `findBySteamIdBetween` already defaults to `List.of()` from Task 1's predecessor setup.
+
+```java
+    @Test
+    void mostImprovedTierWinsWhenRecentFormIsClearlyBetterThanBefore() {
+        final GuessRepository.AllTimeStatsRow improver = allTimeRow("improver", 100, 2.0);
+        stubAllTimeStats(improver);
+
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today)))
+                .thenReturn(consecutiveDaysEnding("improver", today, 1));
+
+        final LocalDate last30Start = today.minusDays(30);
+        final LocalDate last30End = today.minusDays(1);
+        final LocalDate prior30Start = today.minusDays(60);
+        final LocalDate prior30End = today.minusDays(31);
+
+        final List<Guess> last30 = new ArrayList<>();
+        for (int i = 0; i < 15; i++) last30.add(guess("improver", last30Start.plusDays(i), 4));
+        final List<Guess> prior30 = new ArrayList<>();
+        for (int i = 0; i < 15; i++) prior30.add(guess("improver", prior30Start.plusDays(i), 2));
+
+        when(guessRepository.findBySteamIdBetween("improver", last30Start, last30End)).thenReturn(last30);
+        when(guessRepository.findBySteamIdBetween("improver", prior30Start, prior30End)).thenReturn(prior30);
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals("improver", captor.getValue().getSteamId());
+        assertEquals(PlayerSpotlightInsightType.MOST_IMPROVED, captor.getValue().getInsightType());
+    }
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest.mostImprovedTierWinsWhenRecentFormIsClearlyBetterThanBefore"`
+Expected: FAIL — falls through to `MILESTONE`.
+
+- [ ] **Step 4: Implement `evaluateMostImprovedTier` and wire it into `compute()`**
+
+Add these constants:
+
+```java
+    private static final int MOST_IMPROVED_WINDOW_DAYS = 30;
+    private static final int MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW = 10;
+    private static final double MOST_IMPROVED_RELATIVE_THRESHOLD = 1.15;
+    private static final double MOST_IMPROVED_ABSOLUTE_DELTA = 0.3;
+```
+
+Add the method next to `evaluateWelcomeBackTier`:
+
+```java
+    private List<Tiered> evaluateMostImprovedTier(final List<Candidate> eligible, final LocalDate today) {
+        final LocalDate last30Start = today.minusDays(MOST_IMPROVED_WINDOW_DAYS);
+        final LocalDate last30End = today.minusDays(1);
+        final LocalDate prior30Start = today.minusDays(2L * MOST_IMPROVED_WINDOW_DAYS);
+        final LocalDate prior30End = today.minusDays(MOST_IMPROVED_WINDOW_DAYS + 1L);
+
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final List<Guess> last30 = guessRepository.findBySteamIdBetween(c.steamId(), last30Start, last30End);
+            final List<Guess> prior30 = guessRepository.findBySteamIdBetween(c.steamId(), prior30Start, prior30End);
+            if (last30.size() < MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW
+                    || prior30.size() < MOST_IMPROVED_MIN_ROUNDS_PER_WINDOW) {
+                continue;
+            }
+
+            final double last30Avg = last30.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            final double prior30Avg = prior30.stream().mapToInt(Guess::getPoints).average().orElse(0.0);
+            final boolean qualifies = last30Avg >= prior30Avg * MOST_IMPROVED_RELATIVE_THRESHOLD
+                    && (last30Avg - prior30Avg) >= MOST_IMPROVED_ABSOLUTE_DELTA;
+            if (!qualifies) continue;
+
+            final String detail = String.format(
+                    "Leveled up: averaging %.1f pts/round over the last %d days, up from %.1f the month before.",
+                    last30Avg, MOST_IMPROVED_WINDOW_DAYS, prior30Avg);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.MOST_IMPROVED,
+                    "Most improved!", detail, "Last-30d avg", last30Avg));
+        }
+        return tier;
+    }
+```
+
+In `compute()`, add one more `addIfQualifying` call, right after the `WELCOME_BACK` line and before the `HOT_STREAK` line:
+
+```java
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.MOST_IMPROVED, evaluateMostImprovedTier(eligible, today));
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest"`
+Expected: `BUILD SUCCESSFUL`, all 11 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/main/java/org/steam5/domain/PlayerSpotlightInsightType.java \
+        backend/src/main/java/org/steam5/service/PlayerSpotlightService.java \
+        backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+git commit -m "$(cat <<'EOF'
+feat(spotlight): add MOST_IMPROVED insight tier
+
+Fires when a player's last-30-day average is >=15% and >=0.3 points
+higher than their prior-30-day average, with >=10 rounds in each
+window to avoid noise.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Polish the `MILESTONE` fallback text
+
+**Files:**
+- Modify: `backend/src/main/java/org/steam5/service/PlayerSpotlightService.java`
+- Modify: `backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java`
+
+**Interfaces:**
+- Consumes: `Candidate.allTime()` → `GuessRepository.AllTimeStatsRow` (`getRounds()`, `getTotalPoints()`, `getAvgPoints()`, all existing).
+- Produces: no new public surface — `evaluateMilestoneTier`'s generated `detail` text changes for candidates near a milestone; signature unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+    @Test
+    void milestoneTierUsesNiceNumberFramingWhenRoundsAreCloseToAMilestone() {
+        final GuessRepository.AllTimeStatsRow almostCentury = allTimeRow("almostCentury", 98, 2.0);
+        when(almostCentury.getTotalPoints()).thenReturn(400L);
+        stubAllTimeStats(almostCentury);
+
+        when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today)))
+                .thenReturn(consecutiveDaysEnding("almostCentury", today, 1));
+
+        service.computeAndPersistForToday();
+
+        final ArgumentCaptor<PlayerSpotlight> captor = ArgumentCaptor.forClass(PlayerSpotlight.class);
+        verify(playerSpotlightRepository).save(captor.capture());
+        assertEquals(PlayerSpotlightInsightType.MILESTONE, captor.getValue().getInsightType());
+        assertEquals("Closing in on 100 rounds — only 2 away!", captor.getValue().getDetail());
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest.milestoneTierUsesNiceNumberFramingWhenRoundsAreCloseToAMilestone"`
+Expected: FAIL — current text is `"Has played 98 rounds and counting, averaging 2.0 pts/round."`.
+
+- [ ] **Step 3: Replace `evaluateMilestoneTier` with the nice-number version**
+
+Find this method:
+
+```java
+    private List<Tiered> evaluateMilestoneTier(final List<Candidate> eligible) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final double avgPoints = c.allTime().getAvgPoints() != null ? c.allTime().getAvgPoints() : 0.0;
+            final String detail = String.format(
+                    "Has played %d rounds and counting, averaging %.1f pts/round.",
+                    c.allTime().getRounds(), avgPoints);
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.MILESTONE,
+                    "A steady presence!", detail, "Rounds played", (double) c.allTime().getRounds()));
+        }
+        return tier;
+    }
+```
+
+Replace it with:
+
+```java
+    private static final List<Long> ROUND_MILESTONES = List.of(100L, 250L, 500L, 1000L);
+    private static final List<Long> POINTS_MILESTONES = List.of(1000L, 5000L, 10000L);
+    private static final long MILESTONE_TRAILING_WINDOW = 5;
+
+    private List<Tiered> evaluateMilestoneTier(final List<Candidate> eligible) {
+        final List<Tiered> tier = new ArrayList<>();
+        for (final Candidate c : eligible) {
+            final long rounds = c.allTime().getRounds();
+            final long totalPoints = c.allTime().getTotalPoints() != null ? c.allTime().getTotalPoints() : 0L;
+            final double avgPoints = c.allTime().getAvgPoints() != null ? c.allTime().getAvgPoints() : 0.0;
+
+            final String detail = nearestMilestoneDetail(rounds, ROUND_MILESTONES, "rounds")
+                    .or(() -> nearestMilestoneDetail(totalPoints, POINTS_MILESTONES, "lifetime points"))
+                    .orElseGet(() -> String.format("Has played %d rounds and counting, averaging %.1f pts/round.",
+                            rounds, avgPoints));
+
+            tier.add(new Tiered(c.steamId(), PlayerSpotlightInsightType.MILESTONE,
+                    "A steady presence!", detail, "Rounds played", (double) rounds));
+        }
+        return tier;
+    }
+
+    private Optional<String> nearestMilestoneDetail(final long value, final List<Long> milestones, final String unitLabel) {
+        return milestones.stream()
+                .filter(milestone -> Math.abs(value - milestone) <= MILESTONE_TRAILING_WINDOW)
+                .findFirst()
+                .map(milestone -> value >= milestone
+                        ? String.format("Just crossed %,d %s — now at %,d!", milestone, unitLabel, value)
+                        : String.format("Closing in on %,d %s — only %,d away!", milestone, unitLabel, milestone - value));
+    }
+```
+
+**Important:** the constants `ROUND_MILESTONES`, `POINTS_MILESTONES`, and `MILESTONE_TRAILING_WINDOW` must be moved up next to the other `private static final` constants near the top of the class (Java requires field declarations before use is not actually required, but keep all tier constants grouped together for readability — this is a style nit, not a compile requirement).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.service.PlayerSpotlightServiceTest"`
+Expected: `BUILD SUCCESSFUL`, all 12 tests pass.
+
+- [ ] **Step 5: Run the full backend test suite**
+
+Run: `cd backend && sh gradlew test`
+Expected: `BUILD SUCCESSFUL` (confirms nothing outside `PlayerSpotlightServiceTest` was affected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/main/java/org/steam5/service/PlayerSpotlightService.java \
+        backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+git commit -m "$(cat <<'EOF'
+feat(spotlight): use nice-number framing for the MILESTONE fallback
+
+Leads with a round-count or lifetime-points milestone (100/250/500/
+1000 rounds; 1000/5000/10000 points) when the player is within 5 of
+one, instead of always showing the generic "has played N rounds" text.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Frontend support for the four new insight types
+
+**Files:**
+- Modify: `frontend/src/components/PlayerSpotlight.tsx`
+- Modify: `frontend/src/styles/components/playerSpotlight.css`
+
+**Interfaces:**
+- Consumes: the backend's `PlayerSpotlightInsightType` enum values (now includes `BEST_DAY_EVER`, `BEAT_THE_ODDS`, `WELCOME_BACK`, `MOST_IMPROVED`), serialized as the `insightType` string field of `GET /api/stats/spotlight/today`.
+
+- [ ] **Step 1: Extend the `InsightType` union and lookup maps**
+
+In `PlayerSpotlight.tsx`, find:
+
+```tsx
+type InsightType = "DAY_STREAK" | "WEEKLY_ACHIEVEMENT" | "HOT_STREAK" | "MILESTONE";
+```
+
+Replace with:
+
+```tsx
+type InsightType =
+    | "DAY_STREAK"
+    | "BEST_DAY_EVER"
+    | "BEAT_THE_ODDS"
+    | "WELCOME_BACK"
+    | "MOST_IMPROVED"
+    | "WEEKLY_ACHIEVEMENT"
+    | "HOT_STREAK"
+    | "MILESTONE";
+```
+
+Find:
+
+```tsx
+const INSIGHT_MODIFIER: Record<InsightType, string> = {
+    DAY_STREAK: "day-streak",
+    WEEKLY_ACHIEVEMENT: "weekly-achievement",
+    HOT_STREAK: "hot-streak",
+    MILESTONE: "milestone",
+};
+
+const INSIGHT_EMOJI: Record<InsightType, string> = {
+    DAY_STREAK: "🔥",
+    WEEKLY_ACHIEVEMENT: "🏅",
+    HOT_STREAK: "📈",
+    MILESTONE: "⭐",
+};
+```
+
+Replace with:
+
+```tsx
+const INSIGHT_MODIFIER: Record<InsightType, string> = {
+    DAY_STREAK: "day-streak",
+    BEST_DAY_EVER: "best-day-ever",
+    BEAT_THE_ODDS: "beat-the-odds",
+    WELCOME_BACK: "welcome-back",
+    MOST_IMPROVED: "most-improved",
+    WEEKLY_ACHIEVEMENT: "weekly-achievement",
+    HOT_STREAK: "hot-streak",
+    MILESTONE: "milestone",
+};
+
+const INSIGHT_EMOJI: Record<InsightType, string> = {
+    DAY_STREAK: "🔥",
+    BEST_DAY_EVER: "🏆",
+    BEAT_THE_ODDS: "🎯",
+    WELCOME_BACK: "👋",
+    MOST_IMPROVED: "📊",
+    WEEKLY_ACHIEVEMENT: "🏅",
+    HOT_STREAK: "📈",
+    MILESTONE: "⭐",
+};
+```
+
+- [ ] **Step 2: Add CSS accent classes for the four new types**
+
+In `playerSpotlight.css`, find:
+
+```css
+.player-spotlight--milestone {
+    border-color: var(--color-border);
+}
+```
+
+Add these four rules directly after it:
+
+```css
+.player-spotlight--best-day-ever {
+    border-color: color-mix(in srgb, var(--color-score-close) 45%, var(--color-border));
+}
+
+.player-spotlight--beat-the-odds {
+    border-color: color-mix(in srgb, var(--color-score-near) 45%, var(--color-border));
+}
+
+.player-spotlight--welcome-back {
+    border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+}
+
+.player-spotlight--most-improved {
+    border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-border));
+}
+```
+
+- [ ] **Step 3: Type-check the frontend**
+
+Run: `cd frontend && npx tsc --noEmit -p tsconfig.json`
+Expected: no output (no type errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/PlayerSpotlight.tsx frontend/src/styles/components/playerSpotlight.css
+git commit -m "$(cat <<'EOF'
+feat(spotlight): render the four new insight types on the frontend
+
+Adds emoji + accent-color mappings for BEST_DAY_EVER, BEAT_THE_ODDS,
+WELCOME_BACK, and MOST_IMPROVED, matching the existing card styling
+conventions.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Full regression, manual verification against real dev data, push
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full backend test suite**
+
+Run: `cd backend && sh gradlew test`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 2: Manually verify against real dev data**
+
+Create a temporary throwaway test file `backend/src/test/java/org/steam5/ManualPlayerSpotlightVerification.java`:
+
+```java
+package org.steam5;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.steam5.domain.GameDate;
+import org.steam5.repository.PlayerSpotlightRepository;
+import org.steam5.service.PlayerSpotlightService;
+
+@SpringBootTest
+class ManualPlayerSpotlightVerification {
+
+    @Autowired
+    private PlayerSpotlightService playerSpotlightService;
+
+    @Autowired
+    private PlayerSpotlightRepository playerSpotlightRepository;
+
+    @Test
+    void computeAgainstRealDevData() {
+        playerSpotlightRepository.deleteAll();
+        playerSpotlightService.computeAndPersistForToday();
+        playerSpotlightRepository.findById(GameDate.todayUtc())
+                .ifPresentOrElse(
+                        s -> System.out.println("MANUAL_VERIFY_RESULT: " + s),
+                        () -> System.out.println("MANUAL_VERIFY_RESULT: <none - no eligible candidate>")
+                );
+    }
+}
+```
+
+Run: `cd backend && sh gradlew test --tests "org.steam5.ManualPlayerSpotlightVerification" -i 2>&1 | grep MANUAL_VERIFY_RESULT`
+Expected: one line printing a `PlayerSpotlight(...)` with a plausible `insightType` for a real dev-database player (the specific tier depends on current dev data — any of the 8 tiers is a valid outcome).
+
+Delete the temporary file afterward: `rm backend/src/test/java/org/steam5/ManualPlayerSpotlightVerification.java` (do not commit it).
+
+- [ ] **Step 3: Manually verify the API + frontend rendering**
+
+Start the backend: `cd backend && sh gradlew bootRun` (background it; wait for "Started Steam5Application" in the log).
+Run: `curl -s http://localhost:8080/api/stats/spotlight/today`
+Expected: JSON body with an `insightType` field matching one of the 8 enum values, and non-empty `headline`/`detail`.
+
+Start the frontend: `cd frontend && npm run dev` (background it).
+Run: `curl -s http://localhost:3000/review-guesser/1 | grep -o 'player-spotlight--[a-z-]*'`
+Expected: one `player-spotlight--<modifier>` class matching the tier from the API response (e.g. `player-spotlight--best-day-ever`).
+
+Stop both dev servers when done (`pkill -f "org.steam5.Steam5Application"`, `pkill -f "next dev"`).
+
+- [ ] **Step 4: Push**
+
+```bash
+git push
+```
+
+Expected: pushes all commits from Tasks 1–7 (this task has no commit of its own — verification only) to the current branch's upstream.

--- a/docs/superpowers/specs/2026-07-02-spotlight-insights-design.md
+++ b/docs/superpowers/specs/2026-07-02-spotlight-insights-design.md
@@ -1,0 +1,66 @@
+# Player Spotlight: expanded insights & fairer selection
+
+## Context
+
+The Player Spotlight (`PlayerSpotlightService`, shipped on the `player-highlights` branch) shows one eligible player per day on round 1 of `/review-guesser`, picked from a priority ladder of "insight" tiers: `DAY_STREAK`, `WEEKLY_ACHIEVEMENT`, `HOT_STREAK`, `MILESTONE` (guaranteed fallback).
+
+Two problems prompted this follow-up design:
+
+1. **`WEEKLY_ACHIEVEMENT` is redundant.** It just re-surfaces the same per-timeframe achievements (`EARLY_BIRD`, `SHARPSHOOTER`, etc.) that already appear on the leaderboard — not novel, and not particularly "good vibes."
+2. **Strict priority ordering lets one ambient tier dominate.** `DAY_STREAK` sits at priority #1 and qualifies for *any* player on an active ≥5-day streak. Since most regular players maintain a continuous streak, `DAY_STREAK` would win on most days, starving out rarer, more interesting stories even when they occur.
+
+This design adds four new, more novel insight tiers and changes the selection mechanism so no single ambient tier can dominate, while still demoting (not removing) `WEEKLY_ACHIEVEMENT`.
+
+## Selection mechanism
+
+Tiers are split into two groups instead of one flat priority ladder:
+
+1. **Competitive pool** — six tiers, evaluated every day: `DAY_STREAK`, `BEST_DAY_EVER`, `BEAT_THE_ODDS`, `WELCOME_BACK`, `MOST_IMPROVED`, `HOT_STREAK`. Every tier in this pool with ≥1 qualifying candidate is collected, then **one tier is picked uniformly at random** among just those qualifying tiers. A candidate is then picked from that tier using the existing date-seeded tie-break (sort by `steamId`, `Random(today.toEpochDay())`). The tier-pick and the candidate-pick both draw from that same `Random` instance, in that order, so the whole day's result is deterministic and reproducible from the date alone.
+2. **Sequential fallbacks**, evaluated only if the competitive pool has zero qualifying tiers that day:
+   - `WEEKLY_ACHIEVEMENT` — kept, but deliberately excluded from the lottery so it stays a low-visibility fallback rather than a full competitor.
+   - `MILESTONE` — guaranteed last resort (always applicable for any eligible candidate), also excluded from the lottery so it never crowds out a more interesting story.
+
+This directly fixes the dominance problem: on a day where `DAY_STREAK` and `MOST_IMPROVED` both have qualifying candidates, each has an equal chance instead of `DAY_STREAK` automatically winning. Event-based tiers (`BEST_DAY_EVER`, `BEAT_THE_ODDS`, `WELCOME_BACK`) don't need extra weighting to compete — they're naturally rare/self-limiting (true for at most a handful of players on any given day), so they only need to not be auto-beaten when they do occur. Weighting by rarity was considered and rejected for v1 as unnecessary tuning (YAGNI); revisit only if real usage shows a tier still crowds out others despite the lottery.
+
+Eligibility (unchanged): ≥70 rounds all-time, played within the last 14 days.
+
+## New tiers
+
+All "yesterday"-based criteria use yesterday specifically, not "today" — the nightly job runs at 00:15 UTC, before any of the current day's rounds are played, so `GameDate.todayUtc()` at compute time has no guesses yet.
+
+### BEST_DAY_EVER
+Sum of yesterday's points is strictly greater than every one of the player's prior days' point-sums. Requires ≥2 prior days played, so a brand-new veteran's second day can't trivially "win."
+- Data: per-player, per-day point totals, grouped from that player's full `Guess` history (`findBySteamIdBetween` or a new lightweight aggregate query — implementer's choice based on what's cheaper against the existing schema).
+
+### BEAT_THE_ODDS
+Among yesterday's rounds, find the one with the lowest average score across all players, using the existing `GuessRepository.findRoundAvgScoresInRange` (already filtered to ≥5 players for statistical relevance). That round only counts as "hard" if its average score is < 2.0/5. A candidate qualifies if their own points on that specific round were ≥4.
+- Data: `findRoundAvgScoresInRange(yesterday, yesterday)` + the candidate's own `Guess` for that `(gameDate, roundIndex)`.
+
+### WELCOME_BACK
+Across the player's full play history, their two most recent distinct play-dates have a gap ≥4 days between them, **and** their average points on the most recent play-day are ≥3.0/5 (a genuinely good return, not a flop).
+- Data: the unbounded `datesDesc` history already fetched per candidate during eligibility filtering, plus that day's `Guess` rows for the points check.
+
+### MOST_IMPROVED
+Average points over the last 30 days is both ≥15% relatively higher and ≥0.3 points higher than the average over the prior 30-day window (days 31–60 back). Requires ≥10 rounds played in each of the two windows, to avoid noise from sparse data.
+- Data: `findBySteamIdBetween` for the two 30-day windows.
+
+## MILESTONE tier polish
+
+Replace the current generic "has played N rounds and counting, averaging X pts/round" text with **nice-number framing**: if the player's round count or lifetime point total is at or within a small trailing window (e.g. within 5) of a notable number (100/250/500/1000 rounds; 1000/5000/10000 lifetime points), lead with that milestone instead. Otherwise, fall back to the current generic phrasing. Still the guaranteed last-resort tier either way — this is a text-quality change only, not a new eligibility path.
+
+## Edge cases
+
+- Multiple candidates qualify for the tier the lottery picked → existing date-seeded tie-break applies unchanged.
+- A candidate could qualify for more than one competitive tier simultaneously (e.g. both `BEST_DAY_EVER` and `WELCOME_BACK`) — irrelevant, since only the lottery-winning tier is evaluated/used; no cross-tier deduping needed.
+- Exactly one qualifying tier in the competitive pool on a given day → that tier is used deterministically; the mechanism still works, "randomness" just has nothing to do that day.
+- Zero qualifying tiers in the competitive pool → falls through to `WEEKLY_ACHIEVEMENT`, then `MILESTONE`, unchanged from the original design.
+
+## Out of scope for this iteration
+
+Ideas raised during brainstorming but deferred:
+- Leaderboard-rank-movement stories (cracked top 10, climbed N spots) — explicitly de-scoped since rank is already visible on the leaderboard itself.
+- Personal accuracy high (rolling hit-rate personal best).
+- No-flop run (streak of rounds without a 0-point score).
+- Tenure/anniversary and lifetime-points milestones as their own dedicated tiers (partially covered by the `MILESTONE` text polish above, but not a full dedicated tier).
+
+These can be picked up in a future iteration if the current set doesn't feel varied enough in practice.

--- a/frontend/app/profile/[steamId]/page.tsx
+++ b/frontend/app/profile/[steamId]/page.tsx
@@ -8,6 +8,7 @@ import {formatDate, ordinal, placementTier} from "@/lib/format";
 import {flattenDayRounds} from "@/lib/rounds";
 import {BACKEND_ORIGIN as backend} from "@/lib/backend";
 import {formatAwardMetric} from "@/lib/seasons";
+import {INSIGHT_EMOJI, type InsightType} from "@/components/PlayerSpotlight";
 
 type ProfileResponse = {
     steamId: string;
@@ -45,6 +46,14 @@ type ProfileResponse = {
         metricValue: number;
         tiebreakRoll?: number | null;
     }>;
+    spotlights: Array<{
+        gameDate: string;
+        insightType: InsightType;
+        headline: string;
+        detail: string;
+        statLabel?: string | null;
+        statValue?: number | null;
+    }>;
 };
 
 export default async function ProfilePage({params}: { params: { steamId: string } }) {
@@ -63,6 +72,7 @@ export default async function ProfilePage({params}: { params: { steamId: string 
 
     const awards = data.awards ?? [];
     const awardSeasons = groupAwardsBySeason(awards);
+    const spotlights = data.spotlights ?? [];
 
     return (
         <section className="container">
@@ -136,6 +146,29 @@ export default async function ProfilePage({params}: { params: { steamId: string 
                                 </article>
                             ))}
                         </div>
+                    )}
+                </section>
+
+                <section aria-labelledby="spotlights-title">
+                    <h2 id="spotlights-title">Spotlight history</h2>
+                    {spotlights.length === 0 ? (
+                        <p className="muted">No spotlight appearances yet.</p>
+                    ) : (
+                        <ul className="profile__spotlight-list">
+                            {spotlights.map(s => (
+                                <li className="profile__spotlight-row" key={s.gameDate}>
+                                    <span className="profile__spotlight-badge" aria-hidden="true">
+                                        {INSIGHT_EMOJI[s.insightType] ?? "⭐"}
+                                    </span>
+                                    <div className="profile__spotlight-content">
+                                        <p className="profile__spotlight-headline">
+                                            {s.headline} <span className="profile__spotlight-date">{formatDate(s.gameDate)}</span>
+                                        </p>
+                                        <p className="profile__spotlight-detail">{s.detail}</p>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
                     )}
                 </section>
 

--- a/frontend/app/review-guesser/[round]/page.tsx
+++ b/frontend/app/review-guesser/[round]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import ReviewGuesserHero from "@/components/ReviewGuesserHero";
 import GameInfoSection from "@/components/GameInfoSection";
 import NewsBox from "@/components/NewsBox";
+import PlayerSpotlight from "@/components/PlayerSpotlight";
 import ReviewGuesserRound from "@/components/ReviewGuesserRound";
 import {Suspense} from "react";
 import {cookies} from "next/headers";
@@ -108,6 +109,7 @@ export default async function ReviewGuesserRoundPage({params}: { params: Promise
                 />
             </Suspense>
 
+            {roundIndex === 1 && <PlayerSpotlight/>}
             {roundIndex === 1 && <NewsBox/>}
 
             <GameInfoSection pick={pick}/>

--- a/frontend/src/components/PlayerSpotlight.tsx
+++ b/frontend/src/components/PlayerSpotlight.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import Link from "next/link";
+import "@/styles/components/playerSpotlight.css";
+import {BACKEND_ORIGIN as backend} from "@/lib/backend";
+
+type InsightType = "DAY_STREAK" | "WEEKLY_ACHIEVEMENT" | "HOT_STREAK" | "MILESTONE";
+
+type SpotlightResponse = {
+    steamId: string;
+    personaName: string;
+    avatar: string | null;
+    insightType: InsightType;
+    headline: string;
+    detail: string;
+    statLabel: string | null;
+    statValue: number | null;
+};
+
+const INSIGHT_MODIFIER: Record<InsightType, string> = {
+    DAY_STREAK: "day-streak",
+    WEEKLY_ACHIEVEMENT: "weekly-achievement",
+    HOT_STREAK: "hot-streak",
+    MILESTONE: "milestone",
+};
+
+const INSIGHT_EMOJI: Record<InsightType, string> = {
+    DAY_STREAK: "🔥",
+    WEEKLY_ACHIEVEMENT: "🏅",
+    HOT_STREAK: "📈",
+    MILESTONE: "⭐",
+};
+
+async function loadSpotlight(): Promise<SpotlightResponse | null> {
+    try {
+        const res = await fetch(`${backend}/api/stats/spotlight/today`, {
+            headers: {"accept": "application/json"},
+            next: {revalidate: 300, tags: ["spotlight-today"]},
+        });
+        if (!res.ok) return null; // includes 204 No Content — nobody eligible yet
+        return await res.json();
+    } catch {
+        return null;
+    }
+}
+
+export default async function PlayerSpotlight(): Promise<React.ReactElement | null> {
+    const spotlight = await loadSpotlight();
+    if (!spotlight) return null;
+
+    const modifier = INSIGHT_MODIFIER[spotlight.insightType];
+
+    return (
+        <aside className={`player-spotlight player-spotlight--${modifier}`} aria-label="Player spotlight">
+            <p className="player-spotlight__eyebrow">Good vibes</p>
+            <p className="player-spotlight__headline">
+                <span className="player-spotlight__emoji" aria-hidden="true">{INSIGHT_EMOJI[spotlight.insightType]}</span>
+                {' '}
+                <Link href={`/profile/${encodeURIComponent(spotlight.steamId)}`}>
+                    <strong>{spotlight.personaName}</strong>
+                </Link>
+                {' '}{spotlight.headline}
+            </p>
+            <p className="player-spotlight__detail">{spotlight.detail}</p>
+        </aside>
+    );
+}

--- a/frontend/src/components/PlayerSpotlight.tsx
+++ b/frontend/src/components/PlayerSpotlight.tsx
@@ -51,10 +51,16 @@ async function loadSpotlight(): Promise<SpotlightResponse | null> {
         const res = await fetch(`${backend}/api/stats/spotlight/today`, {
             headers: {"accept": "application/json"},
             next: {revalidate: 300, tags: ["spotlight-today"]},
+            signal: AbortSignal.timeout(3000),
         });
-        if (!res.ok) return null; // includes 204 No Content — nobody eligible yet
+        if (res.status === 204) return null; // nobody eligible today — expected, not an error
+        if (!res.ok) {
+            console.error(`PlayerSpotlight: unexpected ${res.status} response from spotlight endpoint`);
+            return null;
+        }
         return await res.json();
-    } catch {
+    } catch (err) {
+        console.error("PlayerSpotlight: failed to load spotlight", err);
         return null;
     }
 }
@@ -63,13 +69,16 @@ export default async function PlayerSpotlight(): Promise<React.ReactElement | nu
     const spotlight = await loadSpotlight();
     if (!spotlight) return null;
 
-    const modifier = INSIGHT_MODIFIER[spotlight.insightType];
+    // Fall back to the MILESTONE styling/emoji for any insightType the frontend
+    // doesn't recognize yet (e.g. a new backend tier deployed before this build).
+    const modifier = INSIGHT_MODIFIER[spotlight.insightType] ?? "milestone";
+    const emoji = INSIGHT_EMOJI[spotlight.insightType] ?? "⭐";
 
     return (
         <aside className={`player-spotlight player-spotlight--${modifier}`} aria-label="Player spotlight">
             <p className="player-spotlight__eyebrow">Good vibes</p>
             <p className="player-spotlight__headline">
-                <span className="player-spotlight__emoji" aria-hidden="true">{INSIGHT_EMOJI[spotlight.insightType]}</span>
+                <span className="player-spotlight__emoji" aria-hidden="true">{emoji}</span>
                 {' '}
                 <Link href={`/profile/${encodeURIComponent(spotlight.steamId)}`}>
                     <strong>{spotlight.personaName}</strong>

--- a/frontend/src/components/PlayerSpotlight.tsx
+++ b/frontend/src/components/PlayerSpotlight.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import "@/styles/components/playerSpotlight.css";
 import {BACKEND_ORIGIN as backend} from "@/lib/backend";
 
-type InsightType =
+export type InsightType =
     | "DAY_STREAK"
     | "BEST_DAY_EVER"
     | "BEAT_THE_ODDS"
@@ -35,7 +35,7 @@ const INSIGHT_MODIFIER: Record<InsightType, string> = {
     MILESTONE: "milestone",
 };
 
-const INSIGHT_EMOJI: Record<InsightType, string> = {
+export const INSIGHT_EMOJI: Record<InsightType, string> = {
     DAY_STREAK: "🔥",
     BEST_DAY_EVER: "🏆",
     BEAT_THE_ODDS: "🎯",

--- a/frontend/src/components/PlayerSpotlight.tsx
+++ b/frontend/src/components/PlayerSpotlight.tsx
@@ -3,7 +3,15 @@ import Link from "next/link";
 import "@/styles/components/playerSpotlight.css";
 import {BACKEND_ORIGIN as backend} from "@/lib/backend";
 
-type InsightType = "DAY_STREAK" | "WEEKLY_ACHIEVEMENT" | "HOT_STREAK" | "MILESTONE";
+type InsightType =
+    | "DAY_STREAK"
+    | "BEST_DAY_EVER"
+    | "BEAT_THE_ODDS"
+    | "WELCOME_BACK"
+    | "MOST_IMPROVED"
+    | "WEEKLY_ACHIEVEMENT"
+    | "HOT_STREAK"
+    | "MILESTONE";
 
 type SpotlightResponse = {
     steamId: string;
@@ -18,6 +26,10 @@ type SpotlightResponse = {
 
 const INSIGHT_MODIFIER: Record<InsightType, string> = {
     DAY_STREAK: "day-streak",
+    BEST_DAY_EVER: "best-day-ever",
+    BEAT_THE_ODDS: "beat-the-odds",
+    WELCOME_BACK: "welcome-back",
+    MOST_IMPROVED: "most-improved",
     WEEKLY_ACHIEVEMENT: "weekly-achievement",
     HOT_STREAK: "hot-streak",
     MILESTONE: "milestone",
@@ -25,6 +37,10 @@ const INSIGHT_MODIFIER: Record<InsightType, string> = {
 
 const INSIGHT_EMOJI: Record<InsightType, string> = {
     DAY_STREAK: "🔥",
+    BEST_DAY_EVER: "🏆",
+    BEAT_THE_ODDS: "🎯",
+    WELCOME_BACK: "👋",
+    MOST_IMPROVED: "📊",
     WEEKLY_ACHIEVEMENT: "🏅",
     HOT_STREAK: "📈",
     MILESTONE: "⭐",

--- a/frontend/src/styles/components/playerSpotlight.css
+++ b/frontend/src/styles/components/playerSpotlight.css
@@ -22,6 +22,22 @@
     border-color: var(--color-border);
 }
 
+.player-spotlight--best-day-ever {
+    border-color: color-mix(in srgb, var(--color-score-close) 45%, var(--color-border));
+}
+
+.player-spotlight--beat-the-odds {
+    border-color: color-mix(in srgb, var(--color-score-near) 45%, var(--color-border));
+}
+
+.player-spotlight--welcome-back {
+    border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+}
+
+.player-spotlight--most-improved {
+    border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-border));
+}
+
 .player-spotlight__eyebrow {
     margin: 0 0 4px;
     font-size: x-small;

--- a/frontend/src/styles/components/playerSpotlight.css
+++ b/frontend/src/styles/components/playerSpotlight.css
@@ -1,0 +1,71 @@
+.player-spotlight {
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin: 12px 0 24px;
+}
+
+.player-spotlight--day-streak {
+    border-color: color-mix(in srgb, var(--color-primary) 40%, var(--color-border));
+}
+
+.player-spotlight--weekly-achievement {
+    border-color: color-mix(in srgb, var(--color-success) 40%, var(--color-border));
+}
+
+.player-spotlight--hot-streak {
+    border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border));
+}
+
+.player-spotlight--milestone {
+    border-color: var(--color-border);
+}
+
+.player-spotlight__eyebrow {
+    margin: 0 0 4px;
+    font-size: x-small;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+}
+
+.player-spotlight__headline {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.player-spotlight__headline a {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: var(--color-border);
+    text-underline-offset: 2px;
+}
+
+.player-spotlight__emoji {
+    margin-right: 2px;
+}
+
+.player-spotlight__detail {
+    margin: 6px 0 0;
+    font-size: 0.875rem;
+    color: var(--color-muted);
+}
+
+/* Mobile density: no extra spacing added — tighten via type scale/contrast only. */
+@media (max-width: 640px) {
+    .player-spotlight {
+        padding: 10px 14px;
+    }
+
+    .player-spotlight__headline {
+        font-size: 0.9375rem;
+    }
+
+    .player-spotlight__detail {
+        font-size: 0.8125rem;
+    }
+}

--- a/frontend/src/styles/components/profile.css
+++ b/frontend/src/styles/components/profile.css
@@ -96,6 +96,61 @@
     font-size: 0.85rem;
 }
 
+.profile__spotlight-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.profile__spotlight-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.45rem 0.25rem;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.profile__spotlight-row:last-child {
+    border-bottom: none;
+}
+
+.profile__spotlight-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    flex-shrink: 0;
+    border-radius: 999px;
+    background: var(--color-border);
+    font-size: 1rem;
+}
+
+.profile__spotlight-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+}
+
+.profile__spotlight-headline {
+    margin: 0;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.profile__spotlight-date {
+    font-weight: 400;
+    color: var(--color-muted);
+    font-size: 0.85rem;
+}
+
+.profile__spotlight-detail {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 0.85rem;
+}
+
 
 /* Performance section */
 


### PR DESCRIPTION
## Summary
- Adds a "Player Spotlight" box shown on round 1 of each day, featuring one established, currently-active player (≥70 rounds all-time, played in the last 14 days) with a positive story — computed nightly by a new Quartz job and persisted, following the same pattern as the existing daily-picks/season jobs.
- Eight insight tiers, selected via a uniform-random lottery among six "competitive" tiers (`DAY_STREAK`, `BEST_DAY_EVER`, `BEAT_THE_ODDS`, `WELCOME_BACK`, `MOST_IMPROVED`, `HOT_STREAK`) so no single ambient tier (e.g. an active streak, which most regulars have) can dominate every day — falling back to `WEEKLY_ACHIEVEMENT` then a nice-number-aware `MILESTONE` message when nothing else qualifies.
- New endpoint `GET /api/stats/spotlight/today`; new frontend `PlayerSpotlight` component rendered only on round 1.

## Design docs
- `docs/superpowers/specs/2026-07-02-spotlight-insights-design.md`
- `docs/superpowers/plans/2026-07-02-spotlight-insights.md`

## Test plan
- [x] `cd backend && sh gradlew test` — full suite green (53/53)
- [x] Manual verification against the real local dev database (all 8 tiers reachable; one insight persisted and served correctly end-to-end)
- [x] `GET /api/stats/spotlight/today` returns the expected payload; `/review-guesser/1` renders the matching `player-spotlight--<tier>` styling, `/review-guesser/2` correctly omits the box
- [x] `npx tsc --noEmit` clean on the frontend
- [x] Per-task spec-compliance + code-quality review during implementation, plus a final whole-branch review (fixes applied in `5be1068`: added test coverage for the lottery draw itself, documented a pre-existing Postgres CHECK-constraint gotcha for future enum growth, refreshed stale doc comments)

Note: there's a known, documented limitation (see the `PlayerSpotlightInsightType` javadoc) where adding a 9th insight type in the future will require a manual `ALTER TABLE` in already-deployed environments, since Hibernate's auto-generated CHECK constraint isn't widened by `ddl-auto: update`. This mirrors an existing characteristic of this codebase's schema management (shared by `season_award_results` and `seasons`) and doesn't block this PR since the table has never been deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)