### PR TITLE
Track random archive round button clicks in Umami

### DIFF
--- a/frontend/src/components/RoundResultActions.tsx
+++ b/frontend/src/components/RoundResultActions.tsx
@@ -39,7 +39,11 @@ export default function RoundResultActions(props: {
                 </div>
             ) : props.randomArchiveHref && (
                 <div className="review-round__actions-primary">
-                    <Link href={props.randomArchiveHref} className="btn-cta" aria-label="Play a random archived round">
+                    <Link
+                        href={props.randomArchiveHref}
+                        className="btn-cta"
+                        aria-label="Play a random archived round"
+                        data-umami-event="random-archive-round">
                         Random archived round <ShuffleIcon size={28}/>
                     </Link>
                 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a custom Umami event (`random-archive-round`) to the "Random archived round" CTA shown after completing the last round of a day.

## Changes

- Add `data-umami-event="random-archive-round"` to the link in `RoundResultActions.tsx`
- Matches the existing pattern used for donate links (`data-umami-event` on clickable elements)

## Testing

- Verified the attribute is present on the random archive CTA link
- No functional behavior change beyond analytics tracking
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f475d-546a-793d-b7e8-10a08be84ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f475d-546a-793d-b7e8-10a08be84ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

