### PR TITLE
Fix busiest highlight fallback when top day has null avgScore

### DIFF
--- a/backend/src/main/java/org/steam5/service/SeasonService.java
+++ b/backend/src/main/java/org/steam5/service/SeasonService.java
@@ -115,7 +115,7 @@ public class SeasonService {
                 .min(Comparator.comparing(GuessRepository.DailyAvgScoreRow::getAvgScore))
                 .orElse(null);
         GuessRepository.DailyAvgScoreRow busiest = rows.stream()
-                .filter(row -> row.getPlayerCount() != null)
+                .filter(row -> row.getPlayerCount() != null && row.getAvgScore() != null)
                 .max(Comparator.comparing(GuessRepository.DailyAvgScoreRow::getPlayerCount))
                 .orElse(null);
 

--- a/backend/src/test/java/org/steam5/service/SeasonServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/SeasonServiceTest.java
@@ -467,7 +467,7 @@ class SeasonServiceTest {
     }
 
     @Test
-    void buildSeasonHighlights_ignoresRowsWithNullAvgScore() {
+    void buildSeasonHighlights_busiestSkipsNullAvgScoreRows() {
         LocalDate start = LocalDate.of(2020, 1, 1);
         LocalDate end = LocalDate.of(2020, 1, 5);
         Season completed = seasonWith(12, start, end, SeasonStatus.FINALIZED);
@@ -487,12 +487,13 @@ class SeasonServiceTest {
 
         SeasonService.SeasonDailyHighlights highlights = service.buildSeasonHighlights(completed);
 
-        // the null-avgScore row is excluded from highest/lowest, and it also "wins" busiest by
-        // playerCount — but toDailyHighlight requires a non-null avgScore for every field, so
-        // the busiest highlight comes back null too rather than falling back to the runner-up.
+        // the null-avgScore row is excluded from highest/lowest and busiest; busiest falls back to the
+        // next-highest playerCount row that has a non-null avgScore.
         assertEquals(start.plusDays(1), highlights.highestAvg().date());
         assertEquals(start.plusDays(1), highlights.lowestAvg().date());
-        assertNull(highlights.busiest());
+        assertEquals(start.plusDays(1), highlights.busiest().date());
+        assertEquals(1L, highlights.busiest().playerCount());
+        assertEquals(2.0d, highlights.busiest().avgScore());
     }
 
     // finalizeSeason ----------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves #89 by aligning `busiest` day selection with `toDailyHighlight` requirements.

When the day with the highest `playerCount` has a null `avgScore`, the API now falls back to the next-highest player-count day that has a valid average score, instead of returning `busiest: null`.

## Changes

- **`SeasonService.buildSeasonHighlights`**: filter `busiest` candidates to rows with both non-null `playerCount` and non-null `avgScore` (consistent with `highest`/`lowest` filtering)
- **`SeasonServiceTest`**: rename and update characterization test to assert runner-up fallback behavior

## Testing

- `./gradlew test --tests org.steam5.service.SeasonServiceTest` — all tests pass

No frontend, API schema, or SQL changes required; the season detail page already renders whatever `busiest` highlight the backend returns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5f86-6710-7648-ab2b-6ff803a25919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5f86-6710-7648-ab2b-6ff803a25919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

