### PR TITLE
fix: season race condition in ensureSeasonForDate (#66)

### DIFF
--- a/backend/src/main/java/org/steam5/service/SeasonService.java
+++ b/backend/src/main/java/org/steam5/service/SeasonService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.steam5.config.SeasonProperties;
@@ -146,7 +147,15 @@ public class SeasonService {
         Objects.requireNonNull(date, "date");
 
         return seasonRepository.findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date)
-                .orElseGet(() -> createSeasonsUntil(date));
+                .orElseGet(() -> {
+                    try {
+                        return createSeasonsUntil(date);
+                    } catch (DataIntegrityViolationException e) {
+                        return seasonRepository
+                                .findByStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date)
+                                .orElseThrow(() -> new IllegalStateException("Season missing after conflict", e));
+                    }
+                });
     }
 
     @Transactional

--- a/backend/src/main/resources/db/migration/V10_add_season_dates_unique_constraint.sql
+++ b/backend/src/main/resources/db/migration/V10_add_season_dates_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE seasons ADD CONSTRAINT uq_seasons_dates UNIQUE (start_date, end_date);


### PR DESCRIPTION
Addresses the race condition where multiple concurrent requests could attempt to create the same season.

Changes:
- Added `V10_add_season_dates_unique_constraint.sql` to enforce unique `(start_date, end_date)` at the database level.
- Updated `SeasonService.ensureSeasonForDate()` to catch `DataIntegrityViolationException` on concurrent inserts and re-query the database for the existing record.
- Verified with backend tests (64/64 passing).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author