### PR TITLE
refactor(leaderboard): extract LeaderboardService

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,6 @@ AUTH_JWT_SECRET=dev-jwt-secret-change-me-32-bytes-minimum-length
 - The frontend redirects `/` to `/review-guesser/1` (HTTP 308). Use `curl -L` when testing.
 - Actuator (port 8081) requires authentication via Spring Security in the dev profile.
 - All Quartz jobs are enabled in the `dev` profile (`application-dev.yml`). Jobs that call the Steam API will log errors with a dummy API key but do not block startup.
-- Backend tests: 2 tests (`AuthControllerTest.validate_token_ok_and_invalid` and `LeaderboardControllerTest.allTime_returnsAggregatedLeaders`) are pre-existing failures due to test/production code drift. The remaining 17 tests pass.
 - Flyway migrations and Hibernate `ddl-auto: update` both run on startup. Schema is auto-managed.
 - No ESLint config exists for the frontend; use `pnpm build` as the lint/type check.
 - Node 22 is installed via nvm. Source nvm before running frontend commands: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"`

--- a/backend/src/main/java/org/steam5/service/LeaderboardService.java
+++ b/backend/src/main/java/org/steam5/service/LeaderboardService.java
@@ -1,0 +1,121 @@
+package org.steam5.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.steam5.domain.Guess;
+import org.steam5.domain.GuessStats;
+import org.steam5.domain.StreakCalculator;
+import org.steam5.domain.User;
+import org.steam5.repository.GuessRepository;
+import org.steam5.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LeaderboardService {
+
+    private final GuessRepository guessRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * Aggregates a set of guesses (already fetched for a specific day/range) into a
+     * leaderboard: one entry per player, sorted by total points descending.
+     */
+    public List<LeaderEntry> buildLeaderboard(final List<Guess> guesses, final LocalDate asOfDate) {
+        final Map<String, List<Guess>> byUser = guesses.stream().collect(Collectors.groupingBy(Guess::getSteamId));
+        final Set<String> steamIds = byUser.keySet();
+        if (steamIds.isEmpty()) {
+            return List.of();
+        }
+
+        final Map<String, User> usersById = userRepository.findAllById(steamIds).stream()
+                .collect(Collectors.toMap(User::getSteamId, user -> user));
+
+        final Map<String, List<LocalDate>> streakDatesById = guessRepository.findDistinctDatesUpToForUsers(List.copyOf(steamIds), asOfDate)
+                .stream()
+                .collect(Collectors.groupingBy(GuessRepository.UserDateRow::getSteamId,
+                        Collectors.mapping(GuessRepository.UserDateRow::getGameDate, Collectors.toList())));
+
+        return byUser.entrySet().stream()
+                .map(entry -> buildEntry(entry, usersById, streakDatesById, asOfDate))
+                .sorted((a, b) -> Long.compare(b.totalPoints(), a.totalPoints()))
+                .toList();
+    }
+
+    /**
+     * Aggregates all-time stats (pre-computed in SQL, already ordered by total points
+     * descending) into a leaderboard.
+     */
+    public List<LeaderEntry> buildAllTimeLeaderboard(final LocalDate today) {
+        final List<GuessRepository.AllTimeStatsRow> rows = guessRepository.aggregateAllTimeStats();
+        if (rows.isEmpty()) {
+            return List.of();
+        }
+
+        final List<String> steamIds = rows.stream().map(GuessRepository.AllTimeStatsRow::getSteamId).toList();
+        final Map<String, User> usersById = userRepository.findAllById(steamIds).stream()
+                .collect(Collectors.toMap(User::getSteamId, user -> user));
+        final Map<String, List<LocalDate>> streakDatesById = guessRepository
+                .findDistinctDatesUpToForUsers(steamIds, today)
+                .stream()
+                .collect(Collectors.groupingBy(GuessRepository.UserDateRow::getSteamId,
+                        Collectors.mapping(GuessRepository.UserDateRow::getGameDate, Collectors.toList())));
+
+        return rows.stream()
+                .map(row -> {
+                    final User user = usersById.get(row.getSteamId());
+                    final List<LocalDate> dates = streakDatesById.getOrDefault(row.getSteamId(), List.of());
+                    final int streak = StreakCalculator.currentStreak(dates, today);
+                    return getLeaderEntry(
+                            row.getSteamId(),
+                            row.getTotalPoints() != null ? row.getTotalPoints() : 0L,
+                            row.getRounds() != null ? row.getRounds() : 0L,
+                            row.getHits() != null ? row.getHits() : 0L,
+                            row.getFlops() != null ? row.getFlops() : 0L,
+                            row.getTooHigh() != null ? row.getTooHigh() : 0L,
+                            row.getTooLow() != null ? row.getTooLow() : 0L,
+                            row.getAvgPoints() != null ? row.getAvgPoints() : 0.0,
+                            streak,
+                            user
+                    );
+                })
+                .toList();
+    }
+
+    private LeaderEntry buildEntry(final Map.Entry<String, List<Guess>> entry,
+                                    final Map<String, User> usersById,
+                                    final Map<String, List<LocalDate>> streakDatesById,
+                                    final LocalDate asOfDate) {
+        final String steamId = entry.getKey();
+        final GuessStats stats = GuessStats.from(entry.getValue());
+        final User user = usersById.get(steamId);
+        final List<LocalDate> dates = streakDatesById.getOrDefault(steamId, List.of());
+        final int streak = StreakCalculator.currentStreak(dates, asOfDate);
+        return getLeaderEntry(steamId, stats.totalPoints(), stats.rounds(), stats.hits(),
+                stats.flops(), stats.tooHigh(), stats.tooLow(), stats.avgPoints(), streak, user);
+    }
+
+    private LeaderEntry getLeaderEntry(final String steamId, final long totalPoints, final long rounds, final long hits, final long flops, final long tooHigh, final long tooLow, final double avgPoints, final int streak, final User user) {
+        final String personaName = user != null && user.getPersonaName() != null && !user.getPersonaName().isBlank() ? user.getPersonaName() : steamId;
+        final String avatar = user != null && user.getAvatarFull() != null && !user.getAvatarFull().isBlank() ? user.getAvatarFull() : null;
+        final String avatarBlurdata = user != null && user.getBlurdataAvatarFull() != null && !user.getBlurdataAvatarFull().isBlank() ? user.getBlurdataAvatarFull() : null;
+        final String profileUrl = user != null && user.getProfileUrl() != null && !user.getProfileUrl().isBlank() ? user.getProfileUrl() : null;
+        return new LeaderEntry(steamId, personaName, totalPoints, rounds, hits, flops, tooHigh, tooLow, avgPoints, streak, avatar, avatarBlurdata, profileUrl);
+    }
+
+    public record LeaderEntry(String steamId,
+                              String personaName,
+                              long totalPoints, long rounds,
+                              long hits, long flops, long tooHigh, long tooLow,
+                              double avgPoints,
+                              int streak,
+                              String avatar,
+                              String avatarBlurdata,
+                              String profileUrl) {
+    }
+}

--- a/backend/src/main/java/org/steam5/web/LeaderboardController.java
+++ b/backend/src/main/java/org/steam5/web/LeaderboardController.java
@@ -1,6 +1,5 @@
 package org.steam5.web;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -11,26 +10,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.steam5.domain.BucketLabel;
 import org.steam5.domain.GameDate;
 import org.steam5.domain.Guess;
-import org.steam5.domain.GuessStats;
 import org.steam5.domain.ReviewGamePick;
 import org.steam5.domain.Season;
-import org.steam5.domain.StreakCalculator;
-import org.steam5.domain.User;
 import org.steam5.repository.GuessRepository;
-import org.steam5.repository.UserRepository;
+import org.steam5.service.LeaderboardService;
 import org.steam5.service.ReviewGameStateService;
 import org.steam5.service.SeasonService;
 
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,22 +30,22 @@ public class LeaderboardController {
 
     private final GuessRepository guessRepository;
     private final ReviewGameStateService reviewGameStateService;
-    private final UserRepository userRepository;
     private final SeasonService seasonService;
     private final CacheManager cacheManager;
+    private final LeaderboardService leaderboardService;
 
     @GetMapping("/today")
     @Cacheable(value = "leaderboard-live", key = "'today:' + T(org.steam5.domain.GameDate).todayUtc()", unless = "#result == null || #result.body == null")
-    public ResponseEntity<List<LeaderEntry>> today() {
+    public ResponseEntity<List<LeaderboardService.LeaderEntry>> today() {
         final List<ReviewGamePick> picks = reviewGameStateService.generateDailyPicks();
         final LocalDate date = picks.isEmpty() ? GameDate.todayUtc() : picks.getFirst().getPickDate();
         final List<Guess> guesses = guessRepository.findAllByDate(date);
-        return getGuessResponse(guesses, date);
+        return ResponseEntity.ok(leaderboardService.buildLeaderboard(guesses, date));
     }
 
     @GetMapping("/weekly")
     @Cacheable(value = "leaderboard-static", key = "'weekly:' + #floating + ':' + T(org.steam5.domain.GameDate).todayUtc()", unless = "#result == null || #result.body == null")
-    public ResponseEntity<List<LeaderEntry>> weekly(@RequestParam(name = "floating", required = false, defaultValue = "false") boolean floating) {
+    public ResponseEntity<List<LeaderboardService.LeaderEntry>> weekly(@RequestParam(name = "floating", required = false, defaultValue = "false") boolean floating) {
         final List<ReviewGamePick> picks = reviewGameStateService.generateDailyPicks();
 
         final LocalDate today = picks.isEmpty() ? GameDate.todayUtc() : picks.getFirst().getPickDate();
@@ -74,25 +64,25 @@ public class LeaderboardController {
         }
 
         final List<Guess> guesses = guessRepository.findAllBetween(start, end);
-        return getGuessResponse(guesses, today);
+        return ResponseEntity.ok(leaderboardService.buildLeaderboard(guesses, today));
     }
 
     @GetMapping("/monthly")
     @Cacheable(value = "leaderboard-static", key = "'monthly:' + T(org.steam5.domain.GameDate).todayUtc()", unless = "#result == null || #result.body == null")
-    public ResponseEntity<List<LeaderEntry>> monthly() {
+    public ResponseEntity<List<LeaderboardService.LeaderEntry>> monthly() {
         final List<ReviewGamePick> picks = reviewGameStateService.generateDailyPicks();
         final LocalDate today = picks.isEmpty() ? GameDate.todayUtc() : picks.getFirst().getPickDate();
-        
+
         // Last 30 days including today
         final LocalDate start = today.minusDays(29);
         final LocalDate end = today;
 
         final List<Guess> guesses = guessRepository.findAllBetween(start, end);
-        return getGuessResponse(guesses, today);
+        return ResponseEntity.ok(leaderboardService.buildLeaderboard(guesses, today));
     }
 
     @GetMapping("/season")
-    public ResponseEntity<List<LeaderEntry>> season() {
+    public ResponseEntity<List<LeaderboardService.LeaderEntry>> season() {
         final LocalDate today = GameDate.todayUtc();
         final Season season = seasonService.findSeasonContaining(today)
                 .orElseGet(() -> seasonService.ensureSeasonForDate(today));
@@ -103,13 +93,13 @@ public class LeaderboardController {
             final Cache.ValueWrapper wrapper = cache.get(cacheKey);
             if (wrapper != null && wrapper.get() instanceof List<?> cached) {
                 @SuppressWarnings("unchecked")
-                final List<LeaderEntry> cachedEntries = (List<LeaderEntry>) cached;
+                final List<LeaderboardService.LeaderEntry> cachedEntries = (List<LeaderboardService.LeaderEntry>) cached;
                 return ResponseEntity.ok(cachedEntries);
             }
         }
 
         final List<Guess> guesses = guessRepository.findAllBetween(season.getStartDate(), asOfDate);
-        final ResponseEntity<List<LeaderEntry>> response = getGuessResponse(guesses, asOfDate);
+        final ResponseEntity<List<LeaderboardService.LeaderEntry>> response = ResponseEntity.ok(leaderboardService.buildLeaderboard(guesses, asOfDate));
         if (cache != null && response.getBody() != null) {
             cache.put(cacheKey, response.getBody());
         }
@@ -118,98 +108,9 @@ public class LeaderboardController {
 
     @GetMapping(value = {"", "/", "/all"})
     @Cacheable(value = "leaderboard-static", key = "'all-time:' + T(org.steam5.domain.GameDate).todayUtc()", unless = "#result == null || #result.body == null")
-    public ResponseEntity<List<LeaderEntry>> allTime() {
+    public ResponseEntity<List<LeaderboardService.LeaderEntry>> allTime() {
         final LocalDate today = GameDate.todayUtc();
-        final List<GuessRepository.AllTimeStatsRow> rows = guessRepository.aggregateAllTimeStats();
-        if (rows.isEmpty()) {
-            return ResponseEntity.ok(List.of());
-        }
-
-        final List<String> steamIds = rows.stream().map(GuessRepository.AllTimeStatsRow::getSteamId).toList();
-        final Map<String, User> usersById = userRepository.findAllById(steamIds).stream()
-                .collect(Collectors.toMap(User::getSteamId, user -> user));
-        final Map<String, List<LocalDate>> streakDatesById = guessRepository
-                .findDistinctDatesUpToForUsers(steamIds, today)
-                .stream()
-                .collect(Collectors.groupingBy(GuessRepository.UserDateRow::getSteamId,
-                        Collectors.mapping(GuessRepository.UserDateRow::getGameDate, Collectors.toList())));
-
-        final List<LeaderEntry> out = rows.stream()
-                .map(row -> {
-                    final User user = usersById.get(row.getSteamId());
-                    final List<LocalDate> dates = streakDatesById.getOrDefault(row.getSteamId(), List.of());
-                    final int streak = StreakCalculator.currentStreak(dates, today);
-                    return getLeaderEntry(
-                            row.getSteamId(),
-                            row.getTotalPoints() != null ? row.getTotalPoints() : 0L,
-                            row.getRounds() != null ? row.getRounds() : 0L,
-                            row.getHits() != null ? row.getHits() : 0L,
-                            row.getFlops() != null ? row.getFlops() : 0L,
-                            row.getTooHigh() != null ? row.getTooHigh() : 0L,
-                            row.getTooLow() != null ? row.getTooLow() : 0L,
-                            row.getAvgPoints() != null ? row.getAvgPoints() : 0.0,
-                            streak,
-                            user
-                    );
-                })
-                .toList();
-        return ResponseEntity.ok(out);
-    }
-
-    @NotNull
-    private ResponseEntity<List<LeaderEntry>> getGuessResponse(final List<Guess> guesses, final LocalDate asOfDate) {
-        final Map<String, List<Guess>> byUser = guesses.stream().collect(Collectors.groupingBy(Guess::getSteamId));
-        final Set<String> steamIds = byUser.keySet();
-        if (steamIds.isEmpty()) {
-            return ResponseEntity.ok(List.of());
-        }
-
-        final Map<String, User> usersById = userRepository.findAllById(steamIds).stream()
-                .collect(Collectors.toMap(User::getSteamId, user -> user));
-
-        final Map<String, List<LocalDate>> streakDatesById = guessRepository.findDistinctDatesUpToForUsers(List.copyOf(steamIds), asOfDate)
-                .stream()
-                .collect(Collectors.groupingBy(GuessRepository.UserDateRow::getSteamId,
-                        Collectors.mapping(GuessRepository.UserDateRow::getGameDate, Collectors.toList())));
-
-        final List<LeaderEntry> out = byUser.entrySet().stream()
-                .map(entry -> buildEntries(entry, usersById, streakDatesById, asOfDate))
-                .sorted((a, b) -> Long.compare(b.totalPoints, a.totalPoints))
-                .toList();
-        return ResponseEntity.ok(out);
-    }
-
-    @NotNull
-    private LeaderboardController.LeaderEntry getLeaderEntry(final String steamId, final long totalPoints, final long rounds, final long hits, final long flops, final long tooHigh, final long tooLow, final double avgPoints, final int streak, final User user) {
-        final String personaName = user != null && user.getPersonaName() != null && !user.getPersonaName().isBlank() ? user.getPersonaName() : steamId;
-        final String avatar = user != null && user.getAvatarFull() != null && !user.getAvatarFull().isBlank() ? user.getAvatarFull() : null;
-        final String avatarBlurdata = user != null && user.getBlurdataAvatarFull() != null && !user.getBlurdataAvatarFull().isBlank() ? user.getBlurdataAvatarFull() : null;
-        final String profileUrl = user != null && user.getProfileUrl() != null && !user.getProfileUrl().isBlank() ? user.getProfileUrl() : null;
-        return new LeaderEntry(steamId, personaName, totalPoints, rounds, hits, flops, tooHigh, tooLow, avgPoints, streak, avatar, avatarBlurdata, profileUrl);
-    }
-
-    private LeaderEntry buildEntries(final Map.Entry<String, List<Guess>> entry,
-                                     final Map<String, User> usersById,
-                                     final Map<String, List<LocalDate>> streakDatesById,
-                                     final LocalDate asOfDate) {
-        final String steamId = entry.getKey();
-        final GuessStats stats = GuessStats.from(entry.getValue());
-        final User user = usersById.get(steamId);
-        final List<LocalDate> dates = streakDatesById.getOrDefault(steamId, List.of());
-        final int streak = StreakCalculator.currentStreak(dates, asOfDate);
-        return getLeaderEntry(steamId, stats.totalPoints(), stats.rounds(), stats.hits(),
-                stats.flops(), stats.tooHigh(), stats.tooLow(), stats.avgPoints(), streak, user);
-    }
-
-    public record LeaderEntry(String steamId,
-                              String personaName,
-                              long totalPoints, long rounds,
-                              long hits, long flops, long tooHigh, long tooLow,
-                              double avgPoints,
-                              int streak,
-                              String avatar,
-                              String avatarBlurdata,
-                              String profileUrl) {
+        return ResponseEntity.ok(leaderboardService.buildAllTimeLeaderboard(today));
     }
 }
 

--- a/backend/src/test/java/org/steam5/service/LeaderboardServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/LeaderboardServiceTest.java
@@ -1,0 +1,119 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.steam5.domain.Guess;
+import org.steam5.domain.User;
+import org.steam5.repository.GuessRepository;
+import org.steam5.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LeaderboardServiceTest {
+
+    private GuessRepository guessRepository;
+    private UserRepository userRepository;
+    private LeaderboardService service;
+
+    @BeforeEach
+    void setUp() {
+        guessRepository = mock(GuessRepository.class);
+        userRepository = mock(UserRepository.class);
+        service = new LeaderboardService(guessRepository, userRepository);
+    }
+
+    @Test
+    void buildLeaderboard_returnsAggregatedLeaders() {
+        LocalDate asOfDate = LocalDate.now();
+        Guess g1 = new Guess(1L, "u1", asOfDate, 1, 100L, "1-100", "1-100", 5, OffsetDateTime.now());
+        Guess g2 = new Guess(2L, "u1", asOfDate, 2, 200L, "101-1000", "1001-10000", 3, OffsetDateTime.now());
+        Guess g3 = new Guess(3L, "u2", asOfDate, 1, 300L, "1001-10000", "101-1000", 1, OffsetDateTime.now());
+        List<Guess> guesses = List.of(g1, g2, g3);
+
+        User u1 = new User();
+        u1.setSteamId("u1");
+        u1.setPersonaName("User One");
+        when(userRepository.findAllById(any())).thenReturn(List.of(u1));
+
+        List<LeaderboardService.LeaderEntry> result = service.buildLeaderboard(guesses, asOfDate);
+
+        assertEquals(2, result.size());
+
+        LeaderboardService.LeaderEntry first = result.get(0);
+        assertEquals("u1", first.steamId());
+        assertEquals("User One", first.personaName());
+        assertEquals(8L, first.totalPoints());
+        assertEquals(2L, first.rounds());
+        assertEquals(1L, first.hits());
+        assertEquals(0L, first.flops());
+        assertEquals(0L, first.tooHigh());
+        assertEquals(1L, first.tooLow());
+        assertEquals(4.0, first.avgPoints());
+        assertEquals(0, first.streak());
+
+        LeaderboardService.LeaderEntry second = result.get(1);
+        assertEquals("u2", second.steamId());
+        assertEquals("u2", second.personaName()); // no User record found — falls back to steamId
+        assertEquals(1L, second.totalPoints());
+        assertEquals(1L, second.rounds());
+        assertEquals(0L, second.hits());
+        assertEquals(1L, second.tooHigh());
+        assertEquals(0L, second.tooLow());
+        assertEquals(1.0, second.avgPoints());
+    }
+
+    @Test
+    void buildLeaderboard_emptyGuesses_returnsEmptyList() {
+        assertEquals(List.of(), service.buildLeaderboard(List.of(), LocalDate.now()));
+    }
+
+    @Test
+    void buildAllTimeLeaderboard_returnsAggregatedLeaders() {
+        // allTime aggregates in SQL via aggregateAllTimeStats(), already ordered by
+        // total points descending — not by walking raw Guess rows.
+        final GuessRepository.AllTimeStatsRow r1 = mock(GuessRepository.AllTimeStatsRow.class);
+        when(r1.getSteamId()).thenReturn("u1");
+        when(r1.getTotalPoints()).thenReturn(5L);
+        when(r1.getRounds()).thenReturn(1L);
+        when(r1.getHits()).thenReturn(1L);
+        when(r1.getFlops()).thenReturn(0L);
+        when(r1.getTooHigh()).thenReturn(0L);
+        when(r1.getTooLow()).thenReturn(0L);
+        when(r1.getAvgPoints()).thenReturn(5.0);
+
+        final GuessRepository.AllTimeStatsRow r2 = mock(GuessRepository.AllTimeStatsRow.class);
+        when(r2.getSteamId()).thenReturn("u2");
+        when(r2.getTotalPoints()).thenReturn(1L);
+        when(r2.getRounds()).thenReturn(1L);
+        when(r2.getHits()).thenReturn(0L);
+        when(r2.getFlops()).thenReturn(0L);
+        when(r2.getTooHigh()).thenReturn(1L);
+        when(r2.getTooLow()).thenReturn(0L);
+        when(r2.getAvgPoints()).thenReturn(1.0);
+
+        when(guessRepository.aggregateAllTimeStats()).thenReturn(List.of(r1, r2));
+        // findAllById / findDistinctDatesUpToForUsers intentionally left unstubbed —
+        // Mockito's empty-collection defaults exercise the null-safe fallback path.
+
+        List<LeaderboardService.LeaderEntry> result = service.buildAllTimeLeaderboard(LocalDate.now());
+
+        assertEquals(2, result.size());
+        assertEquals("u1", result.get(0).steamId());
+        assertEquals(5L, result.get(0).totalPoints());
+        assertEquals("u2", result.get(1).steamId());
+    }
+
+    @Test
+    void buildAllTimeLeaderboard_noRows_returnsEmptyList() {
+        when(guessRepository.aggregateAllTimeStats()).thenReturn(List.of());
+        assertEquals(List.of(), service.buildAllTimeLeaderboard(LocalDate.now()));
+    }
+}

--- a/backend/src/test/java/org/steam5/web/LeaderboardControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/LeaderboardControllerTest.java
@@ -6,101 +6,78 @@ import org.springframework.cache.CacheManager;
 import org.springframework.http.ResponseEntity;
 import org.steam5.domain.Guess;
 import org.steam5.domain.ReviewGamePick;
-import org.steam5.domain.User;
 import org.steam5.repository.GuessRepository;
-import org.steam5.repository.UserRepository;
+import org.steam5.service.LeaderboardService;
 import org.steam5.service.ReviewGameStateService;
 import org.steam5.service.SeasonService;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class LeaderboardControllerTest {
 
     private GuessRepository guessRepository;
     private ReviewGameStateService reviewGameStateService;
-    private UserRepository userRepository;
     private SeasonService seasonService;
     private CacheManager cacheManager;
+    private LeaderboardService leaderboardService;
 
     @BeforeEach
     void setUp() {
         guessRepository = mock(GuessRepository.class);
         reviewGameStateService = mock(ReviewGameStateService.class);
-        userRepository = mock(UserRepository.class);
         seasonService = mock(SeasonService.class);
         cacheManager = mock(CacheManager.class);
+        leaderboardService = mock(LeaderboardService.class);
     }
 
     @Test
-    void today_returnsAggregatedLeaders() {
-        LeaderboardController c = new LeaderboardController(guessRepository, reviewGameStateService, userRepository, seasonService, cacheManager);
-        when(reviewGameStateService.generateDailyPicks()).thenReturn(List.of(new ReviewGamePick(1L, LocalDate.now(), 42L, OffsetDateTime.now())));
+    void today_fetchesGuessesThenDelegatesToService() {
+        LeaderboardController c = new LeaderboardController(guessRepository, reviewGameStateService, seasonService, cacheManager, leaderboardService);
+        LocalDate pickDate = LocalDate.now();
+        when(reviewGameStateService.generateDailyPicks()).thenReturn(List.of(new ReviewGamePick(1L, pickDate, 42L, OffsetDateTime.now())));
 
-        Guess g1 = new Guess(1L, "u1", LocalDate.now(), 1, 100L, "1-100", "1-100", 5, OffsetDateTime.now());
-        Guess g2 = new Guess(2L, "u1", LocalDate.now(), 2, 200L, "101-1000", "1001-10000", 3, OffsetDateTime.now());
-        Guess g3 = new Guess(3L, "u2", LocalDate.now(), 1, 300L, "1001-10000", "101-1000", 1, OffsetDateTime.now());
-        when(guessRepository.findAllByDate(any(LocalDate.class))).thenReturn(List.of(g1, g2, g3));
+        Guess g1 = new Guess(1L, "u1", pickDate, 1, 100L, "1-100", "1-100", 5, OffsetDateTime.now());
+        List<Guess> guesses = List.of(g1);
+        when(guessRepository.findAllByDate(pickDate)).thenReturn(guesses);
 
-        User u1 = new User();
-        u1.setSteamId("u1");
-        u1.setPersonaName("User One");
-        when(userRepository.findById("u1")).thenReturn(Optional.of(u1));
-        when(userRepository.findById("u2")).thenReturn(Optional.empty());
+        List<LeaderboardService.LeaderEntry> canned = List.of(
+                new LeaderboardService.LeaderEntry("u1", "User One", 5L, 1L, 1L, 0L, 0L, 0L, 5.0, 1, null, null, null)
+        );
+        when(leaderboardService.buildLeaderboard(guesses, pickDate)).thenReturn(canned);
 
-        ResponseEntity<List<LeaderboardController.LeaderEntry>> res = c.today();
+        ResponseEntity<List<LeaderboardService.LeaderEntry>> res = c.today();
         assertEquals(200, res.getStatusCode().value());
         assertNotNull(res.getBody());
-        final var bodyToday = res.getBody();
-        assertNotNull(bodyToday);
-        assertEquals(2, bodyToday.size());
+        assertSame(canned, res.getBody());
+        verify(guessRepository).findAllByDate(pickDate);
+        verify(leaderboardService).buildLeaderboard(guesses, pickDate);
     }
 
     @Test
-    void allTime_returnsAggregatedLeaders() {
-        LeaderboardController c = new LeaderboardController(guessRepository, reviewGameStateService, userRepository, seasonService, cacheManager);
+    void allTime_delegatesToService() {
+        LeaderboardController c = new LeaderboardController(guessRepository, reviewGameStateService, seasonService, cacheManager, leaderboardService);
 
-        // allTime() aggregates in SQL via aggregateAllTimeStats(), already ordered by
-        // total points descending — not by walking raw Guess rows.
-        final GuessRepository.AllTimeStatsRow r1 = mock(GuessRepository.AllTimeStatsRow.class);
-        when(r1.getSteamId()).thenReturn("u1");
-        when(r1.getTotalPoints()).thenReturn(5L);
-        when(r1.getRounds()).thenReturn(1L);
-        when(r1.getHits()).thenReturn(1L);
-        when(r1.getFlops()).thenReturn(0L);
-        when(r1.getTooHigh()).thenReturn(0L);
-        when(r1.getTooLow()).thenReturn(0L);
-        when(r1.getAvgPoints()).thenReturn(5.0);
+        List<LeaderboardService.LeaderEntry> canned = List.of(
+                new LeaderboardService.LeaderEntry("u1", "User One", 5L, 1L, 1L, 0L, 0L, 0L, 5.0, 1, null, null, null),
+                new LeaderboardService.LeaderEntry("u2", "u2", 1L, 1L, 0L, 0L, 1L, 0L, 1.0, 0, null, null, null)
+        );
+        when(leaderboardService.buildAllTimeLeaderboard(any(LocalDate.class))).thenReturn(canned);
 
-        final GuessRepository.AllTimeStatsRow r2 = mock(GuessRepository.AllTimeStatsRow.class);
-        when(r2.getSteamId()).thenReturn("u2");
-        when(r2.getTotalPoints()).thenReturn(1L);
-        when(r2.getRounds()).thenReturn(1L);
-        when(r2.getHits()).thenReturn(0L);
-        when(r2.getFlops()).thenReturn(0L);
-        when(r2.getTooHigh()).thenReturn(1L);
-        when(r2.getTooLow()).thenReturn(0L);
-        when(r2.getAvgPoints()).thenReturn(1.0);
-
-        when(guessRepository.aggregateAllTimeStats()).thenReturn(List.of(r1, r2));
-
-        ResponseEntity<List<LeaderboardController.LeaderEntry>> res = c.allTime();
+        ResponseEntity<List<LeaderboardService.LeaderEntry>> res = c.allTime();
         assertEquals(200, res.getStatusCode().value());
-        final var bodyAll = res.getBody();
-        assertNotNull(bodyAll);
-        assertEquals(2, bodyAll.size());
-        assertEquals("u1", bodyAll.get(0).steamId());
-        assertEquals(5L, bodyAll.get(0).totalPoints());
-        assertEquals("u2", bodyAll.get(1).steamId());
+        assertSame(canned, res.getBody());
+        verify(leaderboardService).buildAllTimeLeaderboard(any(LocalDate.class));
+        verifyNoInteractions(guessRepository);
     }
 }
-
-


### PR DESCRIPTION
## Summary
- Extracts aggregation logic (grouping guesses by user, streak computation, `LeaderEntry` construction) out of `LeaderboardController` into a new `LeaderboardService`, closing #69.
- `GuessRepository` stays in the controller only for date-range fetching (`findAllByDate`/`findAllBetween`); `UserRepository` and all aggregation-only repository calls move into the service.
- `@Cacheable` annotations and `season()`'s manual `CacheManager` read/write are unchanged and stay in the controller.
- Adds `LeaderboardServiceTest` to preserve unit coverage of the real aggregation math, since the trimmed `LeaderboardControllerTest` now only asserts delegation.
- Drops a stale `AGENTS.md` note about two "pre-existing" test failures that no longer reproduce.

Closes #69

## Test plan
- [x] `./gradlew compileJava` — clean
- [x] `./gradlew test` — 94/94 passing, 0 failures
- [x] Manual smoke test against running dev backend: `today`/`weekly`/`monthly`/`season`/`all` all return correctly-shaped, populated JSON (including `season()`'s cache-hit path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)