### PR TITLE
Harden round presence WebSocket feature

### DIFF
--- a/backend/src/main/java/org/steam5/config/PresenceProperties.java
+++ b/backend/src/main/java/org/steam5/config/PresenceProperties.java
@@ -1,0 +1,37 @@
+package org.steam5.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "presence")
+public class PresenceProperties {
+
+    /** Maximum concurrent presence WebSocket sessions across all scopes. */
+    private int maxGlobalConnections = 5_000;
+
+    /** Maximum concurrent sessions for a single scope (e.g. one game day). */
+    private int maxScopeConnections = 500;
+
+    /** Maximum concurrent sessions from a single client IP. */
+    private int maxIpConnections = 20;
+
+    /** Per-IP ticket issuance limit per minute. */
+    private int ticketRateLimitPerMinute = 20;
+
+    /** Per-authenticated-user ticket issuance limit per minute. */
+    private int ticketRateLimitPerUserPerMinute = 10;
+
+    /** Per-IP WebSocket handshake limit per minute. */
+    private int handshakeRateLimitPerMinute = 60;
+
+    /** Close sessions with no ping/pong activity for this many seconds. */
+    private int idleTimeoutSeconds = 90;
+
+    /** How often to sweep for closed or idle sessions (milliseconds). */
+    private long sweepIntervalMs = 30_000L;
+}

--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -72,6 +72,11 @@ public class SecurityConfig {
         return http.build();
     }
 
+    /**
+     * Configures security for application endpoints and registers authentication and rate-limiting filters.
+     *
+     * @return the configured application security filter chain
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
                                                    AdminTokenFilter adminTokenFilter,

--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.steam5.security.AdminTokenFilter;
 import org.steam5.security.AuthRateLimitFilter;
+import org.steam5.security.PresenceRateLimitFilter;
 
 import java.util.Arrays;
 
@@ -74,7 +75,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
                                                    AdminTokenFilter adminTokenFilter,
-                                                   AuthRateLimitFilter authRateLimitFilter) throws Exception {
+                                                   AuthRateLimitFilter authRateLimitFilter,
+                                                   PresenceRateLimitFilter presenceRateLimitFilter) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
@@ -97,6 +99,7 @@ public class SecurityConfig {
                 // addFilterBefore inserts each filter directly before the anchor, so the
                 // first registration ends up earliest in the chain.
                 .addFilterBefore(authRateLimitFilter, BasicAuthenticationFilter.class)
+                .addFilterBefore(presenceRateLimitFilter, BasicAuthenticationFilter.class)
                 .addFilterBefore(adminTokenFilter, BasicAuthenticationFilter.class)
                 .httpBasic(basic -> {
                 })

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -16,6 +16,11 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final PresenceWebSocketHandler presenceHandler;
     private final PresenceHandshakeInterceptor handshakeInterceptor;
 
+    /**
+     * Registers the presence WebSocket endpoint and its handshake interceptor.
+     *
+     * @param registry the registry used to configure WebSocket handlers
+     */
     @Override
     public void registerWebSocketHandlers(final WebSocketHandlerRegistry registry) {
         registry.addHandler(presenceHandler, "/ws/presence")

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -1,128 +1,25 @@
 package org.steam5.config;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.server.ServerHttpRequest;
-import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
-import org.springframework.web.socket.server.HandshakeInterceptor;
-import org.steam5.service.RoundPresenceService;
+import org.steam5.web.ws.PresenceHandshakeInterceptor;
 import org.steam5.web.ws.PresenceWebSocketHandler;
 
-import java.net.URI;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-
-@Slf4j
 @Configuration
 @EnableWebSocket
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
 
     private final PresenceWebSocketHandler presenceHandler;
-    private final List<String> allowedOrigins;
-
-    public WebSocketConfig(
-            final PresenceWebSocketHandler presenceHandler,
-            @Value("${cors.allowedOrigins:https://steam5.org,https://next.steam5.org,http://localhost:3000}") final String originsCsv
-    ) {
-        this.presenceHandler = presenceHandler;
-        this.allowedOrigins = Arrays.stream(originsCsv.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .toList();
-    }
+    private final PresenceHandshakeInterceptor handshakeInterceptor;
 
     @Override
     public void registerWebSocketHandlers(final WebSocketHandlerRegistry registry) {
         registry.addHandler(presenceHandler, "/ws/presence")
-                .addInterceptors(new PresenceHandshakeInterceptor(allowedOrigins))
-                .setAllowedOriginPatterns(allowedOrigins.toArray(new String[0]));
-    }
-
-    /**
-     * Validates the {@code Origin} header against the configured allow-list and
-     * copies the {@code scopeKey} and {@code ticket} query parameters into the
-     * WebSocket session attributes so the handler can read them at connection time.
-     */
-    static class PresenceHandshakeInterceptor implements HandshakeInterceptor {
-
-        private static final Pattern SCOPE_KEY_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}(:\\d+:\\d+)?$");
-        private final List<String> allowedOrigins;
-
-        PresenceHandshakeInterceptor(final List<String> allowedOrigins) {
-            this.allowedOrigins = allowedOrigins;
-        }
-
-        @Override
-        public boolean beforeHandshake(final ServerHttpRequest request,
-                                       final ServerHttpResponse response,
-                                       final WebSocketHandler wsHandler,
-                                       final Map<String, Object> attributes) {
-            final String origin = request.getHeaders().getFirst(HttpHeaders.ORIGIN);
-            if (origin == null || !isAllowed(origin)) {
-                log.debug("Rejecting presence handshake — origin '{}' not in allow-list", origin);
-                return false;
-            }
-
-            final URI uri = request.getURI();
-            final String query = uri.getRawQuery();
-            final String scopeKey = extractParam(query, "scopeKey");
-            final String ticket = extractParam(query, "ticket");
-
-            if (scopeKey == null || scopeKey.isBlank()) {
-                log.debug("Rejecting presence handshake — missing scopeKey");
-                return false;
-            }
-
-            if (!SCOPE_KEY_PATTERN.matcher(scopeKey).matches()) {
-                log.debug("Rejecting presence handshake — malformed scopeKey '{}'", scopeKey);
-                return false;
-            }
-
-            attributes.put(RoundPresenceService.ATTR_SCOPE_KEY, scopeKey);
-            if (ticket != null && !ticket.isBlank()) {
-                attributes.put("ticket", ticket);
-            }
-            return true;
-        }
-
-        private boolean isAllowed(final String origin) {
-            for (final String allowed : allowedOrigins) {
-                if (allowed.equals(origin) || "*".equals(allowed)) return true;
-            }
-            return false;
-        }
-
-        @Override
-        public void afterHandshake(final ServerHttpRequest request,
-                                   final ServerHttpResponse response,
-                                   final WebSocketHandler wsHandler,
-                                   final Exception exception) {
-            // no-op
-        }
-
-        private static String extractParam(final String query, final String name) {
-            if (query == null || query.isEmpty()) return null;
-            for (final String pair : query.split("&")) {
-                final int eq = pair.indexOf('=');
-                if (eq < 0) continue;
-                final String key = pair.substring(0, eq);
-                if (!name.equals(key)) continue;
-                final String rawValue = pair.substring(eq + 1);
-                try {
-                    return java.net.URLDecoder.decode(rawValue, java.nio.charset.StandardCharsets.UTF_8);
-                } catch (IllegalArgumentException e) {
-                    return null;
-                }
-            }
-            return null;
-        }
+                .addInterceptors(handshakeInterceptor)
+                .setAllowedOriginPatterns("*");
     }
 }

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -20,6 +20,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
     public void registerWebSocketHandlers(final WebSocketHandlerRegistry registry) {
         registry.addHandler(presenceHandler, "/ws/presence")
                 .addInterceptors(handshakeInterceptor)
-                .setAllowedOriginPatterns("*");
+                .setAllowedOriginPatterns(handshakeInterceptor.getAllowedOrigins().toArray(new String[0]));
     }
 }

--- a/backend/src/main/java/org/steam5/job/PresenceMaintenanceScheduler.java
+++ b/backend/src/main/java/org/steam5/job/PresenceMaintenanceScheduler.java
@@ -1,0 +1,21 @@
+package org.steam5.job;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.steam5.service.RoundPresenceService;
+
+/**
+ * Periodically prunes closed or idle presence sessions and rebroadcasts updated counts.
+ */
+@Component
+@RequiredArgsConstructor
+public class PresenceMaintenanceScheduler {
+
+    private final RoundPresenceService presenceService;
+
+    @Scheduled(fixedDelayString = "${presence.sweep-interval-ms:30000}")
+    public void sweepPresenceSessions() {
+        presenceService.sweepIdleAndClosed();
+    }
+}

--- a/backend/src/main/java/org/steam5/job/PresenceMaintenanceScheduler.java
+++ b/backend/src/main/java/org/steam5/job/PresenceMaintenanceScheduler.java
@@ -14,6 +14,9 @@ public class PresenceMaintenanceScheduler {
 
     private final RoundPresenceService presenceService;
 
+    /**
+     * Prunes idle and closed presence sessions and rebroadcasts updated presence counts.
+     */
     @Scheduled(fixedDelayString = "${presence.sweep-interval-ms:30000}")
     public void sweepPresenceSessions() {
         presenceService.sweepIdleAndClosed();

--- a/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
@@ -6,8 +6,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.steam5.service.PresenceRateLimiter;
 
@@ -21,18 +22,14 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class PresenceRateLimitFilter extends OncePerRequestFilter {
 
-    private static final String TICKET_PATH = "/api/ws/ticket";
+    private static final AntPathRequestMatcher TICKET_MATCHER =
+            new AntPathRequestMatcher("/api/ws/ticket", HttpMethod.POST.name());
 
     private final PresenceRateLimiter presenceRateLimiter;
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        String path = request.getRequestURI();
-        final String contextPath = request.getContextPath();
-        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-        return !"POST".equalsIgnoreCase(request.getMethod()) || !TICKET_PATH.equals(path);
+        return !TICKET_MATCHER.matches(request);
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
@@ -1,0 +1,52 @@
+package org.steam5.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.steam5.service.PresenceRateLimiter;
+
+import java.io.IOException;
+
+/**
+ * Per-IP rate limiter for {@code POST /api/ws/ticket}.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PresenceRateLimitFilter extends OncePerRequestFilter {
+
+    private static final String TICKET_PATH = "/api/ws/ticket";
+
+    private final PresenceRateLimiter presenceRateLimiter;
+
+    @Override
+    protected boolean shouldNotFilter(final HttpServletRequest request) {
+        String path = request.getRequestURI();
+        final String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+        return !"POST".equalsIgnoreCase(request.getMethod()) || !TICKET_PATH.equals(path);
+    }
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request,
+                                    final HttpServletResponse response,
+                                    final FilterChain chain) throws ServletException, IOException {
+        final String ip = request.getRemoteAddr();
+        if (!presenceRateLimiter.tryAcquireTicket(ip)) {
+            log.warn("Presence ticket rate limit exceeded: ip={}", ip);
+            response.setStatus(429);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"rate_limit_exceeded\"}");
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
@@ -6,9 +6,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.steam5.service.PresenceRateLimiter;
 
@@ -22,14 +21,18 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class PresenceRateLimitFilter extends OncePerRequestFilter {
 
-    private static final AntPathRequestMatcher TICKET_MATCHER =
-            new AntPathRequestMatcher("/api/ws/ticket", HttpMethod.POST.name());
+    private static final String TICKET_PATH = "/api/ws/ticket";
 
     private final PresenceRateLimiter presenceRateLimiter;
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        return !TICKET_MATCHER.matches(request);
+        String path = request.getRequestURI();
+        final String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+        return !"POST".equalsIgnoreCase(request.getMethod()) || !TICKET_PATH.equals(path);
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
@@ -25,6 +25,12 @@ public class PresenceRateLimitFilter extends OncePerRequestFilter {
 
     private final PresenceRateLimiter presenceRateLimiter;
 
+    /**
+     * Determines whether the request should bypass presence ticket rate limiting.
+     *
+     * @param request the incoming HTTP request
+     * @return {@code true} unless the request is a {@code POST} to {@code /api/ws/ticket}
+     */
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
         String path = request.getRequestURI();
@@ -35,6 +41,15 @@ public class PresenceRateLimitFilter extends OncePerRequestFilter {
         return !"POST".equalsIgnoreCase(request.getMethod()) || !TICKET_PATH.equals(path);
     }
 
+    /**
+     * Enforces the presence ticket rate limit for the request's client IP.
+     *
+     * @param request  the incoming HTTP request
+     * @param response the HTTP response
+     * @param chain    the filter chain
+     * @throws IOException      if writing the response or continuing the chain fails
+     * @throws ServletException if continuing the filter chain fails
+     */
     @Override
     protected void doFilterInternal(final HttpServletRequest request,
                                     final HttpServletResponse response,

--- a/backend/src/main/java/org/steam5/service/PresenceMetrics.java
+++ b/backend/src/main/java/org/steam5/service/PresenceMetrics.java
@@ -1,0 +1,68 @@
+package org.steam5.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Micrometer metrics for the round-presence WebSocket feature.
+ */
+@Component
+public class PresenceMetrics {
+
+    private final Counter handshakeRejected;
+    private final Counter broadcastFailures;
+    private final Counter ticketsIssued;
+    private final Counter ticketsInvalid;
+    private final Counter idleTimeouts;
+
+    public PresenceMetrics(final MeterRegistry meterRegistry, @Lazy final RoundPresenceService presenceService) {
+        this.handshakeRejected = Counter.builder("presence.handshake.rejected")
+                .description("Presence WebSocket handshakes rejected")
+                .tag("application", "steam5")
+                .register(meterRegistry);
+        this.broadcastFailures = Counter.builder("presence.broadcast.failures")
+                .description("Failed presence snapshot broadcasts to a session")
+                .tag("application", "steam5")
+                .register(meterRegistry);
+        this.ticketsIssued = Counter.builder("presence.ticket.issued")
+                .description("Short-lived WebSocket tickets issued")
+                .tag("application", "steam5")
+                .register(meterRegistry);
+        this.ticketsInvalid = Counter.builder("presence.ticket.invalid")
+                .description("Invalid or expired WebSocket tickets presented at handshake")
+                .tag("application", "steam5")
+                .register(meterRegistry);
+        this.idleTimeouts = Counter.builder("presence.session.idle_timeout")
+                .description("Presence sessions closed due to inactivity")
+                .tag("application", "steam5")
+                .register(meterRegistry);
+
+        Gauge.builder("presence.connections.active", presenceService::activeConnectionCount)
+                .description("Active presence WebSocket connections")
+                .tag("application", "steam5")
+                .register(meterRegistry);
+    }
+
+    public void recordHandshakeRejected() {
+        handshakeRejected.increment();
+    }
+
+    public void recordBroadcastFailure() {
+        broadcastFailures.increment();
+    }
+
+    public void recordTicketIssued() {
+        ticketsIssued.increment();
+    }
+
+    public void recordTicketInvalid() {
+        ticketsInvalid.increment();
+    }
+
+    public void recordIdleTimeout() {
+        idleTimeouts.increment();
+    }
+}

--- a/backend/src/main/java/org/steam5/service/PresenceMetrics.java
+++ b/backend/src/main/java/org/steam5/service/PresenceMetrics.java
@@ -17,8 +17,10 @@ public class PresenceMetrics {
     private final Counter ticketsIssued;
     private final Counter ticketsInvalid;
     private final Counter idleTimeouts;
+    private final MeterRegistry meterRegistry;
 
     public PresenceMetrics(final MeterRegistry meterRegistry, @Lazy final RoundPresenceService presenceService) {
+        this.meterRegistry = meterRegistry;
         this.handshakeRejected = Counter.builder("presence.handshake.rejected")
                 .description("Presence WebSocket handshakes rejected")
                 .tag("application", "steam5")
@@ -64,5 +66,14 @@ public class PresenceMetrics {
 
     public void recordIdleTimeout() {
         idleTimeouts.increment();
+    }
+
+    public void recordRegistrationRejected(final String reason) {
+        Counter.builder("presence.registration.rejected")
+                .description("Presence session registrations rejected after handshake")
+                .tag("application", "steam5")
+                .tag("reason", reason)
+                .register(meterRegistry)
+                .increment();
     }
 }

--- a/backend/src/main/java/org/steam5/service/PresenceMetrics.java
+++ b/backend/src/main/java/org/steam5/service/PresenceMetrics.java
@@ -19,6 +19,12 @@ public class PresenceMetrics {
     private final Counter idleTimeouts;
     private final MeterRegistry meterRegistry;
 
+    /**
+     * Creates the presence metrics and registers them with the specified meter registry.
+     *
+     * @param meterRegistry   the registry used to register presence metrics
+     * @param presenceService the service that provides the active connection count
+     */
     public PresenceMetrics(final MeterRegistry meterRegistry, @Lazy final RoundPresenceService presenceService) {
         this.meterRegistry = meterRegistry;
         this.handshakeRejected = Counter.builder("presence.handshake.rejected")
@@ -48,26 +54,46 @@ public class PresenceMetrics {
                 .register(meterRegistry);
     }
 
+    /**
+     * Records a rejected presence WebSocket handshake.
+     */
     public void recordHandshakeRejected() {
         handshakeRejected.increment();
     }
 
+    /**
+     * Records a failed presence snapshot broadcast.
+     */
     public void recordBroadcastFailure() {
         broadcastFailures.increment();
     }
 
+    /**
+     * Records the issuance of a WebSocket ticket.
+     */
     public void recordTicketIssued() {
         ticketsIssued.increment();
     }
 
+    /**
+     * Records an invalid or expired WebSocket ticket presented during a handshake.
+     */
     public void recordTicketInvalid() {
         ticketsInvalid.increment();
     }
 
+    /**
+     * Records a presence session closed due to inactivity.
+     */
     public void recordIdleTimeout() {
         idleTimeouts.increment();
     }
 
+    /**
+     * Records a rejected presence session registration after the WebSocket handshake.
+     *
+     * @param reason the reason the registration was rejected
+     */
     public void recordRegistrationRejected(final String reason) {
         Counter.builder("presence.registration.rejected")
                 .description("Presence session registrations rejected after handshake")

--- a/backend/src/main/java/org/steam5/service/PresenceRateLimiter.java
+++ b/backend/src/main/java/org/steam5/service/PresenceRateLimiter.java
@@ -1,0 +1,54 @@
+package org.steam5.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.steam5.config.PresenceProperties;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Fixed-window rate limiter for presence ticket issuance and WebSocket handshakes.
+ */
+@Service
+@RequiredArgsConstructor
+public class PresenceRateLimiter {
+
+    private final PresenceProperties properties;
+
+    private final Cache<String, AtomicInteger> ticketByIp = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(1))
+            .maximumSize(10_000)
+            .build();
+
+    private final Cache<String, AtomicInteger> ticketByUser = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(1))
+            .maximumSize(10_000)
+            .build();
+
+    private final Cache<String, AtomicInteger> handshakeByIp = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(1))
+            .maximumSize(10_000)
+            .build();
+
+    public boolean tryAcquireTicket(final String ip) {
+        if (ip == null || ip.isBlank()) return true;
+        return increment(ticketByIp, ip) <= properties.getTicketRateLimitPerMinute();
+    }
+
+    public boolean tryAcquireTicketForUser(final String steamId) {
+        if (steamId == null || steamId.isBlank()) return true;
+        return increment(ticketByUser, steamId) <= properties.getTicketRateLimitPerUserPerMinute();
+    }
+
+    public boolean tryAcquireHandshake(final String ip) {
+        if (ip == null || ip.isBlank()) return true;
+        return increment(handshakeByIp, ip) <= properties.getHandshakeRateLimitPerMinute();
+    }
+
+    private static int increment(final Cache<String, AtomicInteger> cache, final String key) {
+        return cache.get(key, k -> new AtomicInteger(0)).incrementAndGet();
+    }
+}

--- a/backend/src/main/java/org/steam5/service/PresenceRateLimiter.java
+++ b/backend/src/main/java/org/steam5/service/PresenceRateLimiter.java
@@ -33,21 +33,46 @@ public class PresenceRateLimiter {
             .maximumSize(10_000)
             .build();
 
+    /**
+     * Determines whether a presence ticket request from an IP address is within the configured rate limit.
+     *
+     * @param ip the requesting IP address; blank or null values are allowed without rate limiting
+     * @return {@code true} if the request is allowed, {@code false} otherwise
+     */
     public boolean tryAcquireTicket(final String ip) {
         if (ip == null || ip.isBlank()) return true;
         return increment(ticketByIp, ip) <= properties.getTicketRateLimitPerMinute();
     }
 
+    /**
+     * Determines whether a presence ticket request is allowed for a user.
+     *
+     * @param steamId the Steam user identifier used for rate limiting
+     * @return {@code true} if the request is within the configured per-user limit or the identifier is blank, {@code false} otherwise
+     */
     public boolean tryAcquireTicketForUser(final String steamId) {
         if (steamId == null || steamId.isBlank()) return true;
         return increment(ticketByUser, steamId) <= properties.getTicketRateLimitPerUserPerMinute();
     }
 
+    /**
+     * Determines whether a WebSocket handshake attempt from an IP address is within the configured rate limit.
+     *
+     * @param ip the source IP address
+     * @return {@code true} if the attempt is allowed or the IP address is blank, {@code false} otherwise
+     */
     public boolean tryAcquireHandshake(final String ip) {
         if (ip == null || ip.isBlank()) return true;
         return increment(handshakeByIp, ip) <= properties.getHandshakeRateLimitPerMinute();
     }
 
+    /**
+     * Increments the counter associated with a key and returns its updated value.
+     *
+     * @param cache the cache containing counters by key
+     * @param key   the counter key
+     * @return the incremented counter value
+     */
     private static int increment(final Cache<String, AtomicInteger> cache, final String key) {
         return cache.get(key, k -> new AtomicInteger(0)).incrementAndGet();
     }

--- a/backend/src/main/java/org/steam5/service/RoundPresenceService.java
+++ b/backend/src/main/java/org/steam5/service/RoundPresenceService.java
@@ -65,35 +65,38 @@ public class RoundPresenceService {
             new ConcurrentHashMap<>();
     private final AtomicInteger globalConnections = new AtomicInteger();
     private final ConcurrentHashMap<String, AtomicInteger> connectionsByIp = new ConcurrentHashMap<>();
+    private final Object registerLock = new Object();
 
     public RegisterResult register(final WebSocketSession session) {
         final String scopeKey = scopeKeyOf(session);
         if (scopeKey == null) return RegisterResult.SCOPE_LIMIT;
 
-        if (globalConnections.get() >= properties.getMaxGlobalConnections()) {
-            return RegisterResult.GLOBAL_LIMIT;
-        }
-        if (scopeSize(scopeKey) >= properties.getMaxScopeConnections()) {
-            return RegisterResult.SCOPE_LIMIT;
-        }
-
-        final String clientIp = clientIpOf(session);
-        if (clientIp != null) {
-            final AtomicInteger ipCount = connectionsByIp.computeIfAbsent(clientIp, k -> new AtomicInteger(0));
-            if (ipCount.get() >= properties.getMaxIpConnections()) {
-                return RegisterResult.IP_LIMIT;
+        synchronized (registerLock) {
+            if (globalConnections.get() >= properties.getMaxGlobalConnections()) {
+                return RegisterResult.GLOBAL_LIMIT;
             }
-        }
+            if (scopeSize(scopeKey) >= properties.getMaxScopeConnections()) {
+                return RegisterResult.SCOPE_LIMIT;
+            }
 
-        sessionsByScope
-                .computeIfAbsent(scopeKey, k -> new CopyOnWriteArrayList<>())
-                .add(session);
-        globalConnections.incrementAndGet();
-        if (clientIp != null) {
-            connectionsByIp.computeIfAbsent(clientIp, k -> new AtomicInteger(0)).incrementAndGet();
+            final String clientIp = clientIpOf(session);
+            if (clientIp != null) {
+                final AtomicInteger ipCount = connectionsByIp.computeIfAbsent(clientIp, k -> new AtomicInteger(0));
+                if (ipCount.get() >= properties.getMaxIpConnections()) {
+                    return RegisterResult.IP_LIMIT;
+                }
+            }
+
+            sessionsByScope
+                    .computeIfAbsent(scopeKey, k -> new CopyOnWriteArrayList<>())
+                    .add(session);
+            globalConnections.incrementAndGet();
+            if (clientIp != null) {
+                connectionsByIp.computeIfAbsent(clientIp, k -> new AtomicInteger(0)).incrementAndGet();
+            }
+            touchActivity(session);
+            return RegisterResult.OK;
         }
-        touchActivity(session);
-        return RegisterResult.OK;
     }
 
     public void unregister(final WebSocketSession session) {

--- a/backend/src/main/java/org/steam5/service/RoundPresenceService.java
+++ b/backend/src/main/java/org/steam5/service/RoundPresenceService.java
@@ -1,32 +1,41 @@
 package org.steam5.service;
 
 import lombok.RequiredArgsConstructor;
-import tools.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * In-memory registry of active WebSocket sessions per round scope. Broadcasts
+ * In-memory registry of active WebSocket sessions per game-day scope. Broadcasts
  * per-scope presence snapshots when membership changes.
  *
- * <p>Session attribute keys (populated by the handshake interceptor and the
- * WebSocket handler at connection time):</p>
+ * <p>Presence is scoped to a game day ({@code YYYY-MM-DD}). All live round pages
+ * for that day share one pool so counts reflect everyone playing today's game.</p>
+ *
+ * <p>Session attribute keys:</p>
  * <ul>
- *   <li>{@link #ATTR_SCOPE_KEY} — round scope in the form {@code gameDate:roundIndex:appId}</li>
+ *   <li>{@link #ATTR_SCOPE_KEY} — game day in the form {@code YYYY-MM-DD}</li>
+ *   <li>{@link #ATTR_CLIENT_IP} — client IP captured at handshake</li>
  *   <li>{@link #ATTR_STEAM_ID} — verified steamId, or {@code null} for anonymous</li>
  *   <li>{@link #ATTR_PERSONA_NAME} — display name (authenticated only)</li>
  *   <li>{@link #ATTR_AVATAR} — avatar URL (authenticated only)</li>
+ *   <li>{@link #ATTR_LAST_ACTIVITY} — epoch millis of last ping/pong/connect</li>
  * </ul>
  */
 @Slf4j
@@ -35,29 +44,126 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class RoundPresenceService {
 
     public static final String ATTR_SCOPE_KEY = "scopeKey";
+    public static final String ATTR_CLIENT_IP = "clientIp";
     public static final String ATTR_STEAM_ID = "steamId";
     public static final String ATTR_PERSONA_NAME = "personaName";
     public static final String ATTR_AVATAR = "avatar";
+    public static final String ATTR_LAST_ACTIVITY = "lastActivityAt";
+
+    public enum RegisterResult {
+        OK,
+        GLOBAL_LIMIT,
+        SCOPE_LIMIT,
+        IP_LIMIT
+    }
 
     private final ObjectMapper objectMapper;
+    private final org.steam5.config.PresenceProperties properties;
+    private final ObjectProvider<PresenceMetrics> presenceMetrics;
+
     private final ConcurrentHashMap<String, CopyOnWriteArrayList<WebSocketSession>> sessionsByScope =
             new ConcurrentHashMap<>();
+    private final AtomicInteger globalConnections = new AtomicInteger();
+    private final ConcurrentHashMap<String, AtomicInteger> connectionsByIp = new ConcurrentHashMap<>();
 
-    public void register(final WebSocketSession session) {
+    public RegisterResult register(final WebSocketSession session) {
         final String scopeKey = scopeKeyOf(session);
-        if (scopeKey == null) return;
+        if (scopeKey == null) return RegisterResult.SCOPE_LIMIT;
+
+        if (globalConnections.get() >= properties.getMaxGlobalConnections()) {
+            return RegisterResult.GLOBAL_LIMIT;
+        }
+        if (scopeSize(scopeKey) >= properties.getMaxScopeConnections()) {
+            return RegisterResult.SCOPE_LIMIT;
+        }
+
+        final String clientIp = clientIpOf(session);
+        if (clientIp != null) {
+            final AtomicInteger ipCount = connectionsByIp.computeIfAbsent(clientIp, k -> new AtomicInteger(0));
+            if (ipCount.get() >= properties.getMaxIpConnections()) {
+                return RegisterResult.IP_LIMIT;
+            }
+        }
+
         sessionsByScope
                 .computeIfAbsent(scopeKey, k -> new CopyOnWriteArrayList<>())
                 .add(session);
+        globalConnections.incrementAndGet();
+        if (clientIp != null) {
+            connectionsByIp.computeIfAbsent(clientIp, k -> new AtomicInteger(0)).incrementAndGet();
+        }
+        touchActivity(session);
+        return RegisterResult.OK;
     }
 
     public void unregister(final WebSocketSession session) {
         final String scopeKey = scopeKeyOf(session);
         if (scopeKey == null) return;
         sessionsByScope.computeIfPresent(scopeKey, (k, list) -> {
-            list.remove(session);
+            if (list.remove(session)) {
+                decrementConnectionCounters(session);
+            }
             return list.isEmpty() ? null : list;
         });
+    }
+
+    public void touchActivity(final WebSocketSession session) {
+        session.getAttributes().put(ATTR_LAST_ACTIVITY, System.currentTimeMillis());
+    }
+
+    public void handleClientMessage(final WebSocketSession session, final String payload) {
+        try {
+            final JsonNode node = objectMapper.readTree(payload);
+            final String type = node.path("type").asText(null);
+            if ("ping".equals(type) || "pong".equals(type)) {
+                touchActivity(session);
+            }
+        } catch (RuntimeException e) {
+            log.debug("Ignoring non-JSON presence message on session {}: {}", session.getId(), e.toString());
+        }
+    }
+
+    /**
+     * Prunes closed and idle sessions, then rebroadcasts snapshots for scopes that changed.
+     */
+    public void sweepIdleAndClosed() {
+        final long idleCutoff = System.currentTimeMillis()
+                - (properties.getIdleTimeoutSeconds() * 1000L);
+        final Set<String> scopesToBroadcast = new HashSet<>();
+
+        for (final Map.Entry<String, CopyOnWriteArrayList<WebSocketSession>> entry : sessionsByScope.entrySet()) {
+            final String scopeKey = entry.getKey();
+            final CopyOnWriteArrayList<WebSocketSession> list = entry.getValue();
+            boolean changed = false;
+
+            for (final WebSocketSession session : List.copyOf(list)) {
+                if (!session.isOpen()) {
+                    if (list.remove(session)) {
+                        decrementConnectionCounters(session);
+                        changed = true;
+                    }
+                    continue;
+                }
+                final Long lastActivity = (Long) session.getAttributes().get(ATTR_LAST_ACTIVITY);
+                if (lastActivity != null && lastActivity < idleCutoff) {
+                    log.debug("Closing idle presence session {} in scope {}", session.getId(), scopeKey);
+                    presenceMetrics.getObject().recordIdleTimeout();
+                    try {
+                        session.close(CloseStatus.GOING_AWAY);
+                    } catch (IOException e) {
+                        log.debug("Failed to close idle session {}: {}", session.getId(), e.toString());
+                    }
+                    unregister(session);
+                    changed = true;
+                }
+            }
+
+            if (changed) {
+                scopesToBroadcast.add(scopeKey);
+            }
+        }
+
+        scopesToBroadcast.forEach(this::broadcastSnapshot);
     }
 
     public void broadcastSnapshot(final String scopeKey) {
@@ -74,21 +180,23 @@ public class RoundPresenceService {
             return;
         }
 
-        // Player identity (steamId/personaName/avatar) is public Steam profile
-        // data, so every session gets the same snapshot regardless of its own
-        // auth status.
         final TextMessage message = new TextMessage(payload);
         for (final WebSocketSession session : list) {
             if (!session.isOpen()) {
-                list.remove(session);
+                if (list.remove(session)) {
+                    decrementConnectionCounters(session);
+                }
                 continue;
             }
             try {
                 session.sendMessage(message);
             } catch (IOException | IllegalStateException e) {
+                presenceMetrics.getObject().recordBroadcastFailure();
                 log.debug("Pruning failed presence session {} for scope {}: {}",
                         session.getId(), scopeKey, e.toString());
-                list.remove(session);
+                if (list.remove(session)) {
+                    decrementConnectionCounters(session);
+                }
             }
         }
     }
@@ -96,8 +204,8 @@ public class RoundPresenceService {
     Snapshot computeSnapshot(final List<WebSocketSession> sessions) {
         int totalCount = 0;
         int anonymousCount = 0;
-        // LinkedHashMap keeps insertion order — stable output for tests and clients.
         final Map<String, PlayerInfo> playersById = new LinkedHashMap<>();
+        final Set<String> anonymousIps = new HashSet<>();
 
         for (final WebSocketSession session : sessions) {
             if (!session.isOpen()) continue;
@@ -105,6 +213,12 @@ public class RoundPresenceService {
             final String steamId = (String) session.getAttributes().get(ATTR_STEAM_ID);
             if (steamId == null || steamId.isBlank()) {
                 anonymousCount++;
+                final String ip = clientIpOf(session);
+                if (ip != null && !ip.isBlank()) {
+                    anonymousIps.add(ip);
+                } else {
+                    anonymousIps.add("anon:" + session.getId());
+                }
                 continue;
             }
             playersById.computeIfAbsent(steamId, id -> new PlayerInfo(
@@ -114,7 +228,12 @@ public class RoundPresenceService {
             ));
         }
 
-        return new Snapshot(totalCount, anonymousCount, new ArrayList<>(playersById.values()));
+        final int uniquePlayerCount = playersById.size() + anonymousIps.size();
+        return new Snapshot(totalCount, anonymousCount, uniquePlayerCount, new ArrayList<>(playersById.values()));
+    }
+
+    public int activeConnectionCount() {
+        return globalConnections.get();
     }
 
     int scopeSize(final String scopeKey) {
@@ -124,16 +243,31 @@ public class RoundPresenceService {
 
     List<WebSocketSession> sessionsFor(final String scopeKey) {
         final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
-        return list == null ? Collections.emptyList() : Collections.unmodifiableList(list);
+        return list == null ? List.of() : List.copyOf(list);
+    }
+
+    private void decrementConnectionCounters(final WebSocketSession session) {
+        globalConnections.updateAndGet(current -> Math.max(0, current - 1));
+        final String clientIp = clientIpOf(session);
+        if (clientIp != null) {
+            connectionsByIp.computeIfPresent(clientIp, (k, count) -> {
+                final int next = count.decrementAndGet();
+                return next <= 0 ? null : count;
+            });
+        }
     }
 
     private static String scopeKeyOf(final WebSocketSession session) {
         return (String) session.getAttributes().get(ATTR_SCOPE_KEY);
     }
 
+    private static String clientIpOf(final WebSocketSession session) {
+        return (String) session.getAttributes().get(ATTR_CLIENT_IP);
+    }
+
     public record PlayerInfo(String steamId, String personaName, String avatar) {
     }
 
-    public record Snapshot(int totalCount, int anonymousCount, List<PlayerInfo> players) {
+    public record Snapshot(int totalCount, int anonymousCount, int uniquePlayerCount, List<PlayerInfo> players) {
     }
 }

--- a/backend/src/main/java/org/steam5/service/RoundPresenceService.java
+++ b/backend/src/main/java/org/steam5/service/RoundPresenceService.java
@@ -67,6 +67,12 @@ public class RoundPresenceService {
     private final ConcurrentHashMap<String, AtomicInteger> connectionsByIp = new ConcurrentHashMap<>();
     private final Object registerLock = new Object();
 
+    /**
+     * Registers a WebSocket session if the configured connection limits allow it.
+     *
+     * @param session the WebSocket session to register
+     * @return {@code OK} when registered, or the applicable limit result when registration is rejected
+     */
     public RegisterResult register(final WebSocketSession session) {
         final String scopeKey = scopeKeyOf(session);
         if (scopeKey == null) return RegisterResult.SCOPE_LIMIT;
@@ -99,6 +105,11 @@ public class RoundPresenceService {
         }
     }
 
+    /**
+     * Removes a session from its scope and updates the active connection counters.
+     *
+     * @param session the WebSocket session to remove
+     */
     public void unregister(final WebSocketSession session) {
         final String scopeKey = scopeKeyOf(session);
         if (scopeKey == null) return;
@@ -110,10 +121,19 @@ public class RoundPresenceService {
         });
     }
 
+    /**
+     * Updates the session's last-activity timestamp.
+     */
     public void touchActivity(final WebSocketSession session) {
         session.getAttributes().put(ATTR_LAST_ACTIVITY, System.currentTimeMillis());
     }
 
+    /**
+     * Processes a client message and refreshes the session activity timestamp for ping or pong messages.
+     *
+     * @param session the WebSocket session associated with the message
+     * @param payload the client message payload
+     */
     public void handleClientMessage(final WebSocketSession session, final String payload) {
         try {
             final JsonNode node = objectMapper.readTree(payload);
@@ -169,6 +189,11 @@ public class RoundPresenceService {
         scopesToBroadcast.forEach(this::broadcastSnapshot);
     }
 
+    /**
+     * Broadcasts the current presence snapshot to all open sessions in a scope.
+     *
+     * @param scopeKey the scope whose presence snapshot should be broadcast
+     */
     public void broadcastSnapshot(final String scopeKey) {
         if (scopeKey == null) return;
         final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
@@ -204,6 +229,13 @@ public class RoundPresenceService {
         }
     }
 
+    /**
+     * Builds a presence snapshot from the currently open sessions.
+     *
+     * @param sessions the sessions to include in the snapshot
+     * @return a snapshot containing connection totals, anonymous session counts,
+     *         unique player counts, and authenticated player information
+     */
     Snapshot computeSnapshot(final List<WebSocketSession> sessions) {
         int totalCount = 0;
         int anonymousCount = 0;
@@ -235,20 +267,42 @@ public class RoundPresenceService {
         return new Snapshot(totalCount, anonymousCount, uniquePlayerCount, new ArrayList<>(playersById.values()));
     }
 
+    /**
+     * Gets the number of currently active registered connections.
+     *
+     * @return the active connection count
+     */
     public int activeConnectionCount() {
         return globalConnections.get();
     }
 
+    /**
+     * Gets the number of sessions registered for a scope.
+     *
+     * @param scopeKey the scope key to query
+     * @return the number of registered sessions, or {@code 0} if the scope has no sessions
+     */
     int scopeSize(final String scopeKey) {
         final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
         return list == null ? 0 : list.size();
     }
 
+    /**
+     * Retrieves the sessions registered under a scope.
+     *
+     * @param scopeKey the scope whose sessions should be retrieved
+     * @return an immutable snapshot of the sessions for the scope, or an empty list when no sessions are registered
+     */
     List<WebSocketSession> sessionsFor(final String scopeKey) {
         final CopyOnWriteArrayList<WebSocketSession> list = sessionsByScope.get(scopeKey);
         return list == null ? List.of() : List.copyOf(list);
     }
 
+    /**
+     * Decrements the global connection count and the session's client IP count.
+     *
+     * @param session the session whose connection counters are being removed
+     */
     private void decrementConnectionCounters(final WebSocketSession session) {
         globalConnections.updateAndGet(current -> Math.max(0, current - 1));
         final String clientIp = clientIpOf(session);
@@ -260,10 +314,22 @@ public class RoundPresenceService {
         }
     }
 
+    /**
+     * Retrieves the scope key associated with a WebSocket session.
+     *
+     * @param session the WebSocket session whose scope key is read
+     * @return the session's scope key, or {@code null} if none is associated
+     */
     private static String scopeKeyOf(final WebSocketSession session) {
         return (String) session.getAttributes().get(ATTR_SCOPE_KEY);
     }
 
+    /**
+     * Retrieves the client IP address associated with a WebSocket session.
+     *
+     * @param session the WebSocket session
+     * @return the client IP address, or {@code null} if none is associated
+     */
     private static String clientIpOf(final WebSocketSession session) {
         return (String) session.getAttributes().get(ATTR_CLIENT_IP);
     }

--- a/backend/src/main/java/org/steam5/service/WsTicketService.java
+++ b/backend/src/main/java/org/steam5/service/WsTicketService.java
@@ -33,6 +33,13 @@ public class WsTicketService {
             .maximumSize(TICKET_MAX_SIZE)
             .build();
 
+    /**
+     * Creates a short-lived WebSocket authentication ticket bound to a Steam ID and scope.
+     *
+     * @param steamId  the Steam ID associated with the ticket
+     * @param scopeKey the scope authorized by the ticket
+     * @return the generated authentication ticket
+     */
     public String issueTicket(final String steamId, final String scopeKey) {
         final String ticket = UUID.randomUUID().toString();
         tickets.put(ticket, new TicketEntry(steamId, scopeKey));
@@ -40,8 +47,11 @@ public class WsTicketService {
     }
 
     /**
-     * Validates and consumes a ticket. Returns the steamId when the ticket is
-     * valid for the requested scope, otherwise {@code null}.
+     * Validates and consumes a WebSocket authentication ticket for the requested scope.
+     *
+     * @param ticket   the ticket to validate
+     * @param scopeKey the scope associated with the request
+     * @return the ticket owner's Steam ID if the ticket matches the scope, or {@code null} if it is invalid, expired, or already consumed
      */
     public String validateTicket(final String ticket, final String scopeKey) {
         if (ticket == null || scopeKey == null || scopeKey.isBlank()) return null;

--- a/backend/src/main/java/org/steam5/service/WsTicketService.java
+++ b/backend/src/main/java/org/steam5/service/WsTicketService.java
@@ -15,9 +15,8 @@ import java.util.concurrent.TimeUnit;
  * their bearer token for a ticket via {@code POST /api/ws/ticket} and then
  * include that ticket as a query parameter on the WS URL.
  *
- * <p>Tickets are stored in an in-memory Caffeine cache keyed by the opaque
- * ticket string. Entries expire 30 seconds after issue and each ticket is
- * consumed on first validation to prevent reuse.</p>
+ * <p>Tickets are bound to a {@code scopeKey} at issue time and consumed on
+ * first validation to prevent reuse across scopes.</p>
  */
 @Slf4j
 @Service
@@ -26,25 +25,36 @@ public class WsTicketService {
     private static final long TICKET_TTL_SECONDS = 30L;
     private static final long TICKET_MAX_SIZE = 500L;
 
-    private final Cache<String, String> tickets = Caffeine.newBuilder()
+    record TicketEntry(String steamId, String scopeKey) {
+    }
+
+    private final Cache<String, TicketEntry> tickets = Caffeine.newBuilder()
             .expireAfterWrite(TICKET_TTL_SECONDS, TimeUnit.SECONDS)
             .maximumSize(TICKET_MAX_SIZE)
             .build();
 
-    public String issueTicket(final String steamId) {
+    public String issueTicket(final String steamId, final String scopeKey) {
         final String ticket = UUID.randomUUID().toString();
-        tickets.put(ticket, steamId);
+        tickets.put(ticket, new TicketEntry(steamId, scopeKey));
         return ticket;
     }
 
-    public String validateTicket(final String ticket) {
-        if (ticket == null) return null;
-        final String steamId = tickets.asMap().remove(ticket);
-        if (steamId != null) {
-            log.info("WS ticket validated successfully for steamId={}", steamId);
-        } else {
-            log.warn("WS ticket validation failed — ticket not found or expired");
+    /**
+     * Validates and consumes a ticket. Returns the steamId when the ticket is
+     * valid for the requested scope, otherwise {@code null}.
+     */
+    public String validateTicket(final String ticket, final String scopeKey) {
+        if (ticket == null || scopeKey == null || scopeKey.isBlank()) return null;
+        final TicketEntry entry = tickets.asMap().remove(ticket);
+        if (entry == null) {
+            log.debug("WS ticket validation failed — ticket not found or expired");
+            return null;
         }
-        return steamId;
+        if (!scopeKey.equals(entry.scopeKey())) {
+            log.debug("WS ticket validation failed — scope mismatch");
+            return null;
+        }
+        log.debug("WS ticket validated for steamId={}", entry.steamId());
+        return entry.steamId();
     }
 }

--- a/backend/src/main/java/org/steam5/web/PresenceAuthController.java
+++ b/backend/src/main/java/org/steam5/web/PresenceAuthController.java
@@ -29,6 +29,14 @@ public class PresenceAuthController {
     private final PresenceRateLimiter presenceRateLimiter;
     private final PresenceMetrics presenceMetrics;
 
+    /**
+     * Issues a short-lived WebSocket handshake ticket for an authenticated user and scope.
+     *
+     * @param steamId the authenticated user's identifier
+     * @param body    the optional request body containing the required {@code scopeKey}
+     * @return a successful ticket response, or an error response for unauthenticated requests,
+     *         invalid scope keys, or exceeded rate limits
+     */
     @PostMapping("/ticket")
     public ResponseEntity<?> issueTicket(@CurrentUser final String steamId,
                                          @RequestBody(required = false) final Map<String, String> body) {

--- a/backend/src/main/java/org/steam5/web/PresenceAuthController.java
+++ b/backend/src/main/java/org/steam5/web/PresenceAuthController.java
@@ -3,10 +3,14 @@ package org.steam5.web;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.steam5.security.CurrentUser;
+import org.steam5.service.PresenceMetrics;
+import org.steam5.service.PresenceRateLimiter;
 import org.steam5.service.WsTicketService;
+import org.steam5.web.ws.PresenceHandshakeInterceptor;
 
 import java.util.Map;
 
@@ -22,13 +26,28 @@ import java.util.Map;
 public class PresenceAuthController {
 
     private final WsTicketService wsTicketService;
+    private final PresenceRateLimiter presenceRateLimiter;
+    private final PresenceMetrics presenceMetrics;
 
     @PostMapping("/ticket")
-    public ResponseEntity<?> issueTicket(@CurrentUser String steamId) {
+    public ResponseEntity<?> issueTicket(@CurrentUser final String steamId,
+                                         @RequestBody(required = false) final Map<String, String> body) {
         if (steamId == null) {
             return ResponseEntity.status(401).body(Map.of("error", "unauthenticated"));
         }
-        final String ticket = wsTicketService.issueTicket(steamId);
+
+        final String scopeKey = body == null ? null : body.get("scopeKey");
+        if (scopeKey == null || scopeKey.isBlank()
+                || !PresenceHandshakeInterceptor.SCOPE_KEY_PATTERN.matcher(scopeKey).matches()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid_scope_key"));
+        }
+
+        if (!presenceRateLimiter.tryAcquireTicketForUser(steamId)) {
+            return ResponseEntity.status(429).body(Map.of("error", "rate_limit_exceeded"));
+        }
+
+        final String ticket = wsTicketService.issueTicket(steamId, scopeKey);
+        presenceMetrics.recordTicketIssued();
         return ResponseEntity.ok()
                 .header("Cache-Control", "no-store")
                 .body(Map.of("ticket", ticket));

--- a/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.steam5.service.PresenceMetrics;
 import org.steam5.service.PresenceRateLimiter;
 import org.steam5.service.RoundPresenceService;
@@ -117,18 +118,11 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
 
     static String extractParam(final String query, final String name) {
         if (query == null || query.isEmpty()) return null;
-        for (final String pair : query.split("&")) {
-            final int eq = pair.indexOf('=');
-            if (eq < 0) continue;
-            final String key = pair.substring(0, eq);
-            if (!name.equals(key)) continue;
-            final String rawValue = pair.substring(eq + 1);
-            try {
-                return java.net.URLDecoder.decode(rawValue, java.nio.charset.StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException e) {
-                return null;
-            }
-        }
-        return null;
+        final List<String> values = UriComponentsBuilder.newInstance()
+                .query(query)
+                .build()
+                .getQueryParams()
+                .get(name);
+        return (values != null && !values.isEmpty()) ? values.get(0) : null;
     }
 }

--- a/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
@@ -97,6 +97,10 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
         // no-op
     }
 
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
     private boolean isAllowed(final String origin) {
         for (final String allowed : allowedOrigins) {
             if (allowed.equals(origin) || "*".equals(allowed)) return true;

--- a/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
@@ -15,6 +15,9 @@ import org.steam5.service.PresenceRateLimiter;
 import org.steam5.service.RoundPresenceService;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +63,8 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
 
         final String clientIp = resolveClientIp(request);
         if (!presenceRateLimiter.tryAcquireHandshake(clientIp)) {
-            log.warn("Rejecting presence handshake — rate limit exceeded for ip={}", clientIp);
+            log.warn("Rejecting presence handshake — rate limit exceeded for clientRef={}",
+                    loggableClientRef(clientIp));
             presenceMetrics.recordHandshakeRejected();
             return false;
         }
@@ -103,10 +107,25 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
     }
 
     private boolean isAllowed(final String origin) {
-        for (final String allowed : allowedOrigins) {
-            if (allowed.equals(origin) || "*".equals(allowed)) return true;
+        return allowedOrigins.contains(origin);
+    }
+
+    static String loggableClientRef(final String clientIp) {
+        if (clientIp == null || clientIp.isBlank()) {
+            return "unknown";
         }
-        return false;
+        try {
+            final byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(clientIp.getBytes(StandardCharsets.UTF_8));
+            final StringBuilder sb = new StringBuilder(16);
+            sb.append("ipHash:");
+            for (int i = 0; i < 4; i++) {
+                sb.append(String.format("%02x", digest[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return "unknown";
+        }
     }
 
     private static String resolveClientIp(final ServerHttpRequest request) {

--- a/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
@@ -1,0 +1,130 @@
+package org.steam5.web.ws;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.steam5.service.PresenceMetrics;
+import org.steam5.service.PresenceRateLimiter;
+import org.steam5.service.RoundPresenceService;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Validates the {@code Origin} header, enforces handshake rate limits, and copies
+ * handshake query parameters into WebSocket session attributes.
+ */
+@Slf4j
+@Component
+public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
+
+    public static final Pattern SCOPE_KEY_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}(:\\d+:\\d+)?$");
+
+    private final List<String> allowedOrigins;
+    private final PresenceRateLimiter presenceRateLimiter;
+    private final PresenceMetrics presenceMetrics;
+
+    public PresenceHandshakeInterceptor(
+            @Value("${cors.allowedOrigins:https://steam5.org,https://next.steam5.org,http://localhost:3000}") final String originsCsv,
+            final PresenceRateLimiter presenceRateLimiter,
+            final PresenceMetrics presenceMetrics) {
+        this.allowedOrigins = Arrays.stream(originsCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        this.presenceRateLimiter = presenceRateLimiter;
+        this.presenceMetrics = presenceMetrics;
+    }
+
+    @Override
+    public boolean beforeHandshake(final ServerHttpRequest request,
+                                   final ServerHttpResponse response,
+                                   final WebSocketHandler wsHandler,
+                                   final Map<String, Object> attributes) {
+        final String origin = request.getHeaders().getFirst(HttpHeaders.ORIGIN);
+        if (origin == null || !isAllowed(origin)) {
+            log.debug("Rejecting presence handshake — origin '{}' not in allow-list", origin);
+            presenceMetrics.recordHandshakeRejected();
+            return false;
+        }
+
+        final String clientIp = resolveClientIp(request);
+        if (!presenceRateLimiter.tryAcquireHandshake(clientIp)) {
+            log.warn("Rejecting presence handshake — rate limit exceeded for ip={}", clientIp);
+            presenceMetrics.recordHandshakeRejected();
+            return false;
+        }
+
+        final URI uri = request.getURI();
+        final String query = uri.getRawQuery();
+        final String scopeKey = extractParam(query, "scopeKey");
+        final String ticket = extractParam(query, "ticket");
+
+        if (scopeKey == null || scopeKey.isBlank()) {
+            log.debug("Rejecting presence handshake — missing scopeKey");
+            presenceMetrics.recordHandshakeRejected();
+            return false;
+        }
+
+        if (!SCOPE_KEY_PATTERN.matcher(scopeKey).matches()) {
+            log.debug("Rejecting presence handshake — malformed scopeKey '{}'", scopeKey);
+            presenceMetrics.recordHandshakeRejected();
+            return false;
+        }
+
+        attributes.put(RoundPresenceService.ATTR_SCOPE_KEY, scopeKey);
+        attributes.put(RoundPresenceService.ATTR_CLIENT_IP, clientIp);
+        if (ticket != null && !ticket.isBlank()) {
+            attributes.put("ticket", ticket);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(final ServerHttpRequest request,
+                               final ServerHttpResponse response,
+                               final WebSocketHandler wsHandler,
+                               final Exception exception) {
+        // no-op
+    }
+
+    private boolean isAllowed(final String origin) {
+        for (final String allowed : allowedOrigins) {
+            if (allowed.equals(origin) || "*".equals(allowed)) return true;
+        }
+        return false;
+    }
+
+    private static String resolveClientIp(final ServerHttpRequest request) {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            return servletRequest.getServletRequest().getRemoteAddr();
+        }
+        return null;
+    }
+
+    static String extractParam(final String query, final String name) {
+        if (query == null || query.isEmpty()) return null;
+        for (final String pair : query.split("&")) {
+            final int eq = pair.indexOf('=');
+            if (eq < 0) continue;
+            final String key = pair.substring(0, eq);
+            if (!name.equals(key)) continue;
+            final String rawValue = pair.substring(eq + 1);
+            try {
+                return java.net.URLDecoder.decode(rawValue, java.nio.charset.StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
@@ -37,6 +37,11 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
     private final PresenceRateLimiter presenceRateLimiter;
     private final PresenceMetrics presenceMetrics;
 
+    /**
+     * Creates an interceptor configured with the allowed handshake origins.
+     *
+     * @param originsCsv comma-separated list of allowed origins
+     */
     public PresenceHandshakeInterceptor(
             @Value("${cors.allowedOrigins:https://steam5.org,https://next.steam5.org,http://localhost:3000}") final String originsCsv,
             final PresenceRateLimiter presenceRateLimiter,
@@ -49,6 +54,13 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
         this.presenceMetrics = presenceMetrics;
     }
 
+    /**
+     * Validates and prepares a presence WebSocket handshake.
+     *
+     * @param request    the handshake request to validate
+     * @param attributes the WebSocket session attributes to populate on success
+     * @return {@code true} if the handshake is allowed, {@code false} otherwise
+     */
     @Override
     public boolean beforeHandshake(final ServerHttpRequest request,
                                    final ServerHttpResponse response,
@@ -102,6 +114,11 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
         // no-op
     }
 
+    /**
+     * Provides the origins permitted for WebSocket handshakes.
+     *
+     * @return the configured allowed origins
+     */
     public List<String> getAllowedOrigins() {
         return allowedOrigins;
     }
@@ -110,6 +127,13 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
         return allowedOrigins.contains(origin);
     }
 
+    /**
+     * Creates a short, privacy-preserving reference for a client IP address.
+     *
+     * @param clientIp the client IP address to reference
+     * @return an {@code ipHash:} value based on the first four bytes of the SHA-256 digest,
+     *         or {@code unknown} when the address is blank or hashing is unavailable
+     */
     static String loggableClientRef(final String clientIp) {
         if (clientIp == null || clientIp.isBlank()) {
             return "unknown";
@@ -128,6 +152,12 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
         }
     }
 
+    /**
+     * Resolves the remote client IP address from a servlet-backed request.
+     *
+     * @param request the HTTP request
+     * @return the remote client IP address, or {@code null} when the request is not servlet-backed
+     */
     private static String resolveClientIp(final ServerHttpRequest request) {
         if (request instanceof ServletServerHttpRequest servletRequest) {
             return servletRequest.getServletRequest().getRemoteAddr();
@@ -135,6 +165,13 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
         return null;
     }
 
+    /**
+     * Extracts the first value associated with a query parameter name.
+     *
+     * @param query the raw query string
+     * @param name  the query parameter name
+     * @return the first parameter value, or {@code null} when the query is empty or the parameter has no values
+     */
     static String extractParam(final String query, final String name) {
         if (query == null || query.isEmpty()) return null;
         final List<String> values = UriComponentsBuilder.newInstance()

--- a/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
@@ -4,18 +4,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 import org.steam5.domain.User;
 import org.steam5.repository.UserRepository;
+import org.steam5.service.PresenceMetrics;
 import org.steam5.service.RoundPresenceService;
 import org.steam5.service.WsTicketService;
 
 import java.util.Optional;
 
 /**
- * WebSocket handler for the per-round presence endpoint. Resolves the
- * connecting identity from the handshake ticket, registers the session with
+ * WebSocket handler for the per-day presence endpoint. Resolves the connecting
+ * identity from the handshake ticket, registers the session with
  * {@link RoundPresenceService}, and rebroadcasts the snapshot on join/leave.
  */
 @Slf4j
@@ -26,31 +28,52 @@ public class PresenceWebSocketHandler extends TextWebSocketHandler {
     private final RoundPresenceService presenceService;
     private final WsTicketService wsTicketService;
     private final UserRepository userRepository;
+    private final PresenceMetrics presenceMetrics;
 
     @Override
     public void afterConnectionEstablished(final WebSocketSession session) {
         final String scopeKey = (String) session.getAttributes().get(RoundPresenceService.ATTR_SCOPE_KEY);
         final String ticket = (String) session.getAttributes().get("ticket");
 
-        final String steamId = ticket == null ? null : wsTicketService.validateTicket(ticket);
-        if (steamId != null) {
-            session.getAttributes().put(RoundPresenceService.ATTR_STEAM_ID, steamId);
-            try {
-                final Optional<User> user = userRepository.findById(steamId);
-                user.ifPresent(u -> {
-                    session.getAttributes().put(RoundPresenceService.ATTR_PERSONA_NAME, u.getPersonaName());
-                    final String avatarUrl = (u.getAvatarFull() != null && !u.getAvatarFull().isBlank())
-                            ? u.getAvatarFull() : u.getAvatar();
-                    session.getAttributes().put(RoundPresenceService.ATTR_AVATAR, avatarUrl);
-                });
-            } catch (Exception e) {
-                log.debug("Failed to load user {} for presence session {}: {}",
-                        steamId, session.getId(), e.toString());
+        if (ticket != null && !ticket.isBlank()) {
+            final String steamId = wsTicketService.validateTicket(ticket, scopeKey);
+            if (steamId != null) {
+                session.getAttributes().put(RoundPresenceService.ATTR_STEAM_ID, steamId);
+                try {
+                    final Optional<User> user = userRepository.findById(steamId);
+                    user.ifPresent(u -> {
+                        session.getAttributes().put(RoundPresenceService.ATTR_PERSONA_NAME, u.getPersonaName());
+                        final String avatarUrl = (u.getAvatarFull() != null && !u.getAvatarFull().isBlank())
+                                ? u.getAvatarFull() : u.getAvatar();
+                        session.getAttributes().put(RoundPresenceService.ATTR_AVATAR, avatarUrl);
+                    });
+                } catch (Exception e) {
+                    log.debug("Failed to load user {} for presence session {}: {}",
+                            steamId, session.getId(), e.toString());
+                }
+            } else {
+                presenceMetrics.recordTicketInvalid();
             }
         }
 
-        presenceService.register(session);
+        final RoundPresenceService.RegisterResult result = presenceService.register(session);
+        if (result != RoundPresenceService.RegisterResult.OK) {
+            log.debug("Rejecting presence session {} — {}", session.getId(), result);
+            presenceMetrics.recordHandshakeRejected();
+            try {
+                session.close(CloseStatus.POLICY_VIOLATION);
+            } catch (Exception e) {
+                log.debug("Failed to close over-limit session {}: {}", session.getId(), e.toString());
+            }
+            return;
+        }
+
         presenceService.broadcastSnapshot(scopeKey);
+    }
+
+    @Override
+    protected void handleTextMessage(final WebSocketSession session, final TextMessage message) {
+        presenceService.handleClientMessage(session, message.getPayload());
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
@@ -30,6 +30,14 @@ public class PresenceWebSocketHandler extends TextWebSocketHandler {
     private final UserRepository userRepository;
     private final PresenceMetrics presenceMetrics;
 
+    /**
+     * Authenticates and registers a presence session, enriching it with identity details when available.
+     *
+     * <p>Sessions with invalid tickets or rejected registrations are closed with a policy-violation
+     * status. A presence snapshot is broadcast after successful registration.</p>
+     *
+     * @param session the newly established WebSocket session
+     */
     @Override
     public void afterConnectionEstablished(final WebSocketSession session) {
         final String scopeKey = (String) session.getAttributes().get(RoundPresenceService.ATTR_SCOPE_KEY);
@@ -78,11 +86,23 @@ public class PresenceWebSocketHandler extends TextWebSocketHandler {
         presenceService.broadcastSnapshot(scopeKey);
     }
 
+    /**
+     * Processes a text message received from a WebSocket client.
+     *
+     * @param session the WebSocket session that sent the message
+     * @param message the received text message
+     */
     @Override
     protected void handleTextMessage(final WebSocketSession session, final TextMessage message) {
         presenceService.handleClientMessage(session, message.getPayload());
     }
 
+    /**
+     * Removes the closed session from presence tracking and broadcasts the updated presence snapshot.
+     *
+     * @param session the closed WebSocket session
+     * @param status  the reason the connection was closed
+     */
     @Override
     public void afterConnectionClosed(final WebSocketSession session, final CloseStatus status) {
         final String scopeKey = (String) session.getAttributes().get(RoundPresenceService.ATTR_SCOPE_KEY);

--- a/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceWebSocketHandler.java
@@ -37,7 +37,7 @@ public class PresenceWebSocketHandler extends TextWebSocketHandler {
 
         if (ticket != null && !ticket.isBlank()) {
             final String steamId = wsTicketService.validateTicket(ticket, scopeKey);
-            if (steamId != null) {
+            if (steamId != null && !steamId.isBlank()) {
                 session.getAttributes().put(RoundPresenceService.ATTR_STEAM_ID, steamId);
                 try {
                     final Optional<User> user = userRepository.findById(steamId);
@@ -51,15 +51,22 @@ public class PresenceWebSocketHandler extends TextWebSocketHandler {
                     log.debug("Failed to load user {} for presence session {}: {}",
                             steamId, session.getId(), e.toString());
                 }
-            } else {
+            } else if (steamId == null) {
+                log.debug("Rejecting presence session {} — invalid ticket", session.getId());
                 presenceMetrics.recordTicketInvalid();
+                try {
+                    session.close(CloseStatus.POLICY_VIOLATION);
+                } catch (Exception e) {
+                    log.debug("Failed to close session with invalid ticket {}: {}", session.getId(), e.toString());
+                }
+                return;
             }
         }
 
         final RoundPresenceService.RegisterResult result = presenceService.register(session);
         if (result != RoundPresenceService.RegisterResult.OK) {
             log.debug("Rejecting presence session {} — {}", session.getId(), result);
-            presenceMetrics.recordHandshakeRejected();
+            presenceMetrics.recordRegistrationRejected(result.name());
             try {
                 session.close(CloseStatus.POLICY_VIOLATION);
             } catch (Exception e) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -81,6 +81,16 @@ review:
     # refresh reviews for picked apps when older than N days
     min-reviews-fresh-days: ${MIN_REVIEWS_FRESH_DAYS:7}
 
+presence:
+  max-global-connections: ${PRESENCE_MAX_GLOBAL_CONNECTIONS:5000}
+  max-scope-connections: ${PRESENCE_MAX_SCOPE_CONNECTIONS:500}
+  max-ip-connections: ${PRESENCE_MAX_IP_CONNECTIONS:20}
+  ticket-rate-limit-per-minute: ${PRESENCE_TICKET_RATE_LIMIT_PER_MINUTE:20}
+  ticket-rate-limit-per-user-per-minute: ${PRESENCE_TICKET_RATE_LIMIT_PER_USER_PER_MINUTE:10}
+  handshake-rate-limit-per-minute: ${PRESENCE_HANDSHAKE_RATE_LIMIT_PER_MINUTE:60}
+  idle-timeout-seconds: ${PRESENCE_IDLE_TIMEOUT_SECONDS:90}
+  sweep-interval-ms: ${PRESENCE_SWEEP_INTERVAL_MS:30000}
+
 season:
   # default season length in days; persisted seasons keep their own dates if this changes mid-season
   length-days: ${SEASON_LENGTH_DAYS:30}

--- a/backend/src/test/java/org/steam5/service/PresenceRateLimiterTest.java
+++ b/backend/src/test/java/org/steam5/service/PresenceRateLimiterTest.java
@@ -1,0 +1,45 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.steam5.config.PresenceProperties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PresenceRateLimiterTest {
+
+    private PresenceRateLimiter limiter;
+    private PresenceProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new PresenceProperties();
+        properties.setTicketRateLimitPerMinute(2);
+        properties.setTicketRateLimitPerUserPerMinute(2);
+        properties.setHandshakeRateLimitPerMinute(2);
+        limiter = new PresenceRateLimiter(properties);
+    }
+
+    @Test
+    void ticketRateLimitIsPerIp() {
+        assertTrue(limiter.tryAcquireTicket("1.2.3.4"));
+        assertTrue(limiter.tryAcquireTicket("1.2.3.4"));
+        assertFalse(limiter.tryAcquireTicket("1.2.3.4"));
+        assertTrue(limiter.tryAcquireTicket("5.6.7.8"));
+    }
+
+    @Test
+    void handshakeRateLimitIsPerIp() {
+        assertTrue(limiter.tryAcquireHandshake("9.9.9.9"));
+        assertTrue(limiter.tryAcquireHandshake("9.9.9.9"));
+        assertFalse(limiter.tryAcquireHandshake("9.9.9.9"));
+    }
+
+    @Test
+    void ticketUserRateLimitIsPerSteamId() {
+        assertTrue(limiter.tryAcquireTicketForUser("76561"));
+        assertTrue(limiter.tryAcquireTicketForUser("76561"));
+        assertFalse(limiter.tryAcquireTicketForUser("76561"));
+        assertTrue(limiter.tryAcquireTicketForUser("99999"));
+    }
+}

--- a/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/RoundPresenceServiceTest.java
@@ -3,8 +3,11 @@ package org.steam5.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
+import org.steam5.config.PresenceProperties;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -20,27 +23,38 @@ import static org.mockito.Mockito.*;
 class RoundPresenceServiceTest {
 
     private RoundPresenceService service;
+    private PresenceProperties properties;
 
     @BeforeEach
     void setUp() {
-        service = new RoundPresenceService(new ObjectMapper());
+        properties = new PresenceProperties();
+        properties.setMaxGlobalConnections(100);
+        properties.setMaxScopeConnections(50);
+        properties.setMaxIpConnections(5);
+        properties.setIdleTimeoutSeconds(90);
+
+        @SuppressWarnings("unchecked")
+        final ObjectProvider<PresenceMetrics> metricsProvider = mock(ObjectProvider.class);
+        when(metricsProvider.getObject()).thenReturn(mock(PresenceMetrics.class));
+
+        service = new RoundPresenceService(new ObjectMapper(), properties, metricsProvider);
     }
 
     @Test
     void registerAddsSessionToItsScope() {
-        final WebSocketSession session = sessionFor("2026-07-12:1:730", null, null, null);
+        final WebSocketSession session = sessionFor("2026-07-12", "127.0.0.1", null, null, null);
 
-        service.register(session);
+        assertEquals(RoundPresenceService.RegisterResult.OK, service.register(session));
 
-        assertEquals(1, service.scopeSize("2026-07-12:1:730"));
-        assertEquals(0, service.scopeSize("2026-07-12:1:570"));
+        assertEquals(1, service.scopeSize("2026-07-12"));
+        assertEquals(0, service.scopeSize("2026-07-13"));
     }
 
     @Test
     void registerIsolatesScopesFromEachOther() {
-        final WebSocketSession scopeA1 = sessionFor("scopeA", null, null, null);
-        final WebSocketSession scopeA2 = sessionFor("scopeA", null, null, null);
-        final WebSocketSession scopeB1 = sessionFor("scopeB", null, null, null);
+        final WebSocketSession scopeA1 = sessionFor("scopeA", "1.1.1.1", null, null, null);
+        final WebSocketSession scopeA2 = sessionFor("scopeA", "1.1.1.2", null, null, null);
+        final WebSocketSession scopeB1 = sessionFor("scopeB", "1.1.1.3", null, null, null);
 
         service.register(scopeA1);
         service.register(scopeA2);
@@ -52,7 +66,7 @@ class RoundPresenceServiceTest {
 
     @Test
     void unregisterRemovesSessionFromScope() {
-        final WebSocketSession session = sessionFor("scopeA", null, null, null);
+        final WebSocketSession session = sessionFor("scopeA", "1.1.1.1", null, null, null);
         service.register(session);
         assertEquals(1, service.scopeSize("scopeA"));
 
@@ -62,40 +76,67 @@ class RoundPresenceServiceTest {
     }
 
     @Test
+    void registerRejectsWhenIpLimitExceeded() {
+        for (int i = 0; i < 5; i++) {
+            assertEquals(RoundPresenceService.RegisterResult.OK,
+                    service.register(sessionFor("scopeA", "10.0.0.1", null, null, null)));
+        }
+
+        final WebSocketSession overflow = sessionFor("scopeA", "10.0.0.1", null, null, null);
+        assertEquals(RoundPresenceService.RegisterResult.IP_LIMIT, service.register(overflow));
+    }
+
+    @Test
     void snapshotDeduplicatesAuthenticatedPlayersBySteamId() {
-        final WebSocketSession tab1 = sessionFor("scopeA", "76561", "Alice", "http://avatar/alice");
-        final WebSocketSession tab2 = sessionFor("scopeA", "76561", "Alice", "http://avatar/alice");
-        final WebSocketSession tab3 = sessionFor("scopeA", "99999", "Bob", "http://avatar/bob");
-        final WebSocketSession anon = sessionFor("scopeA", null, null, null);
+        final WebSocketSession tab1 = sessionFor("scopeA", "1.1.1.1", "76561", "Alice", "http://avatar/alice");
+        final WebSocketSession tab2 = sessionFor("scopeA", "1.1.1.2", "76561", "Alice", "http://avatar/alice");
+        final WebSocketSession tab3 = sessionFor("scopeA", "1.1.1.3", "99999", "Bob", "http://avatar/bob");
+        final WebSocketSession anon = sessionFor("scopeA", "1.1.1.4", null, null, null);
 
         final RoundPresenceService.Snapshot snapshot =
                 service.computeSnapshot(List.of(tab1, tab2, tab3, anon));
 
         assertEquals(4, snapshot.totalCount());
         assertEquals(1, snapshot.anonymousCount());
+        assertEquals(3, snapshot.uniquePlayerCount());
         assertEquals(2, snapshot.players().size());
         assertEquals(List.of("76561", "99999"),
                 snapshot.players().stream().map(RoundPresenceService.PlayerInfo::steamId).toList());
     }
 
     @Test
+    void snapshotGroupsAnonymousSessionsByIpForUniqueCount() {
+        final WebSocketSession anonTab1 = sessionFor("scopeA", "9.9.9.9", null, null, null);
+        final WebSocketSession anonTab2 = sessionFor("scopeA", "9.9.9.9", null, null, null);
+
+        final RoundPresenceService.Snapshot snapshot =
+                service.computeSnapshot(List.of(anonTab1, anonTab2));
+
+        assertEquals(2, snapshot.totalCount());
+        assertEquals(2, snapshot.anonymousCount());
+        assertEquals(1, snapshot.uniquePlayerCount());
+        assertTrue(snapshot.players().isEmpty());
+    }
+
+    @Test
     void snapshotSkipsClosedSessions() {
-        final WebSocketSession open = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
-        final WebSocketSession closed = sessionFor("scopeA", "2", "Bob", "http://avatar/b");
+        final WebSocketSession open = sessionFor("scopeA", "1.1.1.1", "1", "Alice", "http://avatar/a");
+        final WebSocketSession closed = sessionFor("scopeA", "1.1.1.2", "2", "Bob", "http://avatar/b");
         when(closed.isOpen()).thenReturn(false);
 
         final RoundPresenceService.Snapshot snapshot =
                 service.computeSnapshot(List.of(open, closed));
 
         assertEquals(1, snapshot.totalCount());
+        assertEquals(1, snapshot.uniquePlayerCount());
         assertEquals(1, snapshot.players().size());
         assertEquals("1", snapshot.players().get(0).steamId());
     }
 
     @Test
     void broadcastPrunesClosedSessions() {
-        final WebSocketSession open = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
-        final WebSocketSession closed = sessionFor("scopeA", "2", "Bob", "http://avatar/b");
+        final WebSocketSession open = sessionFor("scopeA", "1.1.1.1", "1", "Alice", "http://avatar/a");
+        final WebSocketSession closed = sessionFor("scopeA", "1.1.1.2", "2", "Bob", "http://avatar/b");
         when(closed.isOpen()).thenReturn(false);
 
         service.register(open);
@@ -110,8 +151,8 @@ class RoundPresenceServiceTest {
 
     @Test
     void broadcastPrunesSessionsThatFailToSend() throws IOException {
-        final WebSocketSession healthy = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
-        final WebSocketSession faulty = sessionFor("scopeA", "2", "Bob", "http://avatar/b");
+        final WebSocketSession healthy = sessionFor("scopeA", "1.1.1.1", "1", "Alice", "http://avatar/a");
+        final WebSocketSession faulty = sessionFor("scopeA", "1.1.1.2", "2", "Bob", "http://avatar/b");
         doThrow(new IOException("boom")).when(faulty).sendMessage(any(TextMessage.class));
 
         service.register(healthy);
@@ -131,40 +172,66 @@ class RoundPresenceServiceTest {
 
     @Test
     void broadcastSendsFullSnapshotToAnonymousSessionsToo() throws IOException {
-        final WebSocketSession authed = sessionFor("scopeA", "1", "Alice", "http://avatar/a");
-        final WebSocketSession anon = sessionFor("scopeA", null, null, null);
+        final WebSocketSession authed = sessionFor("scopeA", "1.1.1.1", "1", "Alice", "http://avatar/a");
+        final WebSocketSession anon = sessionFor("scopeA", "1.1.1.2", null, null, null);
 
         service.register(authed);
         service.register(anon);
         service.broadcastSnapshot("scopeA");
 
-        // Authenticated session receives full snapshot
         final var authedCaptor = ArgumentCaptor.forClass(TextMessage.class);
         verify(authed).sendMessage(authedCaptor.capture());
         final var authedSnapshot = new ObjectMapper().readValue(
                 authedCaptor.getValue().getPayload(), RoundPresenceService.Snapshot.class);
         assertEquals(2, authedSnapshot.totalCount());
+        assertEquals(2, authedSnapshot.uniquePlayerCount());
         assertEquals(1, authedSnapshot.players().size());
 
-        // Anonymous session receives the same full snapshot — player identity
-        // is public Steam profile data, not gated behind the viewer's own auth.
         final var anonCaptor = ArgumentCaptor.forClass(TextMessage.class);
         verify(anon).sendMessage(anonCaptor.capture());
         final var anonSnapshot = new ObjectMapper().readValue(
                 anonCaptor.getValue().getPayload(), RoundPresenceService.Snapshot.class);
         assertEquals(2, anonSnapshot.totalCount());
         assertEquals(1, anonSnapshot.anonymousCount());
+        assertEquals(2, anonSnapshot.uniquePlayerCount());
         assertEquals(1, anonSnapshot.players().size());
+    }
+
+    @Test
+    void sweepClosesIdleSessions() throws IOException {
+        properties.setIdleTimeoutSeconds(1);
+        final WebSocketSession idle = sessionFor("scopeA", "1.1.1.1", null, null, null);
+        service.register(idle);
+        idle.getAttributes().put(RoundPresenceService.ATTR_LAST_ACTIVITY, System.currentTimeMillis() - 5_000L);
+
+        service.sweepIdleAndClosed();
+
+        verify(idle).close(CloseStatus.GOING_AWAY);
+        assertEquals(0, service.scopeSize("scopeA"));
+    }
+
+    @Test
+    void handleClientMessageUpdatesActivityOnPing() {
+        final WebSocketSession session = sessionFor("scopeA", "1.1.1.1", null, null, null);
+        session.getAttributes().put(RoundPresenceService.ATTR_LAST_ACTIVITY, 1L);
+
+        service.handleClientMessage(session, "{\"type\":\"ping\"}");
+
+        final Long updated = (Long) session.getAttributes().get(RoundPresenceService.ATTR_LAST_ACTIVITY);
+        assertNotNull(updated);
+        assertTrue(updated > 1L);
     }
 
     private static final AtomicInteger SESSION_ID = new AtomicInteger();
 
     private static WebSocketSession sessionFor(final String scopeKey,
+                                               final String clientIp,
                                                final String steamId,
                                                final String personaName,
                                                final String avatar) {
         final Map<String, Object> attrs = new HashMap<>();
         attrs.put(RoundPresenceService.ATTR_SCOPE_KEY, scopeKey);
+        if (clientIp != null) attrs.put(RoundPresenceService.ATTR_CLIENT_IP, clientIp);
         if (steamId != null) attrs.put(RoundPresenceService.ATTR_STEAM_ID, steamId);
         if (personaName != null) attrs.put(RoundPresenceService.ATTR_PERSONA_NAME, personaName);
         if (avatar != null) attrs.put(RoundPresenceService.ATTR_AVATAR, avatar);

--- a/backend/src/test/java/org/steam5/service/WsTicketServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/WsTicketServiceTest.java
@@ -1,0 +1,37 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WsTicketServiceTest {
+
+    private WsTicketService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WsTicketService();
+    }
+
+    @Test
+    void issueAndValidateConsumesTicketForMatchingScope() {
+        final String ticket = service.issueTicket("76561", "2026-07-14");
+
+        assertEquals("76561", service.validateTicket(ticket, "2026-07-14"));
+        assertNull(service.validateTicket(ticket, "2026-07-14"));
+    }
+
+    @Test
+    void validateRejectsMismatchedScope() {
+        final String ticket = service.issueTicket("76561", "2026-07-14");
+
+        assertNull(service.validateTicket(ticket, "2026-07-15"));
+        assertNull(service.validateTicket(ticket, "2026-07-14"));
+    }
+
+    @Test
+    void validateRejectsUnknownTicket() {
+        assertNull(service.validateTicket("missing", "2026-07-14"));
+    }
+}

--- a/backend/src/test/java/org/steam5/web/PresenceAuthControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/PresenceAuthControllerTest.java
@@ -3,55 +3,83 @@ package org.steam5.web;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
+import org.steam5.service.PresenceMetrics;
+import org.steam5.service.PresenceRateLimiter;
 import org.steam5.service.WsTicketService;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class PresenceAuthControllerTest {
 
     private WsTicketService wsTicketService;
+    private PresenceRateLimiter presenceRateLimiter;
+    private PresenceMetrics presenceMetrics;
     private PresenceAuthController controller;
 
     @BeforeEach
     void setUp() {
         wsTicketService = mock(WsTicketService.class);
-        controller = new PresenceAuthController(wsTicketService);
+        presenceRateLimiter = mock(PresenceRateLimiter.class);
+        presenceMetrics = mock(PresenceMetrics.class);
+        controller = new PresenceAuthController(wsTicketService, presenceRateLimiter, presenceMetrics);
+        when(presenceRateLimiter.tryAcquireTicketForUser(any())).thenReturn(true);
     }
 
     @Test
     void issueTicket_returns200WithTicketWhenAuthenticated() {
-        when(wsTicketService.issueTicket("76561")).thenReturn("ticket-abc");
+        when(wsTicketService.issueTicket("76561", "2026-07-14")).thenReturn("ticket-abc");
 
-        ResponseEntity<?> response = controller.issueTicket("76561");
+        ResponseEntity<?> response = controller.issueTicket("76561", Map.of("scopeKey", "2026-07-14"));
 
         assertEquals(200, response.getStatusCode().value());
         assertNotNull(response.getBody());
         assertTrue(response.getBody() instanceof Map<?, ?>);
         assertTrue(((Map<?, ?>) response.getBody()).containsKey("ticket"));
         assertEquals("no-store", response.getHeaders().getFirst("Cache-Control"));
+        verify(presenceMetrics).recordTicketIssued();
     }
 
     @Test
     void issueTicket_returns401WhenUnauthenticated() {
-        ResponseEntity<?> response = controller.issueTicket(null);
+        ResponseEntity<?> response = controller.issueTicket(null, Map.of("scopeKey", "2026-07-14"));
 
         assertEquals(401, response.getStatusCode().value());
         assertNotNull(response.getBody());
         assertTrue(response.getBody() instanceof Map<?, ?>);
         assertEquals("unauthenticated", ((Map<?, ?>) response.getBody()).get("error"));
-        verify(wsTicketService, never()).issueTicket(any());
+        verify(wsTicketService, never()).issueTicket(any(), any());
+    }
+
+    @Test
+    void issueTicket_rejectsInvalidScopeKey() {
+        ResponseEntity<?> response = controller.issueTicket("76561", Map.of("scopeKey", "bad"));
+
+        assertEquals(400, response.getStatusCode().value());
+        verify(wsTicketService, never()).issueTicket(any(), any());
+    }
+
+    @Test
+    void issueTicket_returns429WhenUserRateLimited() {
+        when(presenceRateLimiter.tryAcquireTicketForUser("76561")).thenReturn(false);
+
+        ResponseEntity<?> response = controller.issueTicket("76561", Map.of("scopeKey", "2026-07-14"));
+
+        assertEquals(429, response.getStatusCode().value());
+        verify(wsTicketService, never()).issueTicket(any(), any());
     }
 
     @Test
     void issueTicket_delegatesToWsTicketService() {
-        when(wsTicketService.issueTicket("76561")).thenReturn("ticket-xyz");
+        when(wsTicketService.issueTicket("76561", "2026-07-14")).thenReturn("ticket-xyz");
 
-        ResponseEntity<?> response = controller.issueTicket("76561");
+        ResponseEntity<?> response = controller.issueTicket("76561", Map.of("scopeKey", "2026-07-14"));
 
-        verify(wsTicketService, times(1)).issueTicket("76561");
+        verify(wsTicketService, times(1)).issueTicket(eq("76561"), eq("2026-07-14"));
         assertNotNull(response.getBody());
         assertEquals("ticket-xyz", ((Map<?, ?>) response.getBody()).get("ticket"));
     }

--- a/backend/src/test/java/org/steam5/web/ws/PresenceHandshakeInterceptorTest.java
+++ b/backend/src/test/java/org/steam5/web/ws/PresenceHandshakeInterceptorTest.java
@@ -28,4 +28,19 @@ class PresenceHandshakeInterceptorTest {
         assertEquals("abc", PresenceHandshakeInterceptor.extractParam("scopeKey=2026-07-14&ticket=abc", "ticket"));
         assertNull(PresenceHandshakeInterceptor.extractParam(null, "scopeKey"));
     }
+
+    @Test
+    void loggableClientRefHashesIpWithoutEchoingRawValue() {
+        final String hashed = PresenceHandshakeInterceptor.loggableClientRef("203.0.113.10");
+
+        assertTrue(hashed.startsWith("ipHash:"));
+        assertNotEquals("203.0.113.10", hashed);
+        assertEquals(hashed, PresenceHandshakeInterceptor.loggableClientRef("203.0.113.10"));
+    }
+
+    @Test
+    void loggableClientRefReturnsUnknownForBlankInput() {
+        assertEquals("unknown", PresenceHandshakeInterceptor.loggableClientRef(null));
+        assertEquals("unknown", PresenceHandshakeInterceptor.loggableClientRef("  "));
+    }
 }

--- a/backend/src/test/java/org/steam5/web/ws/PresenceHandshakeInterceptorTest.java
+++ b/backend/src/test/java/org/steam5/web/ws/PresenceHandshakeInterceptorTest.java
@@ -1,0 +1,31 @@
+package org.steam5.web.ws;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PresenceHandshakeInterceptorTest {
+
+    @Test
+    void scopeKeyPatternAcceptsGameDay() {
+        assertTrue(PresenceHandshakeInterceptor.SCOPE_KEY_PATTERN.matcher("2026-07-14").matches());
+    }
+
+    @Test
+    void scopeKeyPatternAcceptsOptionalRoundSuffix() {
+        assertTrue(PresenceHandshakeInterceptor.SCOPE_KEY_PATTERN.matcher("2026-07-14:1:730").matches());
+    }
+
+    @Test
+    void scopeKeyPatternRejectsMalformedValues() {
+        assertFalse(PresenceHandshakeInterceptor.SCOPE_KEY_PATTERN.matcher("07-14-2026").matches());
+        assertFalse(PresenceHandshakeInterceptor.SCOPE_KEY_PATTERN.matcher("2026-07-14:abc").matches());
+    }
+
+    @Test
+    void extractParamDecodesScopeKey() {
+        assertEquals("2026-07-14", PresenceHandshakeInterceptor.extractParam("scopeKey=2026-07-14&ticket=abc", "scopeKey"));
+        assertEquals("abc", PresenceHandshakeInterceptor.extractParam("scopeKey=2026-07-14&ticket=abc", "ticket"));
+        assertNull(PresenceHandshakeInterceptor.extractParam(null, "scopeKey"));
+    }
+}

--- a/frontend/app/api/ws/ticket/route.ts
+++ b/frontend/app/api/ws/ticket/route.ts
@@ -7,6 +7,12 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 // Per-user, short-lived — must never be cached by Next, a CDN, or a proxy.
 const NO_STORE = {"Cache-Control": "private, no-store"} as const;
 
+/**
+ * Determines whether an origin uses a loopback hostname.
+ *
+ * @param origin - The origin URL to inspect
+ * @returns `true` if the origin hostname is `localhost`, `127.0.0.1`, or `::1`, `false` otherwise
+ */
 function isLoopbackOrigin(origin: string): boolean {
     try {
         const {hostname} = new URL(origin);
@@ -16,10 +22,22 @@ function isLoopbackOrigin(origin: string): boolean {
     }
 }
 
+/**
+ * Determines whether a scope key matches the expected date-based format.
+ *
+ * @param scopeKey - The scope key to validate
+ * @returns `true` if the scope key contains a `YYYY-MM-DD` date with an optional numeric suffix, `false` otherwise.
+ */
 function isValidScopeKey(scopeKey: string): boolean {
     return /^\d{4}-\d{2}-\d{2}(:\d+:\d+)?$/.test(scopeKey);
 }
 
+/**
+ * Retrieves a WebSocket ticket for the requested scope.
+ *
+ * @param request - Request containing the scope key query parameter and authentication cookie
+ * @returns A JSON response containing the ticket, or `null` when the scope is invalid, authentication is unavailable, or the backend request fails
+ */
 export async function GET(request: NextRequest) {
     const scopeKey = request.nextUrl.searchParams.get('scopeKey') ?? '';
     if (!isValidScopeKey(scopeKey)) {

--- a/frontend/app/api/ws/ticket/route.ts
+++ b/frontend/app/api/ws/ticket/route.ts
@@ -1,4 +1,4 @@
-import {NextResponse} from 'next/server';
+import {NextRequest, NextResponse} from 'next/server';
 import {cookies} from 'next/headers';
 
 const BACKEND_ORIGIN = process.env.API_DOMAIN || process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
@@ -16,7 +16,16 @@ function isLoopbackOrigin(origin: string): boolean {
     }
 }
 
-export async function GET() {
+function isValidScopeKey(scopeKey: string): boolean {
+    return /^\d{4}-\d{2}-\d{2}(:\d+:\d+)?$/.test(scopeKey);
+}
+
+export async function GET(request: NextRequest) {
+    const scopeKey = request.nextUrl.searchParams.get('scopeKey') ?? '';
+    if (!isValidScopeKey(scopeKey)) {
+        return NextResponse.json({ticket: null}, {status: 400, headers: NO_STORE});
+    }
+
     const token = (await cookies()).get('s5_token')?.value;
     // Anonymous mode: client connects without a ticket.
     if (!token) return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
@@ -30,7 +39,12 @@ export async function GET() {
     try {
         const res = await fetch(`${BACKEND_ORIGIN}/api/ws/ticket`, {
             method: 'POST',
-            headers: {authorization: `Bearer ${token}`, accept: 'application/json'},
+            headers: {
+                authorization: `Bearer ${token}`,
+                accept: 'application/json',
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify({scopeKey}),
             cache: 'no-store',
             signal: AbortSignal.timeout(5000),
         });

--- a/frontend/app/review-guesser/[round]/layout.tsx
+++ b/frontend/app/review-guesser/[round]/layout.tsx
@@ -4,6 +4,11 @@ import {BACKEND_ORIGIN as backend} from "@/lib/backend";
 
 export const revalidate = 60;
 
+/**
+ * Loads the current review game date.
+ *
+ * @returns The game date, or `null` if it cannot be loaded or is unavailable.
+ */
 async function loadTodayDate(): Promise<string | null> {
     try {
         const res = await fetch(`${backend}/api/review-game/today`, {
@@ -18,6 +23,11 @@ async function loadTodayDate(): Promise<string | null> {
     }
 }
 
+/**
+ * Provides review-guesser content with presence scoped to today's game date.
+ *
+ * @returns The review-guesser content, optionally wrapped with round presence context.
+ */
 export default async function ReviewGuesserRoundLayout({children}: {children: ReactNode}) {
     const gameDate = await loadTodayDate();
     if (!gameDate) {

--- a/frontend/app/review-guesser/[round]/layout.tsx
+++ b/frontend/app/review-guesser/[round]/layout.tsx
@@ -1,0 +1,31 @@
+import type {ReactNode} from "react";
+import {RoundPresenceProvider} from "@/contexts/RoundPresenceContext";
+import {BACKEND_ORIGIN as backend} from "@/lib/backend";
+
+export const revalidate = 60;
+
+async function loadTodayDate(): Promise<string | null> {
+    try {
+        const res = await fetch(`${backend}/api/review-game/today`, {
+            headers: {"accept": "application/json"},
+            next: {revalidate: 60, tags: ["round-today"]},
+        });
+        if (!res.ok) return null;
+        const data = await res.json() as {date?: string};
+        return typeof data?.date === "string" ? data.date : null;
+    } catch {
+        return null;
+    }
+}
+
+export default async function ReviewGuesserRoundLayout({children}: {children: ReactNode}) {
+    const gameDate = await loadTodayDate();
+    if (!gameDate) {
+        return <>{children}</>;
+    }
+    return (
+        <RoundPresenceProvider scopeKey={gameDate}>
+            {children}
+        </RoundPresenceProvider>
+    );
+}

--- a/frontend/src/components/OtherPlayersNow.tsx
+++ b/frontend/src/components/OtherPlayersNow.tsx
@@ -8,6 +8,12 @@ import "@/styles/components/otherPlayersNow.css";
 
 const MAX_VISIBLE_AVATARS = 8;
 
+/**
+ * Generates a fallback initial for a player's name.
+ *
+ * @param name - The player's name, or `null` when unavailable
+ * @returns The uppercase first character of the trimmed name, or `?` when no name is provided
+ */
 function initialsFor(name: string | null): string {
     if (!name) return "?";
     const trimmed = name.trim();
@@ -15,6 +21,12 @@ function initialsFor(name: string | null): string {
     return trimmed.charAt(0).toUpperCase();
 }
 
+/**
+ * Renders a player's avatar linked to their Steam profile.
+ *
+ * @param player - The player whose avatar and profile link are rendered.
+ * @returns The linked avatar element.
+ */
 function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
     const displayName = player.personaName || "Player";
     const profileUrl = `/profile/${player.steamId}`;
@@ -45,12 +57,24 @@ function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
     );
 }
 
+/**
+ * Creates the player presence label for the current round.
+ *
+ * @param uniquePlayerCount - The number of unique players currently present
+ * @param reconnecting - Whether the presence connection is reconnecting
+ * @returns The appropriate presence status label
+ */
 function presenceLabel(uniquePlayerCount: number, reconnecting: boolean): string {
     if (reconnecting) return "Reconnecting…";
     if (uniquePlayerCount === 1) return "1 playing now";
     return `${uniquePlayerCount} playing now`;
 }
 
+/**
+ * Displays the number of players currently active in the round and their avatars when available.
+ *
+ * @returns The presence indicator, or `null` when the round has no active presence to display.
+ */
 export default function OtherPlayersNow(): React.ReactElement | null {
     const {uniquePlayerCount, players, connected, reconnecting} = useRoundPresenceContext();
 

--- a/frontend/src/components/OtherPlayersNow.tsx
+++ b/frontend/src/components/OtherPlayersNow.tsx
@@ -2,12 +2,9 @@
 
 import React from "react";
 import Link from "next/link";
-import {useRoundPresence, type PlayerInfo} from "@/lib/hooks/useRoundPresence";
+import {useRoundPresenceContext} from "@/contexts/RoundPresenceContext";
+import type {PlayerInfo} from "@/lib/hooks/useRoundPresence";
 import "@/styles/components/otherPlayersNow.css";
-
-interface OtherPlayersNowProps {
-    scopeKey: string;
-}
 
 const MAX_VISIBLE_AVATARS = 8;
 
@@ -48,23 +45,28 @@ function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
     );
 }
 
-export default function OtherPlayersNow(props: Readonly<OtherPlayersNowProps>): React.ReactElement | null {
-    const {scopeKey} = props;
-    const {totalCount, players, connected} = useRoundPresence(scopeKey);
+function presenceLabel(uniquePlayerCount: number, reconnecting: boolean): string {
+    if (reconnecting) return "Reconnecting…";
+    if (uniquePlayerCount === 1) return "1 playing now";
+    return `${uniquePlayerCount} playing now`;
+}
 
-    if (!connected) return null;
-    if (totalCount === 0) return null;
+export default function OtherPlayersNow(): React.ReactElement | null {
+    const {uniquePlayerCount, players, connected, reconnecting} = useRoundPresenceContext();
+
+    if (!connected && !reconnecting) return null;
+    if (!reconnecting && uniquePlayerCount === 0) return null;
 
     const visible = players.slice(0, MAX_VISIBLE_AVATARS);
     const overflow = Math.max(0, players.length - visible.length);
-    const label = totalCount === 1 ? "1 playing now" : `${totalCount} playing now`;
+    const label = presenceLabel(uniquePlayerCount, reconnecting);
 
     return (
         <div
-            className={`other-players${players.length >= 5 ? " other-players--many" : ""}`}
+            className={`other-players${players.length >= 5 ? " other-players--many" : ""}${reconnecting ? " other-players--reconnecting" : ""}`}
             aria-live="polite"
         >
-            {visible.length > 0 && (
+            {visible.length > 0 && !reconnecting && (
                 <div className="other-players__avatars mobile__hide">
                     {visible.map((player) => (
                         <PlayerAvatar key={player.steamId} player={player}/>

--- a/frontend/src/components/ReviewGuesserRound.tsx
+++ b/frontend/src/components/ReviewGuesserRound.tsx
@@ -76,6 +76,20 @@ async function fetchSignedIn(): Promise<boolean> {
     }
 }
 
+/**
+ * Renders the guessing interface and result view for a review round.
+ *
+ * @param appId - The identifier of the current game.
+ * @param buckets - The available review buckets.
+ * @param bucketTitles - Display titles for the review buckets.
+ * @param roundIndex - The current round number.
+ * @param totalRounds - The total number of rounds in the game.
+ * @param pickName - The name of the current pick.
+ * @param gameDate - The date identifying the game.
+ * @param prefilled - An optional previously submitted result to display.
+ * @param allResults - Optional results from other rounds.
+ * @returns The rendered guessing controls, round result, and related actions.
+ */
 export default function ReviewGuesserRound({
                                                appId,
                                                buckets,

--- a/frontend/src/components/ReviewGuesserRound.tsx
+++ b/frontend/src/components/ReviewGuesserRound.tsx
@@ -319,7 +319,7 @@ export default function ReviewGuesserRound({
                 <section className="review-round__guess-card" aria-labelledby="guess-submission">
                     <div className="review-round__guess-header">
                         <h2 id="guess-submission">Submit Your Guess</h2>
-                        <OtherPlayersNow scopeKey={gameDate ?? ''}/>
+                        <OtherPlayersNow/>
                     </div>
                     <GuessButtons
                         appId={appId}
@@ -356,7 +356,7 @@ export default function ReviewGuesserRound({
                         actualBucket: computedPrefill?.actualBucket ?? '',
                         correct: computedPrefill?.actualBucket ? (computedPrefill.actualBucket === (computedPrefill?.selectedLabel ?? '')) : false,
                     }) as GuessResponse}
-                    headerRight={<OtherPlayersNow scopeKey={gameDate ?? ''}/>}
+                    headerRight={<OtherPlayersNow/>}
                 >
                     <RoundResultActions
                         appId={appId}

--- a/frontend/src/contexts/RoundPresenceContext.tsx
+++ b/frontend/src/contexts/RoundPresenceContext.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import {createContext, useContext, type ReactNode} from "react";
+import {useRoundPresence, type PresenceSnapshot} from "@/lib/hooks/useRoundPresence";
+
+export type RoundPresenceState = PresenceSnapshot & {
+    connected: boolean;
+    reconnecting: boolean;
+};
+
+const RoundPresenceContext = createContext<RoundPresenceState | null>(null);
+
+interface RoundPresenceProviderProps {
+    scopeKey: string;
+    children: ReactNode;
+}
+
+/**
+ * Keeps one presence WebSocket alive across round navigation within the same game day.
+ */
+export function RoundPresenceProvider(props: Readonly<RoundPresenceProviderProps>): React.ReactElement {
+    const {scopeKey, children} = props;
+    const value = useRoundPresence(scopeKey);
+    return (
+        <RoundPresenceContext.Provider value={value}>
+            {children}
+        </RoundPresenceContext.Provider>
+    );
+}
+
+export function useRoundPresenceContext(): RoundPresenceState {
+    const ctx = useContext(RoundPresenceContext);
+    if (!ctx) {
+        throw new Error("useRoundPresenceContext must be used within RoundPresenceProvider");
+    }
+    return ctx;
+}

--- a/frontend/src/contexts/RoundPresenceContext.tsx
+++ b/frontend/src/contexts/RoundPresenceContext.tsx
@@ -16,7 +16,10 @@ interface RoundPresenceProviderProps {
 }
 
 /**
- * Keeps one presence WebSocket alive across round navigation within the same game day.
+ * Provides round presence state to descendant components for the specified scope.
+ *
+ * @param props - Provider properties, including the presence scope and descendant content.
+ * @returns The context provider element.
  */
 export function RoundPresenceProvider(props: Readonly<RoundPresenceProviderProps>): React.ReactElement {
     const {scopeKey, children} = props;
@@ -28,6 +31,12 @@ export function RoundPresenceProvider(props: Readonly<RoundPresenceProviderProps
     );
 }
 
+/**
+ * Accesses the presence state provided by the nearest round presence provider.
+ *
+ * @returns The current round presence state
+ * @throws An error if used outside a `RoundPresenceProvider`
+ */
 export function useRoundPresenceContext(): RoundPresenceState {
     const ctx = useContext(RoundPresenceContext);
     if (!ctx) {

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -62,6 +62,7 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
     const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const closedByUserRef = useRef(false);
     const retryCountRef = useRef(0);
+    const connectionIdRef = useRef(0);
 
     useEffect(() => {
         closedByUserRef.current = false;
@@ -121,8 +122,11 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
         const connect = async () => {
             if (disposed) return;
             setReconnecting(retryCountRef.current > 0);
+            const connectionId = ++connectionIdRef.current;
             const ticket = isSignedIn ? await fetchTicket(scopeKey) : null;
-            if (disposed) return;
+            if (disposed || connectionIdRef.current !== connectionId) return;
+
+            closeSocket();
 
             const wsOrigin = toWsOrigin(BACKEND_ORIGIN);
             const url = `${wsOrigin}/ws/presence?scopeKey=${encodeURIComponent(scopeKey)}&ticket=${encodeURIComponent(ticket ?? "")}`;
@@ -138,7 +142,7 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
             socketRef.current = ws;
 
             ws.onopen = () => {
-                if (disposed) return;
+                if (disposed || socketRef.current !== ws) return;
                 retryCountRef.current = 0;
                 setConnected(true);
                 setReconnecting(false);
@@ -146,7 +150,7 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
             };
 
             ws.onmessage = (ev) => {
-                if (disposed) return;
+                if (disposed || socketRef.current !== ws) return;
                 try {
                     const data = JSON.parse(ev.data) as Partial<PresenceSnapshot>;
                     setSnapshot({
@@ -167,7 +171,7 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
             };
 
             ws.onclose = () => {
-                if (disposed) return;
+                if (disposed || socketRef.current !== ws) return;
                 setConnected(false);
                 clearPing();
                 socketRef.current = null;
@@ -189,8 +193,8 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
 
         const handleRecovery = () => {
             if (disposed || closedByUserRef.current) return;
-            if (socketRef.current?.readyState === WebSocket.OPEN) return;
-            retryCountRef.current = 0;
+            const readyState = socketRef.current?.readyState;
+            if (readyState === WebSocket.OPEN || readyState === WebSocket.CONNECTING) return;
             clearReconnect();
             void connect();
         };

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -28,12 +28,24 @@ const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30000;
 const CLIENT_PING_INTERVAL_MS = 30000;
 
+/**
+ * Converts an HTTP origin to its corresponding WebSocket origin.
+ *
+ * @param origin - The origin to convert
+ * @returns The WebSocket-form origin, or `origin` when it uses another scheme
+ */
 function toWsOrigin(origin: string): string {
     if (origin.startsWith("https://")) return "wss://" + origin.slice("https://".length);
     if (origin.startsWith("http://")) return "ws://" + origin.slice("http://".length);
     return origin;
 }
 
+/**
+ * Retrieves a WebSocket ticket for the specified scope.
+ *
+ * @param scopeKey - The scope identifier used to request the ticket.
+ * @returns The ticket string, or `null` if the request fails or the response does not contain a valid ticket.
+ */
 async function fetchTicket(scopeKey: string): Promise<string | null> {
     try {
         const res = await fetch(
@@ -48,6 +60,12 @@ async function fetchTicket(scopeKey: string): Promise<string | null> {
     }
 }
 
+/**
+ * Tracks the real-time presence of players within a round.
+ *
+ * @param scopeKey - Identifier for the round or presence scope to monitor
+ * @returns The current presence snapshot and connection status
+ */
 export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
     connected: boolean;
     reconnecting: boolean;

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -13,14 +13,20 @@ export interface PlayerInfo {
 export interface PresenceSnapshot {
     totalCount: number;
     anonymousCount: number;
+    uniquePlayerCount: number;
     players: PlayerInfo[];
 }
 
-const EMPTY_SNAPSHOT: PresenceSnapshot = {totalCount: 0, anonymousCount: 0, players: []};
+const EMPTY_SNAPSHOT: PresenceSnapshot = {
+    totalCount: 0,
+    anonymousCount: 0,
+    uniquePlayerCount: 0,
+    players: [],
+};
 
-const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30000;
+const CLIENT_PING_INTERVAL_MS = 30000;
 
 function toWsOrigin(origin: string): string {
     if (origin.startsWith("https://")) return "wss://" + origin.slice("https://".length);
@@ -28,9 +34,12 @@ function toWsOrigin(origin: string): string {
     return origin;
 }
 
-async function fetchTicket(): Promise<string | null> {
+async function fetchTicket(scopeKey: string): Promise<string | null> {
     try {
-        const res = await fetch("/api/ws/ticket", {cache: "no-store", credentials: "include"});
+        const res = await fetch(
+            `/api/ws/ticket?scopeKey=${encodeURIComponent(scopeKey)}`,
+            {cache: "no-store", credentials: "include"},
+        );
         if (!res.ok) return null;
         const data = await res.json();
         return typeof data?.ticket === "string" ? data.ticket : null;
@@ -39,22 +48,27 @@ async function fetchTicket(): Promise<string | null> {
     }
 }
 
-export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {connected: boolean} {
+export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
+    connected: boolean;
+    reconnecting: boolean;
+} {
     const {isSignedIn} = useAuth();
     const [snapshot, setSnapshot] = useState<PresenceSnapshot>(EMPTY_SNAPSHOT);
     const [connected, setConnected] = useState(false);
+    const [reconnecting, setReconnecting] = useState(false);
 
     const socketRef = useRef<WebSocket | null>(null);
     const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const closedByUserRef = useRef(false);
     const retryCountRef = useRef(0);
 
     useEffect(() => {
-        // Reset per-scope state.
         closedByUserRef.current = false;
         retryCountRef.current = 0;
         setSnapshot(EMPTY_SNAPSHOT);
         setConnected(false);
+        setReconnecting(false);
 
         if (!scopeKey) {
             return () => {
@@ -71,7 +85,15 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
             }
         };
 
+        const clearPing = () => {
+            if (pingTimerRef.current) {
+                clearInterval(pingTimerRef.current);
+                pingTimerRef.current = null;
+            }
+        };
+
         const closeSocket = () => {
+            clearPing();
             const ws = socketRef.current;
             socketRef.current = null;
             if (ws) {
@@ -83,9 +105,23 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
             }
         };
 
+        const startPing = () => {
+            clearPing();
+            pingTimerRef.current = setInterval(() => {
+                const ws = socketRef.current;
+                if (!ws || ws.readyState !== WebSocket.OPEN) return;
+                try {
+                    ws.send(JSON.stringify({type: "ping"}));
+                } catch {
+                    // let onclose drive reconnect
+                }
+            }, CLIENT_PING_INTERVAL_MS);
+        };
+
         const connect = async () => {
             if (disposed) return;
-            const ticket = isSignedIn ? await fetchTicket() : null;
+            setReconnecting(retryCountRef.current > 0);
+            const ticket = isSignedIn ? await fetchTicket(scopeKey) : null;
             if (disposed) return;
 
             const wsOrigin = toWsOrigin(BACKEND_ORIGIN);
@@ -105,15 +141,24 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
                 if (disposed) return;
                 retryCountRef.current = 0;
                 setConnected(true);
+                setReconnecting(false);
+                startPing();
             };
 
             ws.onmessage = (ev) => {
                 if (disposed) return;
                 try {
-                    const data = JSON.parse(ev.data) as Partial<PresenceSnapshot>;
+                    const data = JSON.parse(ev.data) as Partial<PresenceSnapshot> & {type?: string};
+                    if (data.type === "ping") {
+                        ws.send(JSON.stringify({type: "pong"}));
+                        return;
+                    }
                     setSnapshot({
                         totalCount: typeof data.totalCount === "number" ? data.totalCount : 0,
                         anonymousCount: typeof data.anonymousCount === "number" ? data.anonymousCount : 0,
+                        uniquePlayerCount: typeof data.uniquePlayerCount === "number"
+                            ? data.uniquePlayerCount
+                            : (typeof data.totalCount === "number" ? data.totalCount : 0),
                         players: Array.isArray(data.players) ? data.players : [],
                     });
                 } catch (e) {
@@ -123,12 +168,12 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
 
             ws.onerror = (e) => {
                 console.warn("[useRoundPresence] socket error", e);
-                // Let onclose drive reconnect.
             };
 
             ws.onclose = () => {
                 if (disposed) return;
                 setConnected(false);
+                clearPing();
                 socketRef.current = null;
                 if (!closedByUserRef.current) scheduleReconnect();
             };
@@ -136,7 +181,7 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
 
         const scheduleReconnect = () => {
             if (disposed || closedByUserRef.current) return;
-            if (retryCountRef.current >= MAX_RETRIES) return;
+            setReconnecting(true);
             const attempt = retryCountRef.current++;
             const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS);
             clearReconnect();
@@ -148,10 +193,10 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
 
         const handleRecovery = () => {
             if (disposed || closedByUserRef.current) return;
-            if (retryCountRef.current >= MAX_RETRIES) {
-                retryCountRef.current = 0;
-                scheduleReconnect();
-            }
+            if (socketRef.current?.readyState === WebSocket.OPEN) return;
+            retryCountRef.current = 0;
+            clearReconnect();
+            void connect();
         };
 
         const handleOnline = handleRecovery;
@@ -176,8 +221,9 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {c
             clearReconnect();
             closeSocket();
             setConnected(false);
+            setReconnecting(false);
         };
     }, [scopeKey, isSignedIn]);
 
-    return {...snapshot, connected};
+    return {...snapshot, connected, reconnecting};
 }

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -148,11 +148,7 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
             ws.onmessage = (ev) => {
                 if (disposed) return;
                 try {
-                    const data = JSON.parse(ev.data) as Partial<PresenceSnapshot> & {type?: string};
-                    if (data.type === "ping") {
-                        ws.send(JSON.stringify({type: "pong"}));
-                        return;
-                    }
+                    const data = JSON.parse(ev.data) as Partial<PresenceSnapshot>;
                     setSnapshot({
                         totalCount: typeof data.totalCount === "number" ? data.totalCount : 0,
                         anonymousCount: typeof data.anonymousCount === "number" ? data.anonymousCount : 0,

--- a/frontend/src/styles/components/otherPlayersNow.css
+++ b/frontend/src/styles/components/otherPlayersNow.css
@@ -85,6 +85,15 @@
     }
 }
 
+.other-players--reconnecting .other-players__dot {
+    background: var(--color-muted);
+    animation: none;
+}
+
+.other-players--reconnecting .other-players__count {
+    color: var(--color-muted);
+}
+
 @media (max-width: 640px) {
     .other-players {
         font-size: 0.8125rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the "other players playing now" presence feature with abuse resistance, reliability improvements, clearer player counts, and a more stable frontend connection lifecycle.

## Backend

- **Rate limits**: per-IP limits for `POST /api/ws/ticket` and WS handshakes; per-user ticket limits for authenticated clients
- **Connection caps**: configurable global, per-scope (game day), and per-IP maximums; over-limit sessions are rejected at connect time
- **Idle maintenance**: scheduled sweep closes stale sessions (no ping/pong within timeout) and prunes dead sockets
- **Ticket binding**: WS tickets are now scoped to `scopeKey` at issue time and consumed on first use
- **Snapshot semantics**: adds `uniquePlayerCount` (deduped Steam IDs + anonymous sessions grouped by IP)
- **Metrics**: Prometheus counters/gauge for active connections, rejections, ticket issuance, broadcast failures, and idle timeouts
- **Config**: new `presence.*` properties in `application.yml` (all overridable via env vars)

## Frontend

- **Day-scoped provider**: `RoundPresenceProvider` in `/review-guesser/[round]/layout.tsx` keeps one WebSocket alive across round navigation
- **Persistent reconnect**: exponential backoff with no permanent give-up; retries on tab focus/visibility/network recovery
- **Client keepalive**: sends `ping` every 30s while connected
- **UI**: displays `uniquePlayerCount` instead of raw tab count; shows muted "Reconnecting…" state while the socket is down
- **Ticket proxy**: forwards `scopeKey` to backend when minting tickets

## Tests

- Added/updated unit tests for `RoundPresenceService`, `WsTicketService`, `PresenceRateLimiter`, `PresenceHandshakeInterceptor`, and `PresenceAuthController`
- `pnpm build` passes
- Presence unit tests pass (`./gradlew test --tests org.steam5.service.*Presence* ...`)

## Not in scope

- Redis-backed presence for multi-replica deployments (still in-memory; document sticky sessions or add Redis in a follow-up if needed)

## Config reference

| Property | Default |
|----------|---------|
| `presence.max-global-connections` | 5000 |
| `presence.max-scope-connections` | 500 |
| `presence.max-ip-connections` | 20 |
| `presence.ticket-rate-limit-per-minute` | 20 |
| `presence.handshake-rate-limit-per-minute` | 60 |
| `presence.idle-timeout-seconds` | 90 |
| `presence.sweep-interval-ms` | 30000 |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5f35-293f-757e-843a-04ea13cf70a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5f35-293f-757e-843a-04ea13cf70a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

