### PR TITLE
Add Docker healthcheck to backend image

### DIFF
--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -31,6 +31,6 @@ COPY --from=build /app/build/libs/steam5-*.jar app.jar
 EXPOSE ${PORT}
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD-SHELL curl -fsS "http://localhost:$${MANAGEMENT_SERVER_PORT:-8081}/actuator/health" || exit 1
+  CMD-SHELL curl -fsS "http://localhost:$${SERVER_PORT:-8080}/actuator/health" || exit 1
 
 CMD ["java", "-jar", "app.jar"]

--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -22,11 +22,15 @@ WORKDIR /app
 
 # Create a new account and group for the application
 RUN addgroup -S spring && adduser -S spring -G spring
+RUN apk add --no-cache curl
 USER spring:spring
 
 # Copy and rename so the CMD never needs updating when the Gradle version changes
 COPY --from=build /app/build/libs/steam5-*.jar app.jar
 
 EXPOSE ${PORT}
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD-SHELL curl -fsS http://localhost:8081/actuator/health || exit 1
 
 CMD ["java", "-jar", "app.jar"]

--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -31,6 +31,6 @@ COPY --from=build /app/build/libs/steam5-*.jar app.jar
 EXPOSE ${PORT}
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD-SHELL curl -fsS http://localhost:8081/actuator/health || exit 1
+  CMD-SHELL curl -fsS "http://localhost:$${MANAGEMENT_SERVER_PORT:-8081}/actuator/health" || exit 1
 
 CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #91

Adds a native Docker `HEALTHCHECK` to the backend deployment image so orchestrators (Coolify, Docker Compose, etc.) can detect when the container is ready or unhealthy.

## Changes

- Install `curl` in the Alpine runtime stage of [`Dockerfile.coolify`](Dockerfile.coolify)
- Add `HEALTHCHECK` probing the existing, unauthenticated Spring Boot Actuator health endpoint
- Healthcheck URL uses `SERVER_PORT` (same env var as `application.yml`), with shell fallback to `8080`

## Healthcheck settings

| Setting | Value |
|---------|-------|
| URL | `http://localhost:${SERVER_PORT:-8080}/actuator/health` |
| `interval` | 30s |
| `timeout` | 5s |
| `start-period` | 60s (Spring Boot + Flyway cold start) |
| `retries` | 3 |

No Java or YAML changes were needed — actuator health is already exposed and permitted anonymously via `SecurityConfig`.

## Verification

Docker is not available in the cloud agent environment, so the image was not built here. After merge, verify locally:

```bash
docker build -f Dockerfile.coolify -t steam5-backend-test .
docker inspect --format='{{json .Config.Healthcheck}}' steam5-backend-test
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5f8d-d505-790e-8640-5944b53d1d9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5f8d-d505-790e-8640-5944b53d1d9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

