### PR TITLE
fix overnight JDBC/JVM OOM that breaks login while rounds still load

### DIFF
--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -30,7 +30,12 @@ COPY --from=build /app/build/libs/steam5-*.jar app.jar
 
 EXPOSE ${PORT}
 
+# Respect container memory limits (Coolify/cgroup). Override via JAVA_OPTS in Coolify.
+# ExitOnOutOfMemoryError makes OOMs crash-loop visibly instead of leaving a half-dead JVM
+# that serves cached GETs while auth/DB paths fail.
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD curl -fsS "http://localhost:${MANAGEMENT_SERVER_PORT:-8081}/actuator/health" || exit 1
 
-CMD ["java", "-jar", "app.jar"]
+CMD ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -30,12 +30,13 @@ COPY --from=build /app/build/libs/steam5-*.jar app.jar
 
 EXPOSE ${PORT}
 
-# Respect container memory limits (Coolify/cgroup). Override via JAVA_OPTS in Coolify.
+# Mandatory JVM safety flags: MaxRAMPercentage respects container limits (Coolify/cgroup),
 # ExitOnOutOfMemoryError makes OOMs crash-loop visibly instead of leaving a half-dead JVM
 # that serves cached GETs while auth/DB paths fail.
-ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError"
+# JAVA_EXTRA_OPTS allows Coolify to inject additional flags without losing these.
+ENV JAVA_EXTRA_OPTS=""
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD curl -fsS "http://localhost:${MANAGEMENT_SERVER_PORT:-8081}/actuator/health" || exit 1
 
-CMD ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]
+CMD ["sh", "-c", "exec java -XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError $JAVA_EXTRA_OPTS -jar app.jar"]

--- a/backend/src/main/java/org/steam5/config/SteamAppsConfig.java
+++ b/backend/src/main/java/org/steam5/config/SteamAppsConfig.java
@@ -14,7 +14,6 @@ public class SteamAppsConfig {
     private final boolean includeGames = true;
     private final String downloadCron = "0 5 0 * * *"; // default: daily 00:05 UTC
     private final int httpTimeoutMs = 120_000;
-    private final int reviewsNightlyLimit = 15_000;
     @Value("${STEAM_API_KEY}")
     private String apiKey;
 

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -1,10 +1,12 @@
 package org.steam5.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 import org.steam5.web.ws.PresenceHandshakeInterceptor;
 import org.steam5.web.ws.PresenceWebSocketHandler;
 
@@ -26,5 +28,19 @@ public class WebSocketConfig implements WebSocketConfigurer {
         registry.addHandler(presenceHandler, "/ws/presence")
                 .addInterceptors(handshakeInterceptor)
                 .setAllowedOriginPatterns(handshakeInterceptor.getAllowedOrigins().toArray(new String[0]));
+    }
+
+    /**
+     * Caps Tomcat WebSocket buffer sizes. Presence only exchanges small JSON ping/snapshots;
+     * large defaults waste per-session heap on small Coolify containers.
+     */
+    @Bean
+    public ServletServerContainerFactoryBean createWebSocketContainer() {
+        final ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+        container.setMaxTextMessageBufferSize(8 * 1024);
+        container.setMaxBinaryMessageBufferSize(8 * 1024);
+        // Align with presence.idle-timeout-seconds (default 90); container-level idle is a backstop.
+        container.setMaxSessionIdleTimeout(120_000L);
+        return container;
     }
 }

--- a/backend/src/main/java/org/steam5/config/WebSocketConfig.java
+++ b/backend/src/main/java/org/steam5/config/WebSocketConfig.java
@@ -17,6 +17,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     private final PresenceWebSocketHandler presenceHandler;
     private final PresenceHandshakeInterceptor handshakeInterceptor;
+    private final PresenceProperties presenceProperties;
 
     /**
      * Registers the presence WebSocket endpoint and its handshake interceptor.
@@ -39,8 +40,11 @@ public class WebSocketConfig implements WebSocketConfigurer {
         final ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
         container.setMaxTextMessageBufferSize(8 * 1024);
         container.setMaxBinaryMessageBufferSize(8 * 1024);
-        // Align with presence.idle-timeout-seconds (default 90); container-level idle is a backstop.
-        container.setMaxSessionIdleTimeout(120_000L);
+        // Container-level idle timeout backstop: clamp to max(configured + 30s margin, 120s)
+        // so sweepIdleAndClosed() can close sessions before the container does.
+        final long configuredIdleMs = presenceProperties.getIdleTimeoutSeconds() * 1000L;
+        final long containerTimeout = Math.max(configuredIdleMs + 30_000L, 120_000L);
+        container.setMaxSessionIdleTimeout(containerTimeout);
         return container;
     }
 }

--- a/backend/src/main/java/org/steam5/job/SteamAppReviewsRefreshJob.java
+++ b/backend/src/main/java/org/steam5/job/SteamAppReviewsRefreshJob.java
@@ -2,9 +2,11 @@ package org.steam5.job;
 
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
-import org.steam5.config.SteamAppsConfig;
 import org.steam5.http.SteamApiException;
 import org.steam5.repository.SteamAppReviewsRepository;
 import org.steam5.service.SteamAppReviewsFetcher;
@@ -17,16 +19,21 @@ import java.util.concurrent.TimeUnit;
 @DisallowConcurrentExecution
 public class SteamAppReviewsRefreshJob implements Job {
 
-    // Tuneables: number refreshed per run (respecting 1 req/sec via SteamHttpClient)
-    private static final int DEFAULT_NIGHTLY_REFRESH = 2500; // fallback
+    private static final int DEFAULT_NIGHTLY_REFRESH = 2500;
+
     private final SteamAppReviewsFetcher fetcher;
     private final SteamAppReviewsRepository reviewsRepository;
-    private final SteamAppsConfig steamAppsConfig;
+    private final CacheManager cacheManager;
+    private final int configuredNightlyLimit;
 
-    public SteamAppReviewsRefreshJob(SteamAppReviewsFetcher fetcher, SteamAppReviewsRepository reviewsRepository, SteamAppsConfig steamAppsConfig) {
+    public SteamAppReviewsRefreshJob(SteamAppReviewsFetcher fetcher,
+                                     SteamAppReviewsRepository reviewsRepository,
+                                     CacheManager cacheManager,
+                                     @Value("${jobs.reviews-refresh.nightly-limit:2500}") int configuredNightlyLimit) {
         this.fetcher = fetcher;
         this.reviewsRepository = reviewsRepository;
-        this.steamAppsConfig = steamAppsConfig;
+        this.cacheManager = cacheManager;
+        this.configuredNightlyLimit = configuredNightlyLimit;
     }
 
     @Override
@@ -34,7 +41,7 @@ public class SteamAppReviewsRefreshJob implements Job {
         final long start = System.nanoTime();
         int refreshed = 0;
         try {
-            int limit = steamAppsConfig.getReviewsNightlyLimit() > 0 ? steamAppsConfig.getReviewsNightlyLimit() : DEFAULT_NIGHTLY_REFRESH;
+            int limit = configuredNightlyLimit > 0 ? configuredNightlyLimit : DEFAULT_NIGHTLY_REFRESH;
             final JobDataMap map = context.getMergedJobDataMap();
             if (map != null && map.containsKey("limit")) {
                 try {
@@ -42,10 +49,13 @@ public class SteamAppReviewsRefreshJob implements Job {
                 } catch (Exception ignored) {
                 }
             }
+            log.info("SteamAppReviewsRefreshJob starting with limit={}", limit);
             final List<Long> ids = reviewsRepository.findIdsOrderByUpdatedAtAsc(org.springframework.data.domain.PageRequest.of(0, limit));
             for (Long appId : ids) {
                 try {
-                    fetcher.fetchForAppId(appId);
+                    // Per-app cache eviction only; avoid clearing review-game aggregates on every
+                    // app (that thrash forces DB reloads while this job is already heavy).
+                    fetcher.fetchForAppId(appId, false);
                     refreshed++;
                 } catch (SteamApiException sae) {
                     // Respect rate limiting: abort job on 429
@@ -58,6 +68,13 @@ public class SteamAppReviewsRefreshJob implements Job {
                 } catch (Exception e) {
                     // Log with full exception for better debugging
                     log.warn("Failed refreshing reviews for appId {}", appId, e);
+                }
+            }
+            if (refreshed > 0) {
+                final Cache reviewGame = cacheManager.getCache("review-game");
+                if (reviewGame != null) {
+                    reviewGame.clear();
+                    log.info("Cleared review-game cache after refreshing {} apps", refreshed);
                 }
             }
         } catch (Exception e) {
@@ -77,5 +94,3 @@ public class SteamAppReviewsRefreshJob implements Job {
                 .build();
     }
 }
-
-

--- a/backend/src/main/java/org/steam5/job/SteamAppReviewsRefreshJob.java
+++ b/backend/src/main/java/org/steam5/job/SteamAppReviewsRefreshJob.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 public class SteamAppReviewsRefreshJob implements Job {
 
     private static final int DEFAULT_NIGHTLY_REFRESH = 2500;
+    private static final int MAX_REFRESH_LIMIT = 10_000;
 
     private final SteamAppReviewsFetcher fetcher;
     private final SteamAppReviewsRepository reviewsRepository;
@@ -40,23 +41,28 @@ public class SteamAppReviewsRefreshJob implements Job {
     public void execute(JobExecutionContext context) throws JobExecutionException {
         final long start = System.nanoTime();
         int refreshed = 0;
+        Exception caughtException = null;
         try {
             int limit = configuredNightlyLimit > 0 ? configuredNightlyLimit : DEFAULT_NIGHTLY_REFRESH;
             final JobDataMap map = context.getMergedJobDataMap();
             if (map != null && map.containsKey("limit")) {
                 try {
-                    limit = Math.max(1, Integer.parseInt(String.valueOf(map.get("limit"))));
+                    limit = Integer.parseInt(String.valueOf(map.get("limit")));
                 } catch (Exception ignored) {
                 }
             }
+            // Clamp limit to [1, MAX_REFRESH_LIMIT] to prevent unbounded queries
+            limit = Math.max(1, Math.min(limit, MAX_REFRESH_LIMIT));
             log.info("SteamAppReviewsRefreshJob starting with limit={}", limit);
             final List<Long> ids = reviewsRepository.findIdsOrderByUpdatedAtAsc(org.springframework.data.domain.PageRequest.of(0, limit));
             for (Long appId : ids) {
                 try {
                     // Per-app cache eviction only; avoid clearing review-game aggregates on every
                     // app (that thrash forces DB reloads while this job is already heavy).
-                    fetcher.fetchForAppId(appId, false);
-                    refreshed++;
+                    final boolean success = fetcher.fetchForAppId(appId, false);
+                    if (success) {
+                        refreshed++;
+                    }
                 } catch (SteamApiException sae) {
                     // Respect rate limiting: abort job on 429
                     if (sae.getStatusCode() == 429) {
@@ -70,6 +76,11 @@ public class SteamAppReviewsRefreshJob implements Job {
                     log.warn("Failed refreshing reviews for appId {}", appId, e);
                 }
             }
+        } catch (Exception e) {
+            log.error("SteamAppReviewsRefreshJob error", e);
+            caughtException = e;
+        } finally {
+            // Clear review-game cache after any successful refreshes, even if job aborted early
             if (refreshed > 0) {
                 final Cache reviewGame = cacheManager.getCache("review-game");
                 if (reviewGame != null) {
@@ -77,12 +88,11 @@ public class SteamAppReviewsRefreshJob implements Job {
                     log.info("Cleared review-game cache after refreshing {} apps", refreshed);
                 }
             }
-        } catch (Exception e) {
-            log.error("SteamAppReviewsRefreshJob error", e);
-            throw new JobExecutionException(e, false);
-        } finally {
             long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
             log.info("SteamAppReviewsRefreshJob refreshed={} durationMs={}", refreshed, ms);
+            if (caughtException != null) {
+                throw new JobExecutionException(caughtException, false);
+            }
         }
     }
 

--- a/backend/src/main/java/org/steam5/repository/GuessRepository.java
+++ b/backend/src/main/java/org/steam5/repository/GuessRepository.java
@@ -22,6 +22,8 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
      * Batched form of {@link #findBySteamIdOrderByGameDateDescRoundIndexAsc(String)} for a
      * whole candidate pool at once (e.g. PlayerSpotlightService), avoiding an N+1 pattern
      * across per-tier per-candidate lookups. Callers group the result by steamId in memory.
+     * Prefer {@link #findBySteamIdInAndGameDateBetween} when a date bound is available —
+     * unbounded loads of every guess for many players can OOM the JDBC driver on small heaps.
      */
     List<Guess> findBySteamIdIn(List<String> steamIds);
 
@@ -31,6 +33,26 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
      * hardest round") without querying per candidate.
      */
     List<Guess> findByGameDateAndRoundIndex(LocalDate gameDate, int roundIndex);
+
+    /**
+     * Per-user daily point totals for BEST_DAY_EVER-style comparisons without materializing
+     * every Guess row. Far cheaper than {@link #findBySteamIdIn(List)} for large histories.
+     */
+    @Query("""
+            select g.steamId as steamId,
+                   g.gameDate as gameDate,
+                   sum(g.points) as totalPoints
+            from Guess g
+            where g.steamId in :steamIds
+            group by g.steamId, g.gameDate
+            """)
+    List<DailyTotalRow> findDailyTotalsBySteamIdIn(@Param("steamIds") List<String> steamIds);
+
+    interface DailyTotalRow {
+        String getSteamId();
+        LocalDate getGameDate();
+        Long getTotalPoints();
+    }
 
     /**
      * Per-user round counts within a bounded date range, for a specific list of steamIds —

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -269,14 +269,16 @@ public class PlayerSpotlightService {
                 today.minusDays(COOLDOWN_WINDOW_DAYS), today.minusDays(1));
         final List<Candidate> eligible = excludeRecentlyFeaturedPlayers(rawEligible, recentSpotlights);
 
-        // Batch-prefetch every eligible candidate's guess history in one query, instead of
-        // each tier evaluator querying per-candidate — BEST_DAY_EVER, WELCOME_BACK,
-        // MOST_IMPROVED, and HOT_STREAK all just filter/aggregate this same in-memory map
-        // to their own date window, eliminating what was an N+1 (and 2N for MOST_IMPROVED)
-        // pattern across those four tiers.
+        // Batch-prefetch recent guess rows for windowed tiers (MOST_IMPROVED needs 60d,
+        // HOT_STREAK/WELCOME_BACK need less). Avoid unbounded findBySteamIdIn — loading
+        // every guess for every eligible player is a known JDBC OOM path on small heaps.
+        // BEST_DAY_EVER uses a separate daily-totals aggregation instead of full Guess rows.
         final List<String> eligibleIds = eligible.stream().map(Candidate::steamId).toList();
-        final Map<String, List<Guess>> historyByPlayer = guessRepository.findBySteamIdIn(eligibleIds).stream()
-                .collect(Collectors.groupingBy(Guess::getSteamId));
+        final LocalDate recentHistoryStart = today.minusDays(2L * MOST_IMPROVED_WINDOW_DAYS);
+        final Map<String, List<Guess>> historyByPlayer =
+                guessRepository.findBySteamIdInAndGameDateBetween(eligibleIds, recentHistoryStart, today).stream()
+                        .collect(Collectors.groupingBy(Guess::getSteamId));
+        final Map<String, Map<LocalDate, Integer>> dailyTotalsByPlayer = loadDailyTotalsByPlayer(eligibleIds);
 
         // "Competitive pool": every tier here that has >=1 qualifying candidate goes
         // into a lottery, so no single ambient tier (e.g. DAY_STREAK) can dominate
@@ -284,7 +286,7 @@ public class PlayerSpotlightService {
         final LocalDate yesterday = today.minusDays(1);
         final List<QualifyingTier> qualifying = new ArrayList<>();
         addIfQualifying(qualifying, PlayerSpotlightInsightType.DAY_STREAK, evaluateDayStreakTier(eligible, today));
-        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday, historyByPlayer, today));
+        addIfQualifying(qualifying, PlayerSpotlightInsightType.BEST_DAY_EVER, evaluateBestDayEverTier(eligible, yesterday, dailyTotalsByPlayer, today));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.BEAT_THE_ODDS, evaluateBeatTheOddsTier(eligible, yesterday, today));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.WELCOME_BACK, evaluateWelcomeBackTier(eligible, historyByPlayer, today));
         addIfQualifying(qualifying, PlayerSpotlightInsightType.MOST_IMPROVED, evaluateMostImprovedTier(eligible, today, historyByPlayer));
@@ -310,6 +312,19 @@ public class PlayerSpotlightService {
         // Guaranteed fallback: always show someone among the eligible pool.
         final List<Tiered> milestoneTier = evaluateMilestoneTier(eligible, today);
         return Optional.of(toEntity(today, pickOne(milestoneTier, new Random(mixSeed(today.toEpochDay())))));
+    }
+
+    private Map<String, Map<LocalDate, Integer>> loadDailyTotalsByPlayer(final List<String> eligibleIds) {
+        if (eligibleIds.isEmpty()) {
+            return Map.of();
+        }
+        final Map<String, Map<LocalDate, Integer>> byPlayer = new LinkedHashMap<>();
+        for (final GuessRepository.DailyTotalRow row : guessRepository.findDailyTotalsBySteamIdIn(eligibleIds)) {
+            final int points = row.getTotalPoints() != null ? row.getTotalPoints().intValue() : 0;
+            byPlayer.computeIfAbsent(row.getSteamId(), ignored -> new LinkedHashMap<>())
+                    .put(row.getGameDate(), points);
+        }
+        return byPlayer;
     }
 
     private void addIfQualifying(final List<QualifyingTier> qualifying, final PlayerSpotlightInsightType type,
@@ -423,16 +438,15 @@ public class PlayerSpotlightService {
     }
 
     private List<Tiered> evaluateBestDayEverTier(final List<Candidate> eligible, final LocalDate yesterday,
-                                                  final Map<String, List<Guess>> historyByPlayer, final LocalDate today) {
+                                                  final Map<String, Map<LocalDate, Integer>> dailyTotalsByPlayer,
+                                                  final LocalDate today) {
         final Random copyRandom = copyRandom(today, PlayerSpotlightInsightType.BEST_DAY_EVER);
         final String headline = pickPhrase(BEST_DAY_EVER_HEADLINES, copyRandom);
         final String detailTemplate = pickPhrase(BEST_DAY_EVER_DETAILS, copyRandom);
 
         final List<Tiered> tier = new ArrayList<>();
         for (final Candidate c : eligible) {
-            final List<Guess> history = historyByPlayer.getOrDefault(c.steamId(), List.of());
-            final Map<LocalDate, Integer> dailyTotals = history.stream()
-                    .collect(Collectors.groupingBy(Guess::getGameDate, Collectors.summingInt(Guess::getPoints)));
+            final Map<LocalDate, Integer> dailyTotals = dailyTotalsByPlayer.getOrDefault(c.steamId(), Map.of());
 
             final Integer yesterdayTotal = dailyTotals.get(yesterday);
             if (yesterdayTotal == null) continue;

--- a/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
@@ -78,6 +78,16 @@ public class SteamAppReviewsFetcher implements Fetcher {
     }
 
     public void fetchForAppId(Long appId) throws IOException {
+        fetchForAppId(appId, true);
+    }
+
+    /**
+     * @param clearReviewGameAggregates when true, clears the whole {@code review-game} cache after
+     *                                  saving (safe for single-app updates). Nightly bulk refresh
+     *                                  should pass false and clear once at the end of the job to
+     *                                  avoid thrashing caches under memory pressure.
+     */
+    public void fetchForAppId(Long appId, boolean clearReviewGameAggregates) throws IOException {
         final String url = UriComponentsBuilder.fromUriString("https://store.steampowered.com/appreviews/" + appId)
                 .queryParam("json", 1)
                 .queryParam("num_per_page", 0) //  don't fetch actual review details
@@ -100,12 +110,13 @@ public class SteamAppReviewsFetcher implements Fetcher {
         SteamAppReviews entity = new SteamAppReviews(appId, totalPositive, totalNegative, OffsetDateTime.now());
         reviewsRepository.save(entity);
 
-        // Evict dependent caches: per-app review count and review-game aggregates
         final var reviewGame = cacheManager.getCache("review-game");
         if (reviewGame != null) {
             reviewGame.evict(appId + "review-count");
-            // today/picks can change derived buckets if numbers shift; conservative clear
-            reviewGame.clear();
+            if (clearReviewGameAggregates) {
+                // today/picks can change derived buckets if numbers shift
+                reviewGame.clear();
+            }
         }
     }
 }

--- a/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
@@ -77,8 +77,8 @@ public class SteamAppReviewsFetcher implements Fetcher {
         log.info("Reviews ingestion finished. processed={} starting_after={}", processed, lastAppId);
     }
 
-    public void fetchForAppId(Long appId) throws IOException {
-        fetchForAppId(appId, true);
+    public boolean fetchForAppId(Long appId) throws IOException {
+        return fetchForAppId(appId, true);
     }
 
     /**
@@ -86,8 +86,9 @@ public class SteamAppReviewsFetcher implements Fetcher {
      *                                  saving (safe for single-app updates). Nightly bulk refresh
      *                                  should pass false and clear once at the end of the job to
      *                                  avoid thrashing caches under memory pressure.
+     * @return true if the API response was successful and data was persisted, false otherwise
      */
-    public void fetchForAppId(Long appId, boolean clearReviewGameAggregates) throws IOException {
+    public boolean fetchForAppId(Long appId, boolean clearReviewGameAggregates) throws IOException {
         final String url = UriComponentsBuilder.fromUriString("https://store.steampowered.com/appreviews/" + appId)
                 .queryParam("json", 1)
                 .queryParam("num_per_page", 0) //  don't fetch actual review details
@@ -100,7 +101,7 @@ public class SteamAppReviewsFetcher implements Fetcher {
         final JsonNode root = jsonHttpClient.getJson(url);
         if (root.path("success").asInt(0) != 1) {
             log.error("Reviews API returned non-success for appId {}", appId);
-            return;
+            return false;
         }
 
         final JsonNode summary = root.path("query_summary");
@@ -118,6 +119,7 @@ public class SteamAppReviewsFetcher implements Fetcher {
                 reviewGame.clear();
             }
         }
+        return true;
     }
 }
 

--- a/backend/src/main/resources/application-coolify.yml
+++ b/backend/src/main/resources/application-coolify.yml
@@ -3,6 +3,10 @@ spring:
   cache:
     caffeine:
       spec: maximumSize=500,expireAfterWrite=12h,refreshAfterWrite=1h #https://github.com/ben-manes/caffeine/wiki/Refresh
+  datasource:
+    hikari:
+      # Surface connection leaks in prod logs (0 disables detection)
+      leak-detection-threshold: ${DB_POOL_LEAK_DETECTION_MS:60000}
 management:
   server:
     port: ${MANAGEMENT_SERVER_PORT:8081}

--- a/backend/src/main/resources/application-coolify.yml
+++ b/backend/src/main/resources/application-coolify.yml
@@ -7,6 +7,12 @@ spring:
     hikari:
       # Surface connection leaks in prod logs (0 disables detection)
       leak-detection-threshold: ${DB_POOL_LEAK_DETECTION_MS:60000}
+# Presence WebSocket caps tuned for small Coolify/VPS heaps. Override via PRESENCE_* env vars.
+# Open tabs ping to stay alive; background tabs stop pinging so idle sweep can reclaim them.
+presence:
+  max-global-connections: ${PRESENCE_MAX_GLOBAL_CONNECTIONS:500}
+  max-scope-connections: ${PRESENCE_MAX_SCOPE_CONNECTIONS:200}
+  max-ip-connections: ${PRESENCE_MAX_IP_CONNECTIONS:10}
 management:
   server:
     port: ${MANAGEMENT_SERVER_PORT:8081}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -122,7 +122,9 @@ jobs:
     enabled: ${JOB_BLURHASH_AVATAR:false}
   reviews-refresh:
     enabled: ${JOB_REVIEWS_REFRESH:false}
-    nightly-limit: ${JOB_REVIEWS_REFRESH_LIMIT:15000}
+    # Cap nightly refresh volume. At ~1 Steam req/sec, 2500 apps ≈ 40+ minutes.
+    # Higher values (e.g. 15000) can run for hours and pressure JVM heap on small VPS boxes.
+    nightly-limit: ${JOB_REVIEWS_REFRESH_LIMIT:2500}
   seasons-finalizer:
     enabled: ${JOB_SEASONS_FINALIZER:true}
   seasons-backfill:

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -43,26 +43,30 @@ class PlayerSpotlightServiceTest {
         when(playerSpotlightRepository.existsById(any())).thenReturn(false);
         when(statisticsService.getUserAchievementsWeekly()).thenReturn(List.of());
         when(guessRepository.findBySteamIdBetween(anyString(), any(), any())).thenReturn(List.of());
-        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(List.of());
+        when(guessRepository.findDailyTotalsBySteamIdIn(anyList())).thenReturn(List.of());
         when(guessRepository.findRoundAvgScoresInRange(any(), any())).thenReturn(List.of());
         when(guessRepository.findByGameDateAndRoundIndex(any(), anyInt())).thenReturn(List.of());
         // Default: every requested steamId gets enough (35) low-signal rounds in the recency
-        // window to clear the new activity floor, so most tests don't need to hand-stub this.
-        // Only the count matters here — this is a separate mock from findBySteamIdIn, so it
-        // can never interfere with any tier's own history-based fixture. Tests that need a
-        // candidate to be genuinely inactive override this explicitly (see
-        // excludesPlayersNotActiveInLastTwoWeeks and the dormant-veteran regression test).
-        when(guessRepository.findBySteamIdInAndGameDateBetween(anyList(), any(), any()))
-                .thenAnswer(invocation -> {
-                    final List<String> steamIds = invocation.getArgument(0);
-                    final List<Guess> rows = new ArrayList<>();
-                    for (final String steamId : steamIds) {
-                        for (int i = 0; i < 35; i++) {
-                            rows.add(guess(steamId, today, 2));
-                        }
-                    }
-                    return rows;
-                });
+        // window to clear the activity floor. Wider history-prefetch windows (~60d) default to
+        // empty so tier tests that need specific history stub via stubRecentHistory(...).
+        // Use doAnswer (not when().thenAnswer) so re-stubbing in individual tests does not
+        // re-enter this answer with null matcher args.
+        doAnswer(invocation -> {
+            final List<String> steamIds = invocation.getArgument(0);
+            final LocalDate start = invocation.getArgument(1);
+            final LocalDate end = invocation.getArgument(2);
+            final long spanDays = java.time.temporal.ChronoUnit.DAYS.between(start, end);
+            if (spanDays > 20) {
+                return List.<Guess>of();
+            }
+            final List<Guess> rows = new ArrayList<>();
+            for (final String steamId : steamIds) {
+                for (int i = 0; i < 35; i++) {
+                    rows.add(guess(steamId, today, 2));
+                }
+            }
+            return rows;
+        }).when(guessRepository).findBySteamIdInAndGameDateBetween(anyList(), any(), any());
     }
 
     // NOTE: mocks referenced by an outer when(...).thenReturn(...) must be fully built
@@ -104,6 +108,37 @@ class PlayerSpotlightServiceTest {
         when(guessRepository.aggregateAllTimeStats()).thenReturn(List.of(rows));
     }
 
+    /**
+     * Stubs the wider (~60d) history prefetch used by MOST_IMPROVED / WELCOME_BACK / HOT_STREAK
+     * while keeping the default 14-day recency activity floor intact.
+     */
+    private void stubRecentHistory(List<Guess> history) {
+        doAnswer(invocation -> {
+            final List<String> steamIds = invocation.getArgument(0);
+            final LocalDate start = invocation.getArgument(1);
+            final LocalDate end = invocation.getArgument(2);
+            final long spanDays = java.time.temporal.ChronoUnit.DAYS.between(start, end);
+            if (spanDays > 20) {
+                return history;
+            }
+            final List<Guess> rows = new ArrayList<>();
+            for (final String steamId : steamIds) {
+                for (int i = 0; i < 35; i++) {
+                    rows.add(guess(steamId, today, 2));
+                }
+            }
+            return rows;
+        }).when(guessRepository).findBySteamIdInAndGameDateBetween(anyList(), any(), any());
+    }
+
+    private GuessRepository.DailyTotalRow dailyTotal(String steamId, LocalDate date, long points) {
+        final GuessRepository.DailyTotalRow row = mock(GuessRepository.DailyTotalRow.class);
+        when(row.getSteamId()).thenReturn(steamId);
+        when(row.getGameDate()).thenReturn(date);
+        when(row.getTotalPoints()).thenReturn(points);
+        return row;
+    }
+
     @Test
     void excludesPlayersBelowRoundThreshold() {
         final GuessRepository.AllTimeStatsRow belowThreshold = allTimeRow("belowThreshold", 60, 2.0);
@@ -138,7 +173,7 @@ class PlayerSpotlightServiceTest {
         // recent-rounds count of 0.
         final List<Guess> recentRounds = new ArrayList<>();
         for (int i = 0; i < 35; i++) recentRounds.add(guess("active", today, 2));
-        when(guessRepository.findBySteamIdInAndGameDateBetween(anyList(), any(), any())).thenReturn(recentRounds);
+        doReturn(recentRounds).when(guessRepository).findBySteamIdInAndGameDateBetween(anyList(), any(), any());
 
         service.computeAndPersistForToday();
 
@@ -165,7 +200,7 @@ class PlayerSpotlightServiceTest {
         final List<Guess> recentRounds = new ArrayList<>();
         for (int i = 0; i < 5; i++) recentRounds.add(guess("dormantVeteran", today, 2)); // only 5 in the window
         for (int i = 0; i < 35; i++) recentRounds.add(guess("active", today, 2));
-        when(guessRepository.findBySteamIdInAndGameDateBetween(anyList(), any(), any())).thenReturn(recentRounds);
+        doReturn(recentRounds).when(guessRepository).findBySteamIdInAndGameDateBetween(anyList(), any(), any());
 
         service.computeAndPersistForToday();
 
@@ -335,12 +370,12 @@ class PlayerSpotlightServiceTest {
         final List<GuessRepository.UserDateRow> dates = consecutiveDaysEnding("recordBreaker", yesterday, 1);
         when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
 
-        final List<Guess> history = List.of(
-                guess("recordBreaker", yesterday.minusDays(10), 8),
-                guess("recordBreaker", yesterday.minusDays(5), 12),
-                guess("recordBreaker", yesterday, 24)
+        final List<GuessRepository.DailyTotalRow> dailyTotals = List.of(
+                dailyTotal("recordBreaker", yesterday.minusDays(10), 8),
+                dailyTotal("recordBreaker", yesterday.minusDays(5), 12),
+                dailyTotal("recordBreaker", yesterday, 24)
         );
-        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(history);
+        when(guessRepository.findDailyTotalsBySteamIdIn(anyList())).thenReturn(dailyTotals);
 
         service.computeAndPersistForToday();
 
@@ -391,7 +426,7 @@ class PlayerSpotlightServiceTest {
         dates.add(dateRow("returner", beforeGap));
         when(guessRepository.findDistinctDatesUpToForUsers(anyList(), eq(today))).thenReturn(dates);
 
-        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(List.of(
+        stubRecentHistory(List.of(
                 guess("returner", mostRecent, 4),
                 guess("returner", mostRecent, 3)
         ));
@@ -419,7 +454,7 @@ class PlayerSpotlightServiceTest {
         final List<Guess> history = new ArrayList<>();
         for (int i = 0; i < 15; i++) history.add(guess("improver", last30Start.plusDays(i), 4));
         for (int i = 0; i < 15; i++) history.add(guess("improver", prior30Start.plusDays(i), 2));
-        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(history);
+        stubRecentHistory(history);
 
         service.computeAndPersistForToday();
 
@@ -454,11 +489,11 @@ class PlayerSpotlightServiceTest {
         final List<Guess> history = new ArrayList<>();
         for (int i = 0; i < 15; i++) history.add(guess("improver", last30Start.plusDays(i), 4));
         for (int i = 0; i < 15; i++) history.add(guess("improver", prior30Start.plusDays(i), 2));
-        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(history);
+        stubRecentHistory(history);
 
         // Neither candidate spuriously qualifies for the other's tier or for
         // BEST_DAY_EVER / BEAT_THE_ODDS / WELCOME_BACK / HOT_STREAK:
-        // - "streaker" has no entries in the stubbed findBySteamIdIn(...) result (only
+        // - "streaker" has no entries in the stubbed history prefetch (only
         //   "improver" does), so historyByPlayer.getOrDefault("streaker", ...) is always
         //   empty — it never clears any tier's round-count floor.
         // - "improver" has only a single date in datesDesc, so its current streak is
@@ -505,7 +540,7 @@ class PlayerSpotlightServiceTest {
         final List<Guess> history = new ArrayList<>();
         for (int i = 0; i < 15; i++) history.add(guess("improver", last30Start.plusDays(i), 4));
         for (int i = 0; i < 15; i++) history.add(guess("improver", prior30Start.plusDays(i), 2));
-        when(guessRepository.findBySteamIdIn(anyList())).thenReturn(history);
+        stubRecentHistory(history);
 
         final PlayerSpotlight recentDayStreak = new PlayerSpotlight();
         recentDayStreak.setGameDate(today.minusDays(1));

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -27,6 +27,8 @@ const EMPTY_SNAPSHOT: PresenceSnapshot = {
 const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30000;
 const CLIENT_PING_INTERVAL_MS = 30000;
+/** Random jitter added to reconnect backoff to soften post-restart reconnect herds. */
+const RECONNECT_JITTER_MS = 2000;
 
 /**
  * Converts an HTTP origin to its corresponding WebSocket origin.
@@ -126,9 +128,19 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
 
         const startPing = () => {
             clearPing();
+            // Background / sleeping tabs should not keep the socket alive overnight — without
+            // pings the server idle sweep (presence.idle-timeout-seconds, default 90s) reclaims
+            // the session. Brief tab switches under that window stay connected.
+            if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+                return;
+            }
             pingTimerRef.current = setInterval(() => {
                 const ws = socketRef.current;
                 if (!ws || ws.readyState !== WebSocket.OPEN) return;
+                if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+                    clearPing();
+                    return;
+                }
                 try {
                     ws.send(JSON.stringify({type: "ping"}));
                 } catch {
@@ -199,9 +211,15 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
 
         const scheduleReconnect = () => {
             if (disposed || closedByUserRef.current) return;
+            // Don't burn reconnect attempts while the tab is backgrounded overnight.
+            if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+                setReconnecting(true);
+                return;
+            }
             setReconnecting(true);
             const attempt = retryCountRef.current++;
-            const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS);
+            const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS)
+                + Math.floor(Math.random() * RECONNECT_JITTER_MS);
             clearReconnect();
             reconnectTimerRef.current = setTimeout(() => {
                 reconnectTimerRef.current = null;
@@ -219,9 +237,18 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
 
         const handleOnline = handleRecovery;
         const handleVisibilityChange = () => {
-            if (document.visibilityState === "visible") {
-                handleRecovery();
+            if (document.visibilityState === "hidden") {
+                clearPing();
+                clearReconnect();
+                return;
             }
+            // Tab visible again: resume keepalive or reconnect if the idle sweep dropped us.
+            const readyState = socketRef.current?.readyState;
+            if (readyState === WebSocket.OPEN) {
+                startPing();
+                return;
+            }
+            handleRecovery();
         };
 
         window.addEventListener("online", handleOnline);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Diagnosis

Overnight symptoms (JDBC OOM / “server unavailable” on login, while the round page still works) fit a **backend JVM heap OOM during Quartz batch work**, not host RAM exhaustion. Host btop showing ~380MB free is consistent with a **container cgroup limit** or small heap — the API process dies/restarts while Next.js (and/or warm Caffeine) keeps serving cached round pages. Login always hits the live backend, so it fails.

### Primary pressure (Quartz)
1. `SteamAppReviewsRefreshJob` at 02:00 UTC — `JOB_REVIEWS_REFRESH_LIMIT` was **never wired**; the job always used a hardcoded **15 000** apps
2. Every refreshed app called `review-game.clear()`, thrashing cache under load
3. `PlayerSpotlightJob` loaded **all** guesses for every eligible player via unbounded `findBySteamIdIn`
4. Docker image had **no heap cap** — JVM could grow into the Coolify memory limit

### WebSocket / presence (secondary)
Presence (#82/#90) is **unlikely the smoking gun**: tickets/sessions are bounded, heartbeats are in-memory, and JDBC is only touched once on authenticated connect. It can still raise the overnight memory floor — open tabs keep pinging forever, so sockets never hit the 90s idle sweep. After an OOM restart, reconnect herds can spike load around the same time Quartz fires.

## Changes

**Batch / JDBC**
- Wire `JOB_REVIEWS_REFRESH_LIMIT` (default **2500**); clear `review-game` cache once per run
- Bound spotlight history + SQL daily totals for BEST_DAY_EVER
- `Dockerfile.coolify`: `-XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError`
- Coolify: Hikari leak detection (60s)

**Presence WebSocket**
- Stop keepalive pings while the tab is `hidden` so idle sweep can reclaim overnight background tabs; resume/reconnect on visible
- Coolify defaults: global **500** / scope **200** / IP **10** (override via `PRESENCE_*`)
- Reconnect jitter to soften post-restart herds
- Cap Tomcat WS text/binary buffers at 8KB + 120s container idle backstop

## Ops checklist after deploy

1. Confirm Coolify env: `SPRING_PROFILE=coolify` (not `dev`)
2. Set a container memory limit; optionally override `JAVA_OPTS` / `JOB_REVIEWS_REFRESH_LIMIT` / `PRESENCE_*`
3. Check logs around **00:15** (spotlight) and **02:00 UTC** (reviews refresh)
4. Grafana: `jvm_memory_used_bytes`, `presence.connections.active`, `presence.session.idle_timeout`, Hikari, cAdvisor OOM events — if connections stay tiny while heap climbs, blame Quartz, not WS
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f82ed-5d98-79ba-ac9e-3389cc31a79c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f82ed-5d98-79ba-ac9e-3389cc31a79c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

