### PR TITLE
Track round action button clicks in Umami

### DIFF
--- a/frontend/src/components/RoundResultActions.tsx
+++ b/frontend/src/components/RoundResultActions.tsx
@@ -39,7 +39,11 @@ export default function RoundResultActions(props: {
                 </div>
             ) : props.randomArchiveHref && (
                 <div className="review-round__actions-primary">
-                    <Link href={props.randomArchiveHref} className="btn-cta" aria-label="Play a random archived round">
+                    <Link
+                        href={props.randomArchiveHref}
+                        className="btn-cta"
+                        aria-label="Play a random archived round"
+                        data-umami-event="random-archive-round">
                         Random archived round <ShuffleIcon size={28}/>
                     </Link>
                 </div>

--- a/frontend/src/components/RoundResultActions.tsx
+++ b/frontend/src/components/RoundResultActions.tsx
@@ -21,9 +21,9 @@ export default function RoundResultActions(props: {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="btn-ghost"
-                    aria-label="Open this game on Steam"
-                    data-umami-event="open-on-steam">
-                    Open on Steam <SteamLogoIcon size={28}/>
+                    aria-label="View this game on Steam"
+                    data-umami-event="view-on-steam">
+                    View on Steam <SteamLogoIcon size={28}/>
                 </Link>
                 {props.prevHref && (
                     <Link href={props.prevHref} className="btn-ghost" aria-label="Go to previous round">

--- a/frontend/src/components/RoundResultActions.tsx
+++ b/frontend/src/components/RoundResultActions.tsx
@@ -22,8 +22,8 @@ export default function RoundResultActions(props: {
                     rel="noopener noreferrer"
                     className="btn-ghost"
                     aria-label="Open this game on Steam"
-                >
-                    Open in Steam <SteamLogoIcon size={28}/>
+                    data-umami-event="open-on-steam">
+                    Open on Steam <SteamLogoIcon size={28}/>
                 </Link>
                 {props.prevHref && (
                     <Link href={props.prevHref} className="btn-ghost" aria-label="Go to previous round">

--- a/frontend/src/components/ShareControls.tsx
+++ b/frontend/src/components/ShareControls.tsx
@@ -181,8 +181,13 @@ export default function ShareControls(props: {
     if (inline) {
         return (
             <div className="share-inline">
-                <button type="button" className="btn-success" disabled={namesLoading} onClick={copyToClipboard}
-                        title={namesLoading ? 'Preparing…' : undefined}>Share Results <ExportIcon size={28}/>
+                <button
+                    type="button"
+                    className="btn-success"
+                    disabled={namesLoading}
+                    onClick={copyToClipboard}
+                    title={namesLoading ? 'Preparing…' : undefined}
+                    data-umami-event="share-results">Share Results <ExportIcon size={28}/>
                 </button>
                 <span className={`share-copied ${copied ? 'is-visible' : ''}`}>Copied</span>
             </div>
@@ -191,8 +196,13 @@ export default function ShareControls(props: {
     return (
         <div className="review-round__share">
             <div className="share-inline">
-                <button type="button" className="btn-success" disabled={namesLoading} onClick={copyToClipboard}
-                        title={namesLoading ? 'Preparing…' : undefined}>Share Results <ExportIcon size={28}/>
+                <button
+                    type="button"
+                    className="btn-success"
+                    disabled={namesLoading}
+                    onClick={copyToClipboard}
+                    title={namesLoading ? 'Preparing…' : undefined}
+                    data-umami-event="share-results">Share Results <ExportIcon size={28}/>
                 </button>
                 <span className={`share-copied ${copied ? 'is-visible' : ''}`}>Copied</span>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds custom Umami events for key round-result actions and updates the Steam store button copy.

## Changes

- `random-archive-round` — Random archived round CTA
- `view-on-steam` — View on Steam store link
- `share-results` — Share Results button (inline and standalone layouts)
- Rename visible label to "View on Steam" with matching aria-label and event name

## Testing

- Verified `data-umami-event` attributes are present on all three controls
- No functional behavior change beyond analytics tracking and copy update
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f475d-546a-793d-b7e8-10a08be84ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f475d-546a-793d-b7e8-10a08be84ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

