### PR TITLE
feat: implement real-time per-round presence system (#82)

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="postgres@localhost" uuid="53cc000d-35a2-4c08-b7f8-41900867e3ec">
+    <data-source source="LOCAL" name="steam5_db@localhost" uuid="53cc000d-35a2-4c08-b7f8-41900867e3ec">
       <driver-ref>postgresql</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.postgresql.Driver</jdbc-driver>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,6 +22,45 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/backend" />
   </component>
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
+    <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
+    <option name="myOrdered" value="false" />
+    <option name="myNullables">
+      <value>
+        <list size="11">
+          <item index="0" class="java.lang.String" itemvalue="org.jspecify.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="4" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="5" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="jakarta.annotation.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="9" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="10" class="java.lang.String" itemvalue="org.springframework.lang.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="11">
+          <item index="0" class="java.lang.String" itemvalue="org.jspecify.annotations.NonNull" />
+          <item index="1" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="4" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="5" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="jakarta.annotation.Nonnull" />
+          <item index="8" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="9" class="java.lang.String" itemvalue="lombok.NonNull" />
+          <item index="10" class="java.lang.String" itemvalue="org.springframework.lang.NonNull" />
+        </list>
+      </value>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
     runtimeOnly("org.postgresql:postgresql")

--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -88,6 +88,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/seasons/**").permitAll()
                         .requestMatchers("/api/stats/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/ws/**").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 // Fix #5: both custom filters are anchored before BasicAuthenticationFilter.

--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -89,7 +89,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/stats/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/ws/**").permitAll()
-                        .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/ws/presence").permitAll()
                         .anyRequest().authenticated()
                 )
                 // Fix #5: both custom filters are anchored before BasicAuthenticationFilter.

--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -88,7 +88,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/seasons/**").permitAll()
                         .requestMatchers("/api/stats/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/ws/**").permitAll()
+                        .requestMatchers("/api/ws/ticket").permitAll()
                         .requestMatchers("/ws/presence").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Configuration
@@ -52,6 +53,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
      */
     static class PresenceHandshakeInterceptor implements HandshakeInterceptor {
 
+        private static final Pattern SCOPE_KEY_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}:\\d+:\\d+$");
         private final List<String> allowedOrigins;
 
         PresenceHandshakeInterceptor(final List<String> allowedOrigins) {
@@ -76,6 +78,11 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
             if (scopeKey == null || scopeKey.isBlank()) {
                 log.debug("Rejecting presence handshake — missing scopeKey");
+                return false;
+            }
+
+            if (!SCOPE_KEY_PATTERN.matcher(scopeKey).matches()) {
+                log.debug("Rejecting presence handshake — malformed scopeKey '{}'", scopeKey);
                 return false;
             }
 

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -65,6 +65,12 @@ public class WebSocketConfig implements WebSocketConfigurer {
                                        final ServerHttpResponse response,
                                        final WebSocketHandler wsHandler,
                                        final Map<String, Object> attributes) {
+            final String origin = request.getHeaders().getFirst(HttpHeaders.ORIGIN);
+            if (origin == null || !isAllowed(origin)) {
+                log.debug("Rejecting presence handshake — origin '{}' not in allow-list", origin);
+                return false;
+            }
+
             final URI uri = request.getURI();
             final String query = uri.getRawQuery();
             final String scopeKey = extractParam(query, "scopeKey");
@@ -85,6 +91,13 @@ public class WebSocketConfig implements WebSocketConfigurer {
                 attributes.put("ticket", ticket);
             }
             return true;
+        }
+
+        private boolean isAllowed(final String origin) {
+            for (final String allowed : allowedOrigins) {
+                if (allowed.equals(origin) || "*".equals(allowed)) return true;
+            }
+            return false;
         }
 
         @Override

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -53,7 +53,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
      */
     static class PresenceHandshakeInterceptor implements HandshakeInterceptor {
 
-        private static final Pattern SCOPE_KEY_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}:\\d+:\\d+$");
+        private static final Pattern SCOPE_KEY_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}(:\\d+:\\d+)?$");
         private final List<String> allowedOrigins;
 
         PresenceHandshakeInterceptor(final List<String> allowedOrigins) {

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -65,12 +65,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
                                        final ServerHttpResponse response,
                                        final WebSocketHandler wsHandler,
                                        final Map<String, Object> attributes) {
-            final String origin = request.getHeaders().getFirst(HttpHeaders.ORIGIN);
-            if (origin == null || !isAllowed(origin)) {
-                log.debug("Rejecting presence handshake — origin '{}' not in allow-list", origin);
-                return false;
-            }
-
             final URI uri = request.getURI();
             final String query = uri.getRawQuery();
             final String scopeKey = extractParam(query, "scopeKey");
@@ -101,13 +95,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
             // no-op
         }
 
-        private boolean isAllowed(final String origin) {
-            for (final String allowed : allowedOrigins) {
-                if (allowed.equals(origin) || "*".equals(allowed)) return true;
-            }
-            return false;
-        }
-
         private static String extractParam(final String query, final String name) {
             if (query == null || query.isEmpty()) return null;
             for (final String pair : query.split("&")) {
@@ -116,7 +103,11 @@ public class WebSocketConfig implements WebSocketConfigurer {
                 final String key = pair.substring(0, eq);
                 if (!name.equals(key)) continue;
                 final String rawValue = pair.substring(eq + 1);
-                return java.net.URLDecoder.decode(rawValue, java.nio.charset.StandardCharsets.UTF_8);
+                try {
+                    return java.net.URLDecoder.decode(rawValue, java.nio.charset.StandardCharsets.UTF_8);
+                } catch (IllegalArgumentException e) {
+                    return null;
+                }
             }
             return null;
         }

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -1,0 +1,117 @@
+package org.steam5.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.steam5.service.RoundPresenceService;
+import org.steam5.web.ws.PresenceWebSocketHandler;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final PresenceWebSocketHandler presenceHandler;
+    private final List<String> allowedOrigins;
+
+    public WebSocketConfig(
+            final PresenceWebSocketHandler presenceHandler,
+            @Value("${cors.allowedOrigins:https://steam5.org,https://next.steam5.org,http://localhost:3000}") final String originsCsv
+    ) {
+        this.presenceHandler = presenceHandler;
+        this.allowedOrigins = Arrays.stream(originsCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    @Override
+    public void registerWebSocketHandlers(final WebSocketHandlerRegistry registry) {
+        registry.addHandler(presenceHandler, "/ws/presence")
+                .addInterceptors(new PresenceHandshakeInterceptor(allowedOrigins))
+                .setAllowedOriginPatterns(allowedOrigins.toArray(new String[0]));
+    }
+
+    /**
+     * Validates the {@code Origin} header against the configured allow-list and
+     * copies the {@code scopeKey} and {@code ticket} query parameters into the
+     * WebSocket session attributes so the handler can read them at connection time.
+     */
+    static class PresenceHandshakeInterceptor implements HandshakeInterceptor {
+
+        private final List<String> allowedOrigins;
+
+        PresenceHandshakeInterceptor(final List<String> allowedOrigins) {
+            this.allowedOrigins = allowedOrigins;
+        }
+
+        @Override
+        public boolean beforeHandshake(final ServerHttpRequest request,
+                                       final ServerHttpResponse response,
+                                       final WebSocketHandler wsHandler,
+                                       final Map<String, Object> attributes) {
+            final String origin = request.getHeaders().getFirst(HttpHeaders.ORIGIN);
+            if (origin == null || !isAllowed(origin)) {
+                log.debug("Rejecting presence handshake — origin '{}' not in allow-list", origin);
+                return false;
+            }
+
+            final URI uri = request.getURI();
+            final String query = uri.getRawQuery();
+            final String scopeKey = extractParam(query, "scopeKey");
+            final String ticket = extractParam(query, "ticket");
+
+            if (scopeKey == null || scopeKey.isBlank()) {
+                log.debug("Rejecting presence handshake — missing scopeKey");
+                return false;
+            }
+
+            attributes.put(RoundPresenceService.ATTR_SCOPE_KEY, scopeKey);
+            if (ticket != null && !ticket.isBlank()) {
+                attributes.put("ticket", ticket);
+            }
+            return true;
+        }
+
+        @Override
+        public void afterHandshake(final ServerHttpRequest request,
+                                   final ServerHttpResponse response,
+                                   final WebSocketHandler wsHandler,
+                                   final Exception exception) {
+            // no-op
+        }
+
+        private boolean isAllowed(final String origin) {
+            for (final String allowed : allowedOrigins) {
+                if (allowed.equals(origin) || "*".equals(allowed)) return true;
+            }
+            return false;
+        }
+
+        private static String extractParam(final String query, final String name) {
+            if (query == null || query.isEmpty()) return null;
+            for (final String pair : query.split("&")) {
+                final int eq = pair.indexOf('=');
+                if (eq < 0) continue;
+                final String key = pair.substring(0, eq);
+                if (!name.equals(key)) continue;
+                final String rawValue = pair.substring(eq + 1);
+                return java.net.URLDecoder.decode(rawValue, java.nio.charset.StandardCharsets.UTF_8);
+            }
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/org/steam5/service/RoundPresenceService.java
+++ b/backend/src/main/java/org/steam5/service/RoundPresenceService.java
@@ -1,0 +1,138 @@
+package org.steam5.service;
+
+import lombok.RequiredArgsConstructor;
+import tools.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * In-memory registry of active WebSocket sessions per round scope. Broadcasts
+ * per-scope presence snapshots when membership changes.
+ *
+ * <p>Session attribute keys (populated by the handshake interceptor and the
+ * WebSocket handler at connection time):</p>
+ * <ul>
+ *   <li>{@link #ATTR_SCOPE_KEY} — round scope in the form {@code gameDate:roundIndex:appId}</li>
+ *   <li>{@link #ATTR_STEAM_ID} — verified steamId, or {@code null} for anonymous</li>
+ *   <li>{@link #ATTR_PERSONA_NAME} — display name (authenticated only)</li>
+ *   <li>{@link #ATTR_AVATAR} — avatar URL (authenticated only)</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoundPresenceService {
+
+    public static final String ATTR_SCOPE_KEY = "scopeKey";
+    public static final String ATTR_STEAM_ID = "steamId";
+    public static final String ATTR_PERSONA_NAME = "personaName";
+    public static final String ATTR_AVATAR = "avatar";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ConcurrentHashMap<String, CopyOnWriteArrayList<WebSocketSession>> sessionsByScope =
+            new ConcurrentHashMap<>();
+
+    public void register(final WebSocketSession session) {
+        final String scopeKey = scopeKeyOf(session);
+        if (scopeKey == null) return;
+        sessionsByScope
+                .computeIfAbsent(scopeKey, k -> new CopyOnWriteArrayList<>())
+                .add(session);
+    }
+
+    public void unregister(final WebSocketSession session) {
+        final String scopeKey = scopeKeyOf(session);
+        if (scopeKey == null) return;
+        final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
+        if (list == null) return;
+        list.remove(session);
+        if (list.isEmpty()) {
+            sessionsByScope.remove(scopeKey, list);
+        }
+    }
+
+    public void broadcastSnapshot(final String scopeKey) {
+        if (scopeKey == null) return;
+        final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
+        if (list == null || list.isEmpty()) return;
+
+        final Snapshot snapshot = computeSnapshot(list);
+        final String payload;
+        try {
+            payload = objectMapper.writeValueAsString(snapshot);
+        } catch (RuntimeException e) {
+            log.warn("Failed to serialize presence snapshot for scope {}", scopeKey, e);
+            return;
+        }
+
+        final TextMessage message = new TextMessage(payload);
+        for (final WebSocketSession session : list) {
+            if (!session.isOpen()) {
+                list.remove(session);
+                continue;
+            }
+            try {
+                session.sendMessage(message);
+            } catch (IOException | IllegalStateException e) {
+                log.debug("Pruning failed presence session {} for scope {}: {}",
+                        session.getId(), scopeKey, e.toString());
+                list.remove(session);
+            }
+        }
+    }
+
+    Snapshot computeSnapshot(final List<WebSocketSession> sessions) {
+        int totalCount = 0;
+        int anonymousCount = 0;
+        // LinkedHashMap keeps insertion order — stable output for tests and clients.
+        final Map<String, PlayerInfo> playersById = new LinkedHashMap<>();
+
+        for (final WebSocketSession session : sessions) {
+            if (!session.isOpen()) continue;
+            totalCount++;
+            final String steamId = (String) session.getAttributes().get(ATTR_STEAM_ID);
+            if (steamId == null || steamId.isBlank()) {
+                anonymousCount++;
+                continue;
+            }
+            playersById.computeIfAbsent(steamId, id -> new PlayerInfo(
+                    id,
+                    (String) session.getAttributes().get(ATTR_PERSONA_NAME),
+                    (String) session.getAttributes().get(ATTR_AVATAR)
+            ));
+        }
+
+        return new Snapshot(totalCount, anonymousCount, new ArrayList<>(playersById.values()));
+    }
+
+    int scopeSize(final String scopeKey) {
+        final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
+        return list == null ? 0 : list.size();
+    }
+
+    List<WebSocketSession> sessionsFor(final String scopeKey) {
+        final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
+        return list == null ? Collections.emptyList() : Collections.unmodifiableList(list);
+    }
+
+    private static String scopeKeyOf(final WebSocketSession session) {
+        return (String) session.getAttributes().get(ATTR_SCOPE_KEY);
+    }
+
+    public record PlayerInfo(String steamId, String personaName, String avatar) {
+    }
+
+    public record Snapshot(int totalCount, int anonymousCount, List<PlayerInfo> players) {
+    }
+}

--- a/backend/src/main/java/org/steam5/service/RoundPresenceService.java
+++ b/backend/src/main/java/org/steam5/service/RoundPresenceService.java
@@ -54,7 +54,7 @@ public class RoundPresenceService {
     public void unregister(final WebSocketSession session) {
         final String scopeKey = scopeKeyOf(session);
         if (scopeKey == null) return;
-        sessionsByScope.compute(scopeKey, (k, list) -> {
+        sessionsByScope.computeIfPresent(scopeKey, (k, list) -> {
             list.remove(session);
             return list.isEmpty() ? null : list;
         });

--- a/backend/src/main/java/org/steam5/service/RoundPresenceService.java
+++ b/backend/src/main/java/org/steam5/service/RoundPresenceService.java
@@ -54,12 +54,10 @@ public class RoundPresenceService {
     public void unregister(final WebSocketSession session) {
         final String scopeKey = scopeKeyOf(session);
         if (scopeKey == null) return;
-        final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
-        if (list == null) return;
-        list.remove(session);
-        if (list.isEmpty()) {
-            sessionsByScope.remove(scopeKey, list);
-        }
+        sessionsByScope.compute(scopeKey, (k, list) -> {
+            list.remove(session);
+            return list.isEmpty() ? null : list;
+        });
     }
 
     public void broadcastSnapshot(final String scopeKey) {
@@ -67,23 +65,28 @@ public class RoundPresenceService {
         final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
         if (list == null || list.isEmpty()) return;
 
-        final Snapshot snapshot = computeSnapshot(list);
-        final String payload;
+        final Snapshot fullSnapshot = computeSnapshot(list);
+        final Snapshot countsOnly = new Snapshot(fullSnapshot.totalCount(), fullSnapshot.anonymousCount(), List.of());
+        final String fullPayload;
+        final String countsPayload;
         try {
-            payload = objectMapper.writeValueAsString(snapshot);
+            fullPayload = objectMapper.writeValueAsString(fullSnapshot);
+            countsPayload = objectMapper.writeValueAsString(countsOnly);
         } catch (RuntimeException e) {
             log.warn("Failed to serialize presence snapshot for scope {}", scopeKey, e);
             return;
         }
 
-        final TextMessage message = new TextMessage(payload);
+        final TextMessage fullMessage = new TextMessage(fullPayload);
+        final TextMessage countsMessage = new TextMessage(countsPayload);
         for (final WebSocketSession session : list) {
             if (!session.isOpen()) {
                 list.remove(session);
                 continue;
             }
             try {
-                session.sendMessage(message);
+                final boolean anonymous = session.getAttributes().get(ATTR_STEAM_ID) == null;
+                session.sendMessage(anonymous ? countsMessage : fullMessage);
             } catch (IOException | IllegalStateException e) {
                 log.debug("Pruning failed presence session {} for scope {}: {}",
                         session.getId(), scopeKey, e.toString());

--- a/backend/src/main/java/org/steam5/service/RoundPresenceService.java
+++ b/backend/src/main/java/org/steam5/service/RoundPresenceService.java
@@ -39,7 +39,7 @@ public class RoundPresenceService {
     public static final String ATTR_PERSONA_NAME = "personaName";
     public static final String ATTR_AVATAR = "avatar";
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
     private final ConcurrentHashMap<String, CopyOnWriteArrayList<WebSocketSession>> sessionsByScope =
             new ConcurrentHashMap<>();
 

--- a/backend/src/main/java/org/steam5/service/SeasonCreatorService.java
+++ b/backend/src/main/java/org/steam5/service/SeasonCreatorService.java
@@ -1,0 +1,57 @@
+package org.steam5.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.steam5.config.SeasonProperties;
+import org.steam5.domain.Season;
+import org.steam5.domain.SeasonStatus;
+import org.steam5.repository.SeasonRepository;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+class SeasonCreatorService {
+
+    private final SeasonRepository seasonRepository;
+    private final SeasonProperties seasonProperties;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Season createSeasonsUntil(LocalDate date) {
+        Season last = seasonRepository.findTopByOrderBySeasonNumberDesc().orElse(null);
+        if (last == null) {
+            LocalDate startDate = date;
+            return seasonRepository.save(buildSeason(1, startDate, SeasonStatus.ACTIVE));
+        }
+
+        Season current = last;
+        int nextNumber = last.getSeasonNumber() + 1;
+        LocalDate nextStart = last.getEndDate().plusDays(1);
+        while (current.getEndDate().isBefore(date)) {
+            current = seasonRepository.save(buildSeason(nextNumber++, nextStart, SeasonStatus.ACTIVE));
+            nextStart = current.getEndDate().plusDays(1);
+        }
+        return current;
+    }
+
+    private Season buildSeason(int seasonNumber, LocalDate startDate, SeasonStatus status) {
+        Season season = new Season();
+        season.setSeasonNumber(seasonNumber);
+        season.setStartDate(startDate);
+        season.setEndDate(startDate.plusDays(seasonLengthDays() - 1L));
+        season.setStatus(status);
+        season.setAwardSeed(ThreadLocalRandom.current().nextLong(Long.MAX_VALUE));
+        season.setAwardsFinalizedAt(null);
+        season.setCreatedAt(OffsetDateTime.now());
+        season.setUpdatedAt(OffsetDateTime.now());
+        return season;
+    }
+
+    private int seasonLengthDays() {
+        return Math.max(1, seasonProperties.getLengthDays());
+    }
+}

--- a/backend/src/main/java/org/steam5/service/SeasonService.java
+++ b/backend/src/main/java/org/steam5/service/SeasonService.java
@@ -35,6 +35,7 @@ public class SeasonService {
     private final SeasonAwardResultRepository awardResultRepository;
     private final GuessRepository guessRepository;
     private final SeasonProperties seasonProperties;
+    private final SeasonCreatorService seasonCreator;
 
     private static final int TIE_ROLL_MAX = 1_000_000;
 
@@ -149,7 +150,7 @@ public class SeasonService {
         return seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date)
                 .orElseGet(() -> {
                     try {
-                        return createSeasonsUntil(date);
+                        return seasonCreator.createSeasonsUntil(date);
                     } catch (DataIntegrityViolationException e) {
                         return seasonRepository
                                 .findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date)
@@ -229,23 +230,6 @@ public class SeasonService {
         managed.setAwardsFinalizedAt(OffsetDateTime.now());
         managed.setUpdatedAt(OffsetDateTime.now());
         return seasonRepository.save(managed);
-    }
-
-    private Season createSeasonsUntil(LocalDate date) {
-        Season last = seasonRepository.findTopByOrderBySeasonNumberDesc().orElse(null);
-        if (last == null) {
-            LocalDate startDate = date;
-            return seasonRepository.save(buildSeason(1, startDate, SeasonStatus.ACTIVE));
-        }
-
-        Season current = last;
-        int nextNumber = last.getSeasonNumber() + 1;
-        LocalDate nextStart = last.getEndDate().plusDays(1);
-        while (current.getEndDate().isBefore(date)) {
-            current = seasonRepository.save(buildSeason(nextNumber++, nextStart, SeasonStatus.ACTIVE));
-            nextStart = current.getEndDate().plusDays(1);
-        }
-        return current;
     }
 
     private Season buildSeason(int seasonNumber, LocalDate startDate, SeasonStatus status) {

--- a/backend/src/main/java/org/steam5/service/SeasonService.java
+++ b/backend/src/main/java/org/steam5/service/SeasonService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.steam5.config.SeasonProperties;
@@ -146,7 +147,15 @@ public class SeasonService {
         Objects.requireNonNull(date, "date");
 
         return seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date)
-                .orElseGet(() -> createSeasonsUntil(date));
+                .orElseGet(() -> {
+                    try {
+                        return createSeasonsUntil(date);
+                    } catch (DataIntegrityViolationException e) {
+                        return seasonRepository
+                                .findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date)
+                                .orElseThrow(() -> new IllegalStateException("Season missing after conflict", e));
+                    }
+                });
     }
 
     @Transactional

--- a/backend/src/main/java/org/steam5/service/WsTicketService.java
+++ b/backend/src/main/java/org/steam5/service/WsTicketService.java
@@ -39,9 +39,8 @@ public class WsTicketService {
 
     public String validateTicket(final String ticket) {
         if (ticket == null) return null;
-        final String steamId = tickets.getIfPresent(ticket);
+        final String steamId = tickets.asMap().remove(ticket);
         if (steamId != null) {
-            tickets.invalidate(ticket);
             log.info("WS ticket validated successfully for steamId={}", steamId);
         } else {
             log.warn("WS ticket validation failed — ticket not found or expired");

--- a/backend/src/main/java/org/steam5/service/WsTicketService.java
+++ b/backend/src/main/java/org/steam5/service/WsTicketService.java
@@ -1,0 +1,46 @@
+package org.steam5.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Issues and validates short-lived, one-time tickets used to authenticate
+ * WebSocket handshakes. Browsers cannot attach the {@code Authorization}
+ * header to native WS handshakes, so authenticated clients first exchange
+ * their bearer token for a ticket via {@code POST /api/ws/ticket} and then
+ * include that ticket as a query parameter on the WS URL.
+ *
+ * <p>Tickets are stored in an in-memory Caffeine cache keyed by the opaque
+ * ticket string. Entries expire 30 seconds after issue and each ticket is
+ * consumed on first validation to prevent reuse.</p>
+ */
+@Service
+public class WsTicketService {
+
+    private static final long TICKET_TTL_SECONDS = 30L;
+    private static final long TICKET_MAX_SIZE = 500L;
+
+    private final Cache<String, String> tickets = Caffeine.newBuilder()
+            .expireAfterWrite(TICKET_TTL_SECONDS, TimeUnit.SECONDS)
+            .maximumSize(TICKET_MAX_SIZE)
+            .build();
+
+    public String issueTicket(final String steamId) {
+        final String ticket = UUID.randomUUID().toString();
+        tickets.put(ticket, steamId);
+        return ticket;
+    }
+
+    public String validateTicket(final String ticket) {
+        if (ticket == null) return null;
+        final String steamId = tickets.getIfPresent(ticket);
+        if (steamId != null) {
+            tickets.invalidate(ticket);
+        }
+        return steamId;
+    }
+}

--- a/backend/src/main/java/org/steam5/service/WsTicketService.java
+++ b/backend/src/main/java/org/steam5/service/WsTicketService.java
@@ -2,6 +2,7 @@ package org.steam5.service;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -18,6 +19,7 @@ import java.util.concurrent.TimeUnit;
  * ticket string. Entries expire 30 seconds after issue and each ticket is
  * consumed on first validation to prevent reuse.</p>
  */
+@Slf4j
 @Service
 public class WsTicketService {
 
@@ -40,6 +42,9 @@ public class WsTicketService {
         final String steamId = tickets.getIfPresent(ticket);
         if (steamId != null) {
             tickets.invalidate(ticket);
+            log.info("WS ticket validated successfully for steamId={}", steamId);
+        } else {
+            log.warn("WS ticket validation failed — ticket not found or expired");
         }
         return steamId;
     }

--- a/backend/src/main/java/org/steam5/web/PresenceAuthController.java
+++ b/backend/src/main/java/org/steam5/web/PresenceAuthController.java
@@ -1,0 +1,36 @@
+package org.steam5.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.steam5.security.CurrentUser;
+import org.steam5.service.WsTicketService;
+
+import java.util.Map;
+
+/**
+ * Exchanges an authenticated bearer token for a short-lived WebSocket
+ * handshake ticket. Browsers cannot attach {@code Authorization} headers
+ * to native WS handshakes, so clients call {@code POST /api/ws/ticket}
+ * and then include the returned ticket as a query parameter on the WS URL.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ws")
+public class PresenceAuthController {
+
+    private final WsTicketService wsTicketService;
+
+    @PostMapping("/ticket")
+    public ResponseEntity<?> issueTicket(@CurrentUser String steamId) {
+        if (steamId == null) {
+            return ResponseEntity.status(401).body(Map.of("error", "unauthenticated"));
+        }
+        final String ticket = wsTicketService.issueTicket(steamId);
+        return ResponseEntity.ok()
+                .header("Cache-Control", "no-store")
+                .body(Map.of("ticket", ticket));
+    }
+}

--- a/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
@@ -1,0 +1,66 @@
+package org.steam5.web.ws;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+import org.steam5.domain.User;
+import org.steam5.repository.UserRepository;
+import org.steam5.service.RoundPresenceService;
+import org.steam5.service.WsTicketService;
+
+import java.util.Optional;
+
+/**
+ * WebSocket handler for the per-round presence endpoint. Resolves the
+ * connecting identity from the handshake ticket, registers the session with
+ * {@link RoundPresenceService}, and rebroadcasts the snapshot on join/leave.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PresenceWebSocketHandler extends TextWebSocketHandler {
+
+    private final RoundPresenceService presenceService;
+    private final WsTicketService wsTicketService;
+    private final UserRepository userRepository;
+
+    @Override
+    public void afterConnectionEstablished(final WebSocketSession session) {
+        final String scopeKey = (String) session.getAttributes().get(RoundPresenceService.ATTR_SCOPE_KEY);
+        final String ticket = (String) session.getAttributes().get("ticket");
+
+        final String steamId = ticket == null ? null : wsTicketService.validateTicket(ticket);
+        if (steamId != null) {
+            session.getAttributes().put(RoundPresenceService.ATTR_STEAM_ID, steamId);
+            try {
+                final Optional<User> user = userRepository.findById(steamId);
+                user.ifPresent(u -> {
+                    session.getAttributes().put(RoundPresenceService.ATTR_PERSONA_NAME, u.getPersonaName());
+                    session.getAttributes().put(RoundPresenceService.ATTR_AVATAR, u.getAvatar());
+                });
+            } catch (Exception e) {
+                log.debug("Failed to load user {} for presence session {}: {}",
+                        steamId, session.getId(), e.toString());
+            }
+        }
+
+        presenceService.register(session);
+        presenceService.broadcastSnapshot(scopeKey);
+    }
+
+    @Override
+    public void afterConnectionClosed(final WebSocketSession session, final CloseStatus status) {
+        final String scopeKey = (String) session.getAttributes().get(RoundPresenceService.ATTR_SCOPE_KEY);
+        presenceService.unregister(session);
+        presenceService.broadcastSnapshot(scopeKey);
+    }
+
+    @Override
+    public void handleTransportError(final WebSocketSession session, final Throwable exception) {
+        log.warn("Presence WebSocket transport error on session {}: {}", session.getId(), exception.toString());
+        presenceService.unregister(session);
+    }
+}

--- a/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
@@ -39,7 +39,9 @@ public class PresenceWebSocketHandler extends TextWebSocketHandler {
                 final Optional<User> user = userRepository.findById(steamId);
                 user.ifPresent(u -> {
                     session.getAttributes().put(RoundPresenceService.ATTR_PERSONA_NAME, u.getPersonaName());
-                    session.getAttributes().put(RoundPresenceService.ATTR_AVATAR, u.getAvatar());
+                    final String avatarUrl = (u.getAvatarFull() != null && !u.getAvatarFull().isBlank())
+                            ? u.getAvatarFull() : u.getAvatar();
+                    session.getAttributes().put(RoundPresenceService.ATTR_AVATAR, avatarUrl);
                 });
             } catch (Exception e) {
                 log.debug("Failed to load user {} for presence session {}: {}",

--- a/backend/src/main/resources/db/migration/V10_add_season_dates_unique_constraint.sql
+++ b/backend/src/main/resources/db/migration/V10_add_season_dates_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE seasons ADD CONSTRAINT uq_seasons_dates UNIQUE (start_date, end_date);

--- a/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
@@ -2,8 +2,10 @@ package org.steam5.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -125,6 +127,33 @@ class RoundPresenceServiceTest {
     @Test
     void broadcastIsSafeWhenScopeHasNoSessions() {
         assertDoesNotThrow(() -> service.broadcastSnapshot("unknownScope"));
+    }
+
+    @Test
+    void broadcastSendsCountsOnlyToAnonymousSessions() throws IOException {
+        final WebSocketSession authed = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
+        final WebSocketSession anon = sessionFor("scopeA", null, null, null);
+
+        service.register(authed);
+        service.register(anon);
+        service.broadcastSnapshot("scopeA");
+
+        // Authenticated session receives full snapshot
+        final var authedCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(authed).sendMessage(authedCaptor.capture());
+        final var authedSnapshot = new ObjectMapper().readValue(
+                authedCaptor.getValue().getPayload(), RoundPresenceService.Snapshot.class);
+        assertEquals(2, authedSnapshot.totalCount());
+        assertEquals(1, authedSnapshot.players().size());
+
+        // Anonymous session receives counts-only snapshot
+        final var anonCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(anon).sendMessage(anonCaptor.capture());
+        final var anonSnapshot = new ObjectMapper().readValue(
+                anonCaptor.getValue().getPayload(), RoundPresenceService.Snapshot.class);
+        assertEquals(2, anonSnapshot.totalCount());
+        assertEquals(1, anonSnapshot.anonymousCount());
+        assertTrue(anonSnapshot.players().isEmpty());
     }
 
     private static final AtomicInteger SESSION_ID = new AtomicInteger();

--- a/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
@@ -23,7 +23,7 @@ class RoundPresenceServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new RoundPresenceService();
+        service = new RoundPresenceService(new ObjectMapper());
     }
 
     @Test

--- a/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
@@ -1,0 +1,148 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class RoundPresenceServiceTest {
+
+    private RoundPresenceService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RoundPresenceService();
+    }
+
+    @Test
+    void registerAddsSessionToItsScope() {
+        final WebSocketSession session = sessionFor("2026-07-12:1:730", null, null, null);
+
+        service.register(session);
+
+        assertEquals(1, service.scopeSize("2026-07-12:1:730"));
+        assertEquals(0, service.scopeSize("2026-07-12:1:570"));
+    }
+
+    @Test
+    void registerIsolatesScopesFromEachOther() {
+        final WebSocketSession scopeA1 = sessionFor("scopeA", null, null, null);
+        final WebSocketSession scopeA2 = sessionFor("scopeA", null, null, null);
+        final WebSocketSession scopeB1 = sessionFor("scopeB", null, null, null);
+
+        service.register(scopeA1);
+        service.register(scopeA2);
+        service.register(scopeB1);
+
+        assertEquals(2, service.scopeSize("scopeA"));
+        assertEquals(1, service.scopeSize("scopeB"));
+    }
+
+    @Test
+    void unregisterRemovesSessionFromScope() {
+        final WebSocketSession session = sessionFor("scopeA", null, null, null);
+        service.register(session);
+        assertEquals(1, service.scopeSize("scopeA"));
+
+        service.unregister(session);
+
+        assertEquals(0, service.scopeSize("scopeA"));
+    }
+
+    @Test
+    void snapshotDeduplicatesAuthenticatedPlayersBySteamId() {
+        final WebSocketSession tab1 = sessionFor("scopeA", "76561", "Alice", "http://avatar/alice");
+        final WebSocketSession tab2 = sessionFor("scopeA", "76561", "Alice", "http://avatar/alice");
+        final WebSocketSession tab3 = sessionFor("scopeA", "99999", "Bob", "http://avatar/bob");
+        final WebSocketSession anon = sessionFor("scopeA", null, null, null);
+
+        final RoundPresenceService.Snapshot snapshot =
+                service.computeSnapshot(List.of(tab1, tab2, tab3, anon));
+
+        assertEquals(4, snapshot.totalCount());
+        assertEquals(1, snapshot.anonymousCount());
+        assertEquals(2, snapshot.players().size());
+        assertEquals(List.of("76561", "99999"),
+                snapshot.players().stream().map(RoundPresenceService.PlayerInfo::steamId).toList());
+    }
+
+    @Test
+    void snapshotSkipsClosedSessions() {
+        final WebSocketSession open = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
+        final WebSocketSession closed = sessionFor("scopeA", "2", "Bob", "http://avatar/b");
+        when(closed.isOpen()).thenReturn(false);
+
+        final RoundPresenceService.Snapshot snapshot =
+                service.computeSnapshot(List.of(open, closed));
+
+        assertEquals(1, snapshot.totalCount());
+        assertEquals(1, snapshot.players().size());
+        assertEquals("1", snapshot.players().get(0).steamId());
+    }
+
+    @Test
+    void broadcastPrunesClosedSessions() {
+        final WebSocketSession open = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
+        final WebSocketSession closed = sessionFor("scopeA", "2", "Bob", "http://avatar/b");
+        when(closed.isOpen()).thenReturn(false);
+
+        service.register(open);
+        service.register(closed);
+        assertEquals(2, service.scopeSize("scopeA"));
+
+        service.broadcastSnapshot("scopeA");
+
+        assertEquals(1, service.scopeSize("scopeA"));
+        assertTrue(service.sessionsFor("scopeA").contains(open));
+    }
+
+    @Test
+    void broadcastPrunesSessionsThatFailToSend() throws IOException {
+        final WebSocketSession healthy = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
+        final WebSocketSession faulty = sessionFor("scopeA", "2", "Bob", "http://avatar/b");
+        doThrow(new IOException("boom")).when(faulty).sendMessage(any(TextMessage.class));
+
+        service.register(healthy);
+        service.register(faulty);
+
+        service.broadcastSnapshot("scopeA");
+
+        assertEquals(1, service.scopeSize("scopeA"));
+        assertFalse(service.sessionsFor("scopeA").contains(faulty));
+        verify(healthy, atLeastOnce()).sendMessage(any(TextMessage.class));
+    }
+
+    @Test
+    void broadcastIsSafeWhenScopeHasNoSessions() {
+        assertDoesNotThrow(() -> service.broadcastSnapshot("unknownScope"));
+    }
+
+    private static final AtomicInteger SESSION_ID = new AtomicInteger();
+
+    private static WebSocketSession sessionFor(final String scopeKey,
+                                               final String steamId,
+                                               final String personaName,
+                                               final String avatar) {
+        final Map<String, Object> attrs = new HashMap<>();
+        attrs.put(RoundPresenceService.ATTR_SCOPE_KEY, scopeKey);
+        if (steamId != null) attrs.put(RoundPresenceService.ATTR_STEAM_ID, steamId);
+        if (personaName != null) attrs.put(RoundPresenceService.ATTR_PERSONA_NAME, personaName);
+        if (avatar != null) attrs.put(RoundPresenceService.ATTR_AVATAR, avatar);
+
+        final WebSocketSession session = mock(WebSocketSession.class);
+        when(session.getAttributes()).thenReturn(attrs);
+        when(session.isOpen()).thenReturn(true);
+        when(session.getId()).thenReturn("session-" + SESSION_ID.incrementAndGet());
+        return session;
+    }
+}

--- a/backend/src/test/java/org/steam5/service/SeasonCreatorServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/SeasonCreatorServiceTest.java
@@ -1,0 +1,105 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.steam5.config.SeasonProperties;
+import org.steam5.domain.Season;
+import org.steam5.domain.SeasonStatus;
+import org.steam5.repository.SeasonRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SeasonCreatorServiceTest {
+
+    private SeasonRepository seasonRepository;
+    private SeasonProperties seasonProperties;
+    private SeasonCreatorService service;
+
+    @BeforeEach
+    void setUp() {
+        seasonRepository = mock(SeasonRepository.class);
+        seasonProperties = new SeasonProperties();
+        seasonProperties.setLengthDays(7);
+        service = new SeasonCreatorService(seasonRepository, seasonProperties);
+
+        when(seasonRepository.save(any(Season.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void createSeasonsUntil_createsFirstSeasonWhenNoneExist() {
+        when(seasonRepository.findTopByOrderBySeasonNumberDesc()).thenReturn(Optional.empty());
+        final LocalDate date = LocalDate.of(2026, 1, 1);
+
+        final Season result = service.createSeasonsUntil(date);
+
+        final ArgumentCaptor<Season> captor = ArgumentCaptor.forClass(Season.class);
+        verify(seasonRepository, times(1)).save(captor.capture());
+        final Season saved = captor.getValue();
+        assertEquals(1, saved.getSeasonNumber());
+        assertEquals(date, saved.getStartDate());
+        assertEquals(date.plusDays(6), saved.getEndDate());
+        assertEquals(SeasonStatus.ACTIVE, saved.getStatus());
+        assertSame(saved, result);
+    }
+
+    @Test
+    void createSeasonsUntil_returnsExistingSeasonWhenDateIsWithinIt() {
+        // Use a 30-day season for this scenario so 2026-01-15 falls within it.
+        seasonProperties.setLengthDays(30);
+        final Season existing = new Season();
+        existing.setSeasonNumber(1);
+        existing.setStartDate(LocalDate.of(2026, 1, 1));
+        existing.setEndDate(LocalDate.of(2026, 1, 30));
+        existing.setStatus(SeasonStatus.ACTIVE);
+        when(seasonRepository.findTopByOrderBySeasonNumberDesc()).thenReturn(Optional.of(existing));
+
+        final Season result = service.createSeasonsUntil(LocalDate.of(2026, 1, 15));
+
+        assertSame(existing, result);
+        verify(seasonRepository, never()).save(any());
+    }
+
+    @Test
+    void createSeasonsUntil_createsOneGapSeason() {
+        final Season last = new Season();
+        last.setSeasonNumber(1);
+        last.setStartDate(LocalDate.of(2026, 1, 1));
+        last.setEndDate(LocalDate.of(2026, 1, 30));
+        when(seasonRepository.findTopByOrderBySeasonNumberDesc()).thenReturn(Optional.of(last));
+
+        // Length is 7 days, so next season 2026-01-31..2026-02-06 covers 2026-02-06? No, need to reach 2026-02-15.
+        // Let's use a date within a single 7-day gap season: 2026-02-05 is within 2026-01-31..2026-02-06.
+        final Season result = service.createSeasonsUntil(LocalDate.of(2026, 2, 5));
+
+        final ArgumentCaptor<Season> captor = ArgumentCaptor.forClass(Season.class);
+        verify(seasonRepository, times(1)).save(captor.capture());
+        final Season saved = captor.getValue();
+        assertEquals(2, saved.getSeasonNumber());
+        assertEquals(LocalDate.of(2026, 1, 31), saved.getStartDate());
+        assertEquals(LocalDate.of(2026, 2, 6), saved.getEndDate());
+        assertSame(saved, result);
+    }
+
+    @Test
+    void createSeasonsUntil_chainsMultipleGapSeasons() {
+        final Season last = new Season();
+        last.setSeasonNumber(1);
+        last.setStartDate(LocalDate.of(2026, 1, 1));
+        last.setEndDate(LocalDate.of(2026, 1, 30));
+        when(seasonRepository.findTopByOrderBySeasonNumberDesc()).thenReturn(Optional.of(last));
+
+        final LocalDate target = LocalDate.of(2026, 3, 1);
+        final Season result = service.createSeasonsUntil(target);
+
+        verify(seasonRepository, atLeast(2)).save(any(Season.class));
+        assertNotNull(result.getEndDate());
+        assertFalse(result.getEndDate().isBefore(target),
+                "Returned season endDate " + result.getEndDate() + " must be >= " + target);
+    }
+}

--- a/backend/src/test/java/org/steam5/service/SeasonServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/SeasonServiceTest.java
@@ -1,0 +1,179 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.steam5.config.SeasonProperties;
+import org.steam5.domain.Season;
+import org.steam5.domain.SeasonStatus;
+import org.steam5.repository.GuessRepository;
+import org.steam5.repository.SeasonAwardResultRepository;
+import org.steam5.repository.SeasonRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SeasonServiceTest {
+
+    private SeasonRepository seasonRepository;
+    private SeasonAwardResultRepository awardResultRepository;
+    private GuessRepository guessRepository;
+    private SeasonCreatorService seasonCreator;
+    private SeasonProperties seasonProperties;
+    private SeasonService service;
+
+    @BeforeEach
+    void setUp() {
+        seasonRepository = mock(SeasonRepository.class);
+        awardResultRepository = mock(SeasonAwardResultRepository.class);
+        guessRepository = mock(GuessRepository.class);
+        seasonCreator = mock(SeasonCreatorService.class);
+        seasonProperties = new SeasonProperties();
+        service = new SeasonService(seasonRepository, awardResultRepository, guessRepository,
+                seasonProperties, seasonCreator);
+    }
+
+    private static Season seasonWith(int number, LocalDate start, LocalDate end, SeasonStatus status) {
+        Season s = new Season();
+        s.setId((long) number);
+        s.setSeasonNumber(number);
+        s.setStartDate(start);
+        s.setEndDate(end);
+        s.setStatus(status);
+        return s;
+    }
+
+    // ensureSeasonForDate ---------------------------------------------------------------
+
+    @Test
+    void ensureSeasonForDate_returnsExistingSeasonWhenFound() {
+        LocalDate date = LocalDate.of(2026, 1, 15);
+        Season existing = seasonWith(1, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 30), SeasonStatus.ACTIVE);
+        when(seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date))
+                .thenReturn(Optional.of(existing));
+
+        Season result = service.ensureSeasonForDate(date);
+
+        assertSame(existing, result);
+        verify(seasonCreator, never()).createSeasonsUntil(any());
+    }
+
+    @Test
+    void ensureSeasonForDate_callsCreatorWhenNoSeasonFound() {
+        LocalDate date = LocalDate.of(2026, 1, 15);
+        Season created = seasonWith(1, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 30), SeasonStatus.ACTIVE);
+        when(seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date))
+                .thenReturn(Optional.empty());
+        when(seasonCreator.createSeasonsUntil(date)).thenReturn(created);
+
+        Season result = service.ensureSeasonForDate(date);
+
+        assertSame(created, result);
+        verify(seasonCreator, times(1)).createSeasonsUntil(date);
+    }
+
+    @Test
+    void ensureSeasonForDate_retriesOnDataIntegrityViolation() {
+        LocalDate date = LocalDate.of(2026, 1, 15);
+        Season recovered = seasonWith(1, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 30), SeasonStatus.ACTIVE);
+        when(seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(recovered));
+        when(seasonCreator.createSeasonsUntil(date))
+                .thenThrow(new DataIntegrityViolationException("conflict"));
+
+        Season result = service.ensureSeasonForDate(date);
+
+        assertSame(recovered, result);
+        verify(seasonRepository, times(2))
+                .findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date);
+    }
+
+    @Test
+    void ensureSeasonForDate_throwsWhenSecondFindAlsoFails() {
+        LocalDate date = LocalDate.of(2026, 1, 15);
+        when(seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date))
+                .thenReturn(Optional.empty());
+        when(seasonCreator.createSeasonsUntil(date))
+                .thenThrow(new DataIntegrityViolationException("conflict"));
+
+        assertThrows(IllegalStateException.class, () -> service.ensureSeasonForDate(date));
+    }
+
+    @Test
+    void ensureSeasonForDate_throwsOnNullDate() {
+        assertThrows(NullPointerException.class, () -> service.ensureSeasonForDate(null));
+    }
+
+    // findSeasonContaining --------------------------------------------------------------
+
+    @Test
+    void findSeasonContaining_delegatesToRepository() {
+        LocalDate date = LocalDate.of(2026, 5, 10);
+        Season s = seasonWith(2, date.minusDays(3), date.plusDays(3), SeasonStatus.ACTIVE);
+        when(seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date))
+                .thenReturn(Optional.of(s));
+
+        Optional<Season> result = service.findSeasonContaining(date);
+
+        assertTrue(result.isPresent());
+        assertSame(s, result.get());
+        verify(seasonRepository, times(1))
+                .findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date);
+    }
+
+    // listSeasonsDescending -------------------------------------------------------------
+
+    @Test
+    void listSeasonsDescending_returnsRepositoryResult() {
+        List<Season> seasons = List.of(
+                seasonWith(2, LocalDate.of(2026, 2, 1), LocalDate.of(2026, 2, 28), SeasonStatus.ACTIVE),
+                seasonWith(1, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31), SeasonStatus.FINALIZED)
+        );
+        when(seasonRepository.findAllByOrderBySeasonNumberDesc()).thenReturn(seasons);
+
+        List<Season> result = service.listSeasonsDescending();
+
+        assertEquals(seasons, result);
+        verify(seasonRepository, times(1)).findAllByOrderBySeasonNumberDesc();
+    }
+
+    // buildSeasonReport -----------------------------------------------------------------
+
+    @Test
+    void buildSeasonReport_returnsEmptyStatsForFutureSeasonWithNoData() {
+        LocalDate today = LocalDate.now();
+        Season future = seasonWith(99, today.plusDays(10), today.plusDays(40), SeasonStatus.ACTIVE);
+
+        SeasonService.SeasonReport report = service.buildSeasonReport(future);
+
+        assertNotNull(report);
+        assertTrue(report.players().isEmpty());
+        assertNotNull(report.summary());
+        assertEquals(0, report.summary().totalPlayers());
+        assertNull(report.summary().dataThrough());
+        verify(guessRepository, never()).findSeasonStats(any(), any());
+    }
+
+    @Test
+    void buildSeasonReport_throwsOnNullSeason() {
+        assertThrows(NullPointerException.class, () -> service.buildSeasonReport(null));
+    }
+
+    // backfillHistoricalSeasons ---------------------------------------------------------
+
+    @Test
+    void backfillHistoricalSeasons_returnsEmptyListWhenNoGuesses() {
+        when(guessRepository.findEarliestGameDate()).thenReturn(Optional.empty());
+
+        List<Season> result = service.backfillHistoricalSeasons();
+
+        assertTrue(result.isEmpty());
+        verify(seasonRepository, never()).save(any());
+    }
+}

--- a/backend/src/test/java/org/steam5/web/PresenceAuthControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/PresenceAuthControllerTest.java
@@ -1,0 +1,58 @@
+package org.steam5.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.steam5.service.WsTicketService;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PresenceAuthControllerTest {
+
+    private WsTicketService wsTicketService;
+    private PresenceAuthController controller;
+
+    @BeforeEach
+    void setUp() {
+        wsTicketService = mock(WsTicketService.class);
+        controller = new PresenceAuthController(wsTicketService);
+    }
+
+    @Test
+    void issueTicket_returns200WithTicketWhenAuthenticated() {
+        when(wsTicketService.issueTicket("76561")).thenReturn("ticket-abc");
+
+        ResponseEntity<?> response = controller.issueTicket("76561");
+
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody() instanceof Map<?, ?>);
+        assertTrue(((Map<?, ?>) response.getBody()).containsKey("ticket"));
+        assertEquals("no-store", response.getHeaders().getFirst("Cache-Control"));
+    }
+
+    @Test
+    void issueTicket_returns401WhenUnauthenticated() {
+        ResponseEntity<?> response = controller.issueTicket(null);
+
+        assertEquals(401, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody() instanceof Map<?, ?>);
+        assertEquals("unauthenticated", ((Map<?, ?>) response.getBody()).get("error"));
+        verify(wsTicketService, never()).issueTicket(any());
+    }
+
+    @Test
+    void issueTicket_delegatesToWsTicketService() {
+        when(wsTicketService.issueTicket("76561")).thenReturn("ticket-xyz");
+
+        ResponseEntity<?> response = controller.issueTicket("76561");
+
+        verify(wsTicketService, times(1)).issueTicket("76561");
+        assertNotNull(response.getBody());
+        assertEquals("ticket-xyz", ((Map<?, ?>) response.getBody()).get("ticket"));
+    }
+}

--- a/frontend/app/api/ws/ticket/route.ts
+++ b/frontend/app/api/ws/ticket/route.ts
@@ -1,0 +1,25 @@
+import {NextResponse} from 'next/server';
+import {cookies} from 'next/headers';
+
+const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
+
+// Per-user, short-lived — must never be cached by Next, a CDN, or a proxy.
+const NO_STORE = {"Cache-Control": "private, no-store"} as const;
+
+export async function GET() {
+    const token = (await cookies()).get('s5_token')?.value;
+    // Anonymous mode: client connects without a ticket.
+    if (!token) return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
+    try {
+        const res = await fetch(`${BACKEND_ORIGIN}/api/ws/ticket`, {
+            method: 'POST',
+            headers: {authorization: `Bearer ${token}`, accept: 'application/json'},
+            cache: 'no-store',
+        });
+        if (!res.ok) return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
+        const data = await res.json();
+        return NextResponse.json({ticket: data?.ticket ?? null}, {status: 200, headers: NO_STORE});
+    } catch {
+        return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
+    }
+}

--- a/frontend/app/api/ws/ticket/route.ts
+++ b/frontend/app/api/ws/ticket/route.ts
@@ -1,7 +1,8 @@
 import {NextResponse} from 'next/server';
 import {cookies} from 'next/headers';
 
-const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
+const BACKEND_ORIGIN = process.env.API_DOMAIN || process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
+const isDevelopment = process.env.NODE_ENV === 'development';
 
 // Per-user, short-lived — must never be cached by Next, a CDN, or a proxy.
 const NO_STORE = {"Cache-Control": "private, no-store"} as const;
@@ -10,16 +11,24 @@ export async function GET() {
     const token = (await cookies()).get('s5_token')?.value;
     // Anonymous mode: client connects without a ticket.
     if (!token) return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
+
+    // Validate HTTPS in production before sending bearer tokens.
+    if (!isDevelopment && !BACKEND_ORIGIN.startsWith('https://')) {
+        console.error('[ws-ticket] Backend origin must use HTTPS in production:', BACKEND_ORIGIN);
+        return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
+    }
     try {
         const res = await fetch(`${BACKEND_ORIGIN}/api/ws/ticket`, {
             method: 'POST',
             headers: {authorization: `Bearer ${token}`, accept: 'application/json'},
             cache: 'no-store',
+            signal: AbortSignal.timeout(5000),
         });
         if (!res.ok) return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
         const data = await res.json();
         return NextResponse.json({ticket: data?.ticket ?? null}, {status: 200, headers: NO_STORE});
-    } catch {
+    } catch (error) {
+        console.error('[ws-ticket] Backend fetch failed:', error);
         return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
     }
 }

--- a/frontend/app/review-guesser/[round]/page.tsx
+++ b/frontend/app/review-guesser/[round]/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import ReviewGuesserHero from "@/components/ReviewGuesserHero";
 import GameInfoSection from "@/components/GameInfoSection";
 import NewsBox from "@/components/NewsBox";
-import OtherPlayersNow from "@/components/OtherPlayersNow";
 import PlayerSpotlight from "@/components/PlayerSpotlight";
 import ReviewGuesserRound from "@/components/ReviewGuesserRound";
 import {Suspense} from "react";
@@ -109,8 +108,6 @@ export default async function ReviewGuesserRoundPage({params}: { params: Promise
                     allResults={allResults}
                 />
             </Suspense>
-
-            <OtherPlayersNow scopeKey={`${today.date}:${roundIndex}:${pick.appId}`}/>
 
             {roundIndex === 1 && <PlayerSpotlight/>}
             {roundIndex === 1 && <NewsBox/>}

--- a/frontend/app/review-guesser/[round]/page.tsx
+++ b/frontend/app/review-guesser/[round]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import ReviewGuesserHero from "@/components/ReviewGuesserHero";
 import GameInfoSection from "@/components/GameInfoSection";
 import NewsBox from "@/components/NewsBox";
+import OtherPlayersNow from "@/components/OtherPlayersNow";
 import PlayerSpotlight from "@/components/PlayerSpotlight";
 import ReviewGuesserRound from "@/components/ReviewGuesserRound";
 import {Suspense} from "react";
@@ -94,6 +95,8 @@ export default async function ReviewGuesserRoundPage({params}: { params: Promise
             <ReviewGuesserHero today={today}
                                pick={pick}
                                roundIndex={roundIndex}/>
+
+            <OtherPlayersNow scopeKey={`${today.date}:${roundIndex}:${pick.appId}`}/>
 
             <Suspense fallback={<div style={{height: 220, background: 'var(--color-border)', borderRadius: 8}}/>}>
                 <ReviewGuesserRound

--- a/frontend/app/review-guesser/[round]/page.tsx
+++ b/frontend/app/review-guesser/[round]/page.tsx
@@ -96,8 +96,6 @@ export default async function ReviewGuesserRoundPage({params}: { params: Promise
                                pick={pick}
                                roundIndex={roundIndex}/>
 
-            <OtherPlayersNow scopeKey={`${today.date}:${roundIndex}:${pick.appId}`}/>
-
             <Suspense fallback={<div style={{height: 220, background: 'var(--color-border)', borderRadius: 8}}/>}>
                 <ReviewGuesserRound
                     appId={pick.appId}
@@ -111,6 +109,8 @@ export default async function ReviewGuesserRoundPage({params}: { params: Promise
                     allResults={allResults}
                 />
             </Suspense>
+
+            <OtherPlayersNow scopeKey={`${today.date}:${roundIndex}:${pick.appId}`}/>
 
             {roundIndex === 1 && <PlayerSpotlight/>}
             {roundIndex === 1 && <NewsBox/>}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -507,16 +507,16 @@ packages:
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
-  baseline-browser-mapping@2.10.42:
-    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
-  caniuse-lite@1.0.30001803:
-    resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
+  caniuse-lite@1.0.30001805:
+    resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -567,8 +567,8 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -700,8 +700,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -747,8 +747,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.17:
+    resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
     engines: {node: ^10 || ^12 || >=14}
 
   react-dom@19.2.7:
@@ -1285,11 +1285,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  baseline-browser-mapping@2.10.42: {}
+  baseline-browser-mapping@2.10.43: {}
 
   bcp-47-match@2.0.3: {}
 
-  caniuse-lite@1.0.30001803: {}
+  caniuse-lite@1.0.30001805: {}
 
   chai@6.2.2: {}
 
@@ -1348,7 +1348,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-module-lexer@2.3.0: {}
+  es-module-lexer@2.3.1: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -1458,14 +1458,14 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   next@16.2.10(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001803
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -1497,13 +1497,13 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.16:
+  postcss@8.5.17:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1628,7 +1628,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.17
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -1644,7 +1644,7 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3

--- a/frontend/src/components/OtherPlayersNow.tsx
+++ b/frontend/src/components/OtherPlayersNow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import {useRoundPresence, type PlayerInfo} from "@/lib/hooks/useRoundPresence";
 import "@/styles/components/otherPlayersNow.css";
 
@@ -19,19 +20,19 @@ function initialsFor(name: string | null): string {
 
 function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
     const displayName = player.personaName || "Player";
-    if (player.avatar) {
-        return (
-            <img
-                className="other-players__avatar"
-                src={player.avatar}
-                alt={displayName}
-                title={displayName}
-                loading="lazy"
-                referrerPolicy="no-referrer"
-            />
-        );
-    }
-    return (
+    const profileUrl = `/profile/${player.steamId}`;
+    const content = player.avatar ? (
+        <img
+            className="other-players__avatar"
+            src={player.avatar}
+            alt={displayName}
+            title={displayName}
+            width={32}
+            height={32}
+            loading="lazy"
+            referrerPolicy="no-referrer"
+        />
+    ) : (
         <span
             className="other-players__avatar"
             title={displayName}
@@ -39,6 +40,11 @@ function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
         >
             {initialsFor(player.personaName)}
         </span>
+    );
+    return (
+        <Link href={profileUrl} aria-label={`View ${displayName}'s Steam profile`}>
+            {content}
+        </Link>
     );
 }
 

--- a/frontend/src/components/OtherPlayersNow.tsx
+++ b/frontend/src/components/OtherPlayersNow.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React from "react";
+import {useRoundPresence, type PlayerInfo} from "@/lib/hooks/useRoundPresence";
+import "@/styles/components/otherPlayersNow.css";
+
+interface OtherPlayersNowProps {
+    scopeKey: string;
+}
+
+const MAX_VISIBLE_AVATARS = 8;
+
+function initialsFor(name: string | null): string {
+    if (!name) return "?";
+    const trimmed = name.trim();
+    if (!trimmed) return "?";
+    return trimmed.charAt(0).toUpperCase();
+}
+
+function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
+    const displayName = player.personaName || "Player";
+    if (player.avatar) {
+        return (
+            <img
+                className="other-players__avatar"
+                src={player.avatar}
+                alt={displayName}
+                title={displayName}
+                loading="lazy"
+                referrerPolicy="no-referrer"
+            />
+        );
+    }
+    return (
+        <span
+            className="other-players__avatar"
+            title={displayName}
+            aria-label={displayName}
+        >
+            {initialsFor(player.personaName)}
+        </span>
+    );
+}
+
+export default function OtherPlayersNow(props: Readonly<OtherPlayersNowProps>): React.ReactElement | null {
+    const {scopeKey} = props;
+    const {totalCount, players, connected} = useRoundPresence(scopeKey);
+
+    if (!connected) return null;
+    if (totalCount === 0) return null;
+
+    const visible = players.slice(0, MAX_VISIBLE_AVATARS);
+    const overflow = Math.max(0, players.length - visible.length);
+    const label = totalCount === 1 ? "1 playing now" : `${totalCount} playing now`;
+
+    return (
+        <div className="other-players" aria-live="polite">
+            {visible.length > 0 && (
+                <div className="other-players__avatars" aria-hidden={false}>
+                    {visible.map((player) => (
+                        <PlayerAvatar key={player.steamId} player={player}/>
+                    ))}
+                    {overflow > 0 && (
+                        <span
+                            className="other-players__overflow"
+                            title={`${overflow} more player${overflow === 1 ? "" : "s"}`}
+                            aria-label={`${overflow} more players`}
+                        >
+                            +{overflow}
+                        </span>
+                    )}
+                </div>
+            )}
+            <span className="other-players__count">
+                <span className="other-players__dot" aria-hidden="true"/>
+                {label}
+            </span>
+        </div>
+    );
+}

--- a/frontend/src/components/OtherPlayersNow.tsx
+++ b/frontend/src/components/OtherPlayersNow.tsx
@@ -1,82 +1,24 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
-import {useRoundPresence, type PlayerInfo} from "@/lib/hooks/useRoundPresence";
+import {useRoundPresence} from "@/lib/hooks/useRoundPresence";
 import "@/styles/components/otherPlayersNow.css";
 
 interface OtherPlayersNowProps {
     scopeKey: string;
 }
 
-const MAX_VISIBLE_AVATARS = 8;
-
-function initialsFor(name: string | null): string {
-    if (!name) return "?";
-    const trimmed = name.trim();
-    if (!trimmed) return "?";
-    return trimmed.charAt(0).toUpperCase();
-}
-
-function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
-    const displayName = player.personaName || "Player";
-    const profileUrl = `/profile/${player.steamId}`;
-    const content = player.avatar ? (
-        <img
-            className="other-players__avatar"
-            src={player.avatar}
-            alt={displayName}
-            title={displayName}
-            width={32}
-            height={32}
-            loading="lazy"
-            referrerPolicy="no-referrer"
-        />
-    ) : (
-        <span
-            className="other-players__avatar"
-            title={displayName}
-            aria-label={displayName}
-        >
-            {initialsFor(player.personaName)}
-        </span>
-    );
-    return (
-        <Link href={profileUrl} aria-label={`View ${displayName}'s Steam profile`}>
-            {content}
-        </Link>
-    );
-}
-
 export default function OtherPlayersNow(props: Readonly<OtherPlayersNowProps>): React.ReactElement | null {
     const {scopeKey} = props;
-    const {totalCount, players, connected} = useRoundPresence(scopeKey);
+    const {totalCount, connected} = useRoundPresence(scopeKey);
 
     if (!connected) return null;
     if (totalCount === 0) return null;
 
-    const visible = players.slice(0, MAX_VISIBLE_AVATARS);
-    const overflow = Math.max(0, players.length - visible.length);
     const label = totalCount === 1 ? "1 playing now" : `${totalCount} playing now`;
 
     return (
         <div className="other-players" aria-live="polite">
-            {visible.length > 0 && (
-                <div className="other-players__avatars" aria-hidden={false}>
-                    {visible.map((player) => (
-                        <PlayerAvatar key={player.steamId} player={player}/>
-                    ))}
-                    {overflow > 0 && (
-                        <span
-                            className="other-players__overflow"
-                            title={`${overflow} more player${overflow === 1 ? "" : "s"}`}
-                            aria-label={`${overflow} more players`}
-                        >
-                            +{overflow}
-                        </span>
-                    )}
-                </div>
-            )}
             <span className="other-players__count">
                 <span className="other-players__dot" aria-hidden="true"/>
                 {label}

--- a/frontend/src/components/ReviewGuesserRound.tsx
+++ b/frontend/src/components/ReviewGuesserRound.tsx
@@ -8,6 +8,7 @@ import GuessButtons from "@/components/GuessButtons";
 import AuthWarningModal from "@/components/AuthWarningModal";
 import RoundResultDialog from "@/components/RoundResultDialog";
 import RoundResultActions from "@/components/RoundResultActions";
+import OtherPlayersNow from "@/components/OtherPlayersNow";
 import ShareControls from "@/components/ShareControls";
 import RoundSummary from "@/components/RoundSummary";
 import {buildSteamLoginUrl} from "@/components/SteamLoginButton";
@@ -318,6 +319,7 @@ export default function ReviewGuesserRound({
                 <section className="review-round__guess-card" aria-labelledby="guess-submission">
                     <div className="review-round__guess-header">
                         <h2 id="guess-submission">Submit Your Guess</h2>
+                        <OtherPlayersNow scopeKey={gameDate ?? ''}/>
                     </div>
                     <GuessButtons
                         appId={appId}
@@ -354,6 +356,7 @@ export default function ReviewGuesserRound({
                         actualBucket: computedPrefill?.actualBucket ?? '',
                         correct: computedPrefill?.actualBucket ? (computedPrefill.actualBucket === (computedPrefill?.selectedLabel ?? '')) : false,
                     }) as GuessResponse}
+                    headerRight={<OtherPlayersNow scopeKey={gameDate ?? ''}/>}
                 >
                     <RoundResultActions
                         appId={appId}

--- a/frontend/src/components/RoundResult.tsx
+++ b/frontend/src/components/RoundResult.tsx
@@ -1,19 +1,21 @@
 "use client";
 
-import React from "react";
+import React, {type ReactNode} from "react";
 import type {GuessResponse} from "@/types/review-game";
 import {ArrowRightIcon} from "@phosphor-icons/react/ssr";
 import type {RoundResultTier} from "@/lib/scoring";
 import {tierEmoji} from "@/lib/scoring";
 import "@/styles/components/reviewRoundResult.css";
 
-export default function RoundResult({result, selectedLabel, actualBucket, headerText, tier}: {
+export default function RoundResult(props: {
     result: GuessResponse;
     selectedLabel?: string | null;
     actualBucket: string;
     headerText: string;
     tier: RoundResultTier;
+    headerRight?: ReactNode;
 }): React.ReactElement {
+    const {result, selectedLabel, actualBucket, headerText, tier} = props;
     const correct = result.correct;
     const showComparison = !!selectedLabel;
 
@@ -21,10 +23,13 @@ export default function RoundResult({result, selectedLabel, actualBucket, header
         <div className="result-body">
             <div className={`result-header result-header--${tier}`}
                  aria-live="polite">
-                <span className="result-header__icon result-header__icon--square" aria-hidden="true">{tierEmoji(tier)}</span>
-                <span className="result-header__text">
-                    {headerText}
-                </span>
+                <div className="result-header__left">
+                    <span className="result-header__icon result-header__icon--square" aria-hidden="true">{tierEmoji(tier)}</span>
+                    <span className="result-header__text">
+                        {headerText}
+                    </span>
+                </div>
+                {props.headerRight}
             </div>
 
             {showComparison && (

--- a/frontend/src/components/RoundResultDialog.tsx
+++ b/frontend/src/components/RoundResultDialog.tsx
@@ -34,6 +34,7 @@ export default function RoundResultDialog(props: {
     selectedLabel: string | null | undefined;
     result: GuessResponse;
     children?: ReactNode;
+    headerRight?: ReactNode;
 }) {
     const correct = props.result.correct;
     const headerText = resolveHeaderText(correct, props.buckets, props.selectedLabel, props.result.actualBucket);
@@ -50,6 +51,7 @@ export default function RoundResultDialog(props: {
                 actualBucket={props.result.actualBucket}
                 headerText={headerText}
                 tier={tier}
+                headerRight={props.headerRight}
             />
             <div className="result-footer">
                 <span className="result-detail">

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -2,6 +2,7 @@
 
 import {useEffect, useRef, useState} from "react";
 import {useAuth} from "@/contexts/AuthContext";
+import {BACKEND_ORIGIN} from "@/lib/backend";
 
 export interface PlayerInfo {
     steamId: string;
@@ -17,7 +18,6 @@ export interface PresenceSnapshot {
 
 const EMPTY_SNAPSHOT: PresenceSnapshot = {totalCount: 0, anonymousCount: 0, players: []};
 
-const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_DOMAIN || "http://localhost:8080";
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30000;
@@ -89,7 +89,7 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
             if (disposed) return;
 
             const wsOrigin = toWsOrigin(BACKEND_ORIGIN);
-            const url = `${wsOrigin}/ws/presence?scopeKey=${encodeURIComponent(scopeKey)}&ticket=${ticket ?? ""}`;
+            const url = `${wsOrigin}/ws/presence?scopeKey=${encodeURIComponent(scopeKey)}&ticket=${encodeURIComponent(ticket ?? "")}`;
 
             let ws: WebSocket;
             try {
@@ -146,11 +146,33 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
             }, delay);
         };
 
+        const handleRecovery = () => {
+            if (disposed || closedByUserRef.current) return;
+            if (retryCountRef.current >= MAX_RETRIES) {
+                retryCountRef.current = 0;
+                scheduleReconnect();
+            }
+        };
+
+        const handleOnline = handleRecovery;
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === "visible") {
+                handleRecovery();
+            }
+        };
+
+        window.addEventListener("online", handleOnline);
+        window.addEventListener("focus", handleRecovery);
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+
         void connect();
 
         return () => {
             disposed = true;
             closedByUserRef.current = true;
+            window.removeEventListener("online", handleOnline);
+            window.removeEventListener("focus", handleRecovery);
+            document.removeEventListener("visibilitychange", handleVisibilityChange);
             clearReconnect();
             closeSocket();
             setConnected(false);

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -1,0 +1,161 @@
+"use client";
+
+import {useEffect, useRef, useState} from "react";
+import {useAuth} from "@/contexts/AuthContext";
+
+export interface PlayerInfo {
+    steamId: string;
+    personaName: string | null;
+    avatar: string | null;
+}
+
+export interface PresenceSnapshot {
+    totalCount: number;
+    anonymousCount: number;
+    players: PlayerInfo[];
+}
+
+const EMPTY_SNAPSHOT: PresenceSnapshot = {totalCount: 0, anonymousCount: 0, players: []};
+
+const BACKEND_ORIGIN = process.env.NEXT_PUBLIC_API_DOMAIN || "http://localhost:8080";
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
+
+function toWsOrigin(origin: string): string {
+    if (origin.startsWith("https://")) return "wss://" + origin.slice("https://".length);
+    if (origin.startsWith("http://")) return "ws://" + origin.slice("http://".length);
+    return origin;
+}
+
+async function fetchTicket(): Promise<string | null> {
+    try {
+        const res = await fetch("/api/ws/ticket", {cache: "no-store", credentials: "include"});
+        if (!res.ok) return null;
+        const data = await res.json();
+        return typeof data?.ticket === "string" ? data.ticket : null;
+    } catch {
+        return null;
+    }
+}
+
+export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {connected: boolean} {
+    const {isSignedIn} = useAuth();
+    const [snapshot, setSnapshot] = useState<PresenceSnapshot>(EMPTY_SNAPSHOT);
+    const [connected, setConnected] = useState(false);
+
+    const socketRef = useRef<WebSocket | null>(null);
+    const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const closedByUserRef = useRef(false);
+    const retryCountRef = useRef(0);
+
+    useEffect(() => {
+        // Reset per-scope state.
+        closedByUserRef.current = false;
+        retryCountRef.current = 0;
+        setSnapshot(EMPTY_SNAPSHOT);
+        setConnected(false);
+
+        if (!scopeKey) {
+            return () => {
+                // nothing to clean up
+            };
+        }
+
+        let disposed = false;
+
+        const clearReconnect = () => {
+            if (reconnectTimerRef.current) {
+                clearTimeout(reconnectTimerRef.current);
+                reconnectTimerRef.current = null;
+            }
+        };
+
+        const closeSocket = () => {
+            const ws = socketRef.current;
+            socketRef.current = null;
+            if (ws) {
+                try {
+                    ws.close();
+                } catch {
+                    // ignore
+                }
+            }
+        };
+
+        const connect = async () => {
+            if (disposed) return;
+            const ticket = isSignedIn ? await fetchTicket() : null;
+            if (disposed) return;
+
+            const wsOrigin = toWsOrigin(BACKEND_ORIGIN);
+            const url = `${wsOrigin}/ws/presence?scopeKey=${encodeURIComponent(scopeKey)}&ticket=${ticket ?? ""}`;
+
+            let ws: WebSocket;
+            try {
+                ws = new WebSocket(url);
+            } catch (e) {
+                console.warn("[useRoundPresence] failed to open socket", e);
+                scheduleReconnect();
+                return;
+            }
+            socketRef.current = ws;
+
+            ws.onopen = () => {
+                if (disposed) return;
+                retryCountRef.current = 0;
+                setConnected(true);
+            };
+
+            ws.onmessage = (ev) => {
+                if (disposed) return;
+                try {
+                    const data = JSON.parse(ev.data) as Partial<PresenceSnapshot>;
+                    setSnapshot({
+                        totalCount: typeof data.totalCount === "number" ? data.totalCount : 0,
+                        anonymousCount: typeof data.anonymousCount === "number" ? data.anonymousCount : 0,
+                        players: Array.isArray(data.players) ? data.players : [],
+                    });
+                } catch (e) {
+                    console.warn("[useRoundPresence] bad message", e);
+                }
+            };
+
+            ws.onerror = (e) => {
+                console.warn("[useRoundPresence] socket error", e);
+                // Let onclose drive reconnect.
+            };
+
+            ws.onclose = () => {
+                if (disposed) return;
+                setConnected(false);
+                socketRef.current = null;
+                if (!closedByUserRef.current) scheduleReconnect();
+            };
+        };
+
+        const scheduleReconnect = () => {
+            if (disposed || closedByUserRef.current) return;
+            if (retryCountRef.current >= MAX_RETRIES) return;
+            const attempt = retryCountRef.current++;
+            const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS);
+            clearReconnect();
+            reconnectTimerRef.current = setTimeout(() => {
+                reconnectTimerRef.current = null;
+                void connect();
+            }, delay);
+        };
+
+        void connect();
+
+        return () => {
+            disposed = true;
+            closedByUserRef.current = true;
+            clearReconnect();
+            closeSocket();
+            setConnected(false);
+        };
+    }, [scopeKey, isSignedIn]);
+
+    return {...snapshot, connected};
+}

--- a/frontend/src/styles/components/otherPlayersNow.css
+++ b/frontend/src/styles/components/otherPlayersNow.css
@@ -1,0 +1,99 @@
+.other-players {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0.5rem 0 1rem;
+    font-size: 0.875rem;
+    color: var(--color-muted);
+}
+
+.other-players__avatars {
+    display: flex;
+    align-items: center;
+}
+
+.other-players__avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 2px solid var(--color-surface);
+    background: var(--color-surface-variant);
+    object-fit: cover;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text);
+    text-transform: uppercase;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.other-players__avatar + .other-players__avatar,
+.other-players__avatars > .other-players__overflow {
+    margin-left: -10px;
+}
+
+.other-players__overflow {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 2px solid var(--color-surface);
+    background: var(--color-surface-variant);
+    color: var(--color-text);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.other-players__count {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--color-muted);
+}
+
+.other-players__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-success);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 60%, transparent);
+    animation: presence-pulse 1.8s ease-out infinite;
+    flex-shrink: 0;
+}
+
+@keyframes presence-pulse {
+    0% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 60%, transparent);
+    }
+    70% {
+        box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-success) 0%, transparent);
+    }
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 0%, transparent);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .other-players__dot {
+        animation: none;
+    }
+}
+
+@media (max-width: 640px) {
+    .other-players {
+        font-size: 0.8125rem;
+        gap: 0.5rem;
+    }
+
+    .other-players__avatar,
+    .other-players__overflow {
+        width: 28px;
+        height: 28px;
+    }
+}

--- a/frontend/src/styles/components/otherPlayersNow.css
+++ b/frontend/src/styles/components/otherPlayersNow.css
@@ -2,58 +2,15 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    margin: 0.5rem 0 1rem;
     font-size: 0.875rem;
+    font-weight: normal;
     color: var(--color-muted);
-}
-
-.other-players__avatars {
-    display: flex;
-    align-items: center;
-}
-
-.other-players__avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 2px solid var(--color-surface);
-    background: var(--color-surface-variant);
-    object-fit: cover;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: var(--color-text);
-    text-transform: uppercase;
-    overflow: hidden;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-}
-
-.other-players__avatar + .other-players__avatar,
-.other-players__avatars > .other-players__overflow {
-    margin-left: -10px;
-}
-
-.other-players__overflow {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 2px solid var(--color-surface);
-    background: var(--color-surface-variant);
-    color: var(--color-text);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.7rem;
-    font-weight: 600;
-    line-height: 1;
 }
 
 .other-players__count {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.6rem;
     color: var(--color-muted);
 }
 
@@ -89,11 +46,5 @@
     .other-players {
         font-size: 0.8125rem;
         gap: 0.5rem;
-    }
-
-    .other-players__avatar,
-    .other-players__overflow {
-        width: 28px;
-        height: 28px;
     }
 }

--- a/frontend/src/styles/components/reviewGuessButtons.css
+++ b/frontend/src/styles/components/reviewGuessButtons.css
@@ -123,3 +123,10 @@
         text-align: center;
     }
 }
+
+@media (max-width: 390px) {
+    .review-round__guess-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/frontend/src/styles/components/reviewGuessButtons.css
+++ b/frontend/src/styles/components/reviewGuessButtons.css
@@ -8,6 +8,9 @@
 }
 
 .review-round__guess-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     padding: 0.625rem 0.875rem;
     background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface));
     border-bottom: 1px solid var(--color-border);

--- a/frontend/src/styles/components/reviewRoundResult.css
+++ b/frontend/src/styles/components/reviewRoundResult.css
@@ -80,11 +80,18 @@
 .result-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
     padding: 0.625rem 0.875rem;
     font-weight: 700;
     font-size: 1rem;
     border-radius: 9px 9px 0 0;
+    justify-content: space-between;
+    /* no gap here — gap lives in __left */
+}
+
+.result-header__left {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 .result-header--exact {


### PR DESCRIPTION
Closes #82

Implement real-time presence tracking for game rounds.
- Backend: WebSocket infrastructure, in-memory registry, ticket-based auth.
- Frontend: useRoundPresence hook, ticket proxy, OtherPlayersNow UI component.
- Verified with 72 backend tests and 79 frontend tests.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author