### PR TITLE
fix: overnight defensive hardening (ingest caps, stagger jobs, JDBC)

### DIFF
--- a/backend/src/main/java/org/steam5/config/JobsConfig.java
+++ b/backend/src/main/java/org/steam5/config/JobsConfig.java
@@ -1,0 +1,51 @@
+package org.steam5.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Per-run batch limits for background ingest/maintenance jobs. Limits how much work
+ * each scheduled execution performs so small VPS heaps are not exhausted in one pass.
+ * Cursors in {@code ingest_state} resume on the next run.
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "jobs")
+public class JobsConfig {
+
+    private SteamAppList steamAppList = new SteamAppList();
+    private SteamAppReviews steamAppReviews = new SteamAppReviews();
+    private SteamAppDetails steamAppDetails = new SteamAppDetails();
+    private Blurhash blurhash = new Blurhash();
+
+    @Getter
+    @Setter
+    public static class SteamAppList {
+        /** Max Steam API list pages per run (each page may contain up to 50k apps). */
+        private int batchLimit = 1;
+    }
+
+    @Getter
+    @Setter
+    public static class SteamAppReviews {
+        /** Max apps whose review counts are fetched per ingest run. */
+        private int batchLimit = 1000;
+    }
+
+    @Getter
+    @Setter
+    public static class SteamAppDetails {
+        /** Max apps whose store details are fetched per ingest run. */
+        private int batchLimit = 500;
+    }
+
+    @Getter
+    @Setter
+    public static class Blurhash {
+        /** Max screenshots encoded per full blurhash job run. */
+        private int batchLimit = 100;
+    }
+}

--- a/backend/src/main/java/org/steam5/config/QuartzConfig.java
+++ b/backend/src/main/java/org/steam5/config/QuartzConfig.java
@@ -87,9 +87,9 @@ public class QuartzConfig {
     public Trigger triggerSeasonFinalizerJob(@Qualifier("SeasonFinalizerJob") JobDetail job) {
         return TriggerBuilder.newTrigger().forJob(job)
                 .withIdentity("SeasonFinalizerJob_Trigger")
-                // daily at 00:10 to close finished seasons
+                // daily at 00:25 UTC — staggered after backfill so season SQL does not pile up at 00:10
                 .withSchedule(
-                        CronScheduleBuilder.cronSchedule("0 10 0 * * ?")
+                        CronScheduleBuilder.cronSchedule("0 25 0 * * ?")
                                 .inTimeZone(TimeZone.getTimeZone("UTC"))
                 )
                 .build();
@@ -100,9 +100,9 @@ public class QuartzConfig {
     public Trigger triggerSeasonBackfillJob(@Qualifier("SeasonBackfillJob") JobDetail job) {
         return TriggerBuilder.newTrigger().forJob(job)
                 .withIdentity("SeasonBackfillJob_Trigger")
-                // daily at 00:05
+                // daily at 00:20 UTC — after review-game picks (00:01), before finalizer/spotlight
                 .withSchedule(
-                        CronScheduleBuilder.cronSchedule("0 5 0 * * ?")
+                        CronScheduleBuilder.cronSchedule("0 20 0 * * ?")
                                 .inTimeZone(TimeZone.getTimeZone("UTC"))
                 )
                 .build();
@@ -113,9 +113,9 @@ public class QuartzConfig {
     public Trigger triggerPlayerSpotlightJob(@Qualifier("PlayerSpotlightJob") JobDetail job) {
         return TriggerBuilder.newTrigger().forJob(job)
                 .withIdentity("PlayerSpotlightJob_Trigger")
-                // daily at 00:15, after season backfill/finalizer have settled streak data
+                // daily at 00:35 UTC — after season jobs settle streak data; avoids midnight pile-up
                 .withSchedule(
-                        CronScheduleBuilder.cronSchedule("0 15 0 * * ?")
+                        CronScheduleBuilder.cronSchedule("0 35 0 * * ?")
                                 .inTimeZone(TimeZone.getTimeZone("UTC"))
                 )
                 .build();

--- a/backend/src/main/java/org/steam5/job/BlurhashScreenshotsJob.java
+++ b/backend/src/main/java/org/steam5/job/BlurhashScreenshotsJob.java
@@ -5,7 +5,6 @@ import org.quartz.*;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.steam5.config.JobsConfig;
@@ -96,22 +95,22 @@ public class BlurhashScreenshotsJob implements Job {
         final int batchLimit = Math.max(1, jobsConfig.getBlurhash().getBatchLimit());
         try {
             final int pageSize = 10; // small batch to limit memory
-            int page = 0;
+            long cursorId = 0L; // keyset cursor: query rows with id > cursorId
             boolean more = true;
             while (more && scanned < batchLimit) {
-                final Page<Screenshot> batch = screenshotRepository.findPageWithoutBlurhash(PageRequest.of(page, pageSize));
+                final List<Screenshot> batch = screenshotRepository.findPageWithoutBlurhash(cursorId, PageRequest.of(0, pageSize));
                 if (batch.isEmpty()) break;
-                for (Screenshot screenshot : batch.getContent()) {
+                for (Screenshot screenshot : batch) {
                     if (scanned >= batchLimit) {
                         break;
                     }
                     scanned++;
+                    cursorId = screenshot.getId(); // advance cursor to last scanned screenshot
                     final Counters c = handleScreenshot(screenshot);
                     encoded += c.encoded;
                     failed += c.failed;
                 }
-                page++;
-                more = batch.hasNext() && scanned < batchLimit;
+                more = (batch.size() == pageSize) && scanned < batchLimit;
             }
             if (scanned >= batchLimit && more) {
                 log.info("BlurhashScreenshotsJob batch limit reached ({}); remaining work deferred to next run", batchLimit);

--- a/backend/src/main/java/org/steam5/job/BlurhashScreenshotsJob.java
+++ b/backend/src/main/java/org/steam5/job/BlurhashScreenshotsJob.java
@@ -8,24 +8,35 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+import org.steam5.config.JobsConfig;
 import org.steam5.domain.details.Screenshot;
 import org.steam5.repository.details.ScreenshotRepository;
 import org.steam5.service.BlurhashService;
+import org.steam5.service.DomainCacheEvictor;
 
 import java.util.List;
 
 @Component
 @Slf4j
+@DisallowConcurrentExecution
 public class BlurhashScreenshotsJob implements Job {
 
     private final BlurhashService service;
     private final CacheManager cacheManager;
     private final ScreenshotRepository screenshotRepository;
+    private final DomainCacheEvictor cacheEvictor;
+    private final JobsConfig jobsConfig;
 
-    public BlurhashScreenshotsJob(final BlurhashService service, final CacheManager cacheManager, final ScreenshotRepository screenshotRepository) {
+    public BlurhashScreenshotsJob(final BlurhashService service,
+                                  final CacheManager cacheManager,
+                                  final ScreenshotRepository screenshotRepository,
+                                  final DomainCacheEvictor cacheEvictor,
+                                  final JobsConfig jobsConfig) {
         this.service = service;
         this.cacheManager = cacheManager;
         this.screenshotRepository = screenshotRepository;
+        this.cacheEvictor = cacheEvictor;
+        this.jobsConfig = jobsConfig;
     }
 
     /**
@@ -69,10 +80,7 @@ public class BlurhashScreenshotsJob implements Job {
                 try {
                     int encoded = encodeForApp(appId);
                     if (encoded > 0) {
-                        final Cache cache = cacheManager.getCache("review-game");
-                        if (cache != null) {
-                            cache.clear();
-                        }
+                        cacheEvictor.evictAppDetail(appId);
                     }
                     log.info("Targeted BlurhashScreenshotsJob finished for appId={} encoded={}", appId, encoded);
                 } catch (Exception e) {
@@ -82,37 +90,41 @@ public class BlurhashScreenshotsJob implements Job {
             }
         }
 
-        // Fallback 'full-run' job, which encodes all screenshots.
+        // Fallback 'full-run' job, which encodes screenshots up to the configured batch limit.
         long start = System.nanoTime();
         int scanned = 0, encoded = 0, failed = 0;
+        final int batchLimit = Math.max(1, jobsConfig.getBlurhash().getBatchLimit());
         try {
             final int pageSize = 10; // small batch to limit memory
             int page = 0;
             boolean more = true;
-            while (more) {
+            while (more && scanned < batchLimit) {
                 final Page<Screenshot> batch = screenshotRepository.findPageWithoutBlurhash(PageRequest.of(page, pageSize));
                 if (batch.isEmpty()) break;
                 for (Screenshot screenshot : batch.getContent()) {
+                    if (scanned >= batchLimit) {
+                        break;
+                    }
                     scanned++;
                     final Counters c = handleScreenshot(screenshot);
                     encoded += c.encoded;
                     failed += c.failed;
                 }
                 page++;
-                more = batch.hasNext();
-                try {
-                    System.gc();
-                } catch (Throwable ignored) {
-                }
+                more = batch.hasNext() && scanned < batchLimit;
+            }
+            if (scanned >= batchLimit && more) {
+                log.info("BlurhashScreenshotsJob batch limit reached ({}); remaining work deferred to next run", batchLimit);
             }
         } catch (Exception e) {
             log.error("BlurhashScreenshotsJob execution error", e);
             throw new JobExecutionException(e, false);
         } finally {
             long ms = (System.nanoTime() - start) / 1_000_000L;
-            log.info("BlurhashScreenshotsJob finished scanned={} encoded={} failed={} durationMs={}", scanned, encoded, failed, ms);
+            log.info("BlurhashScreenshotsJob finished scanned={} encoded={} failed={} batchLimit={} durationMs={}",
+                    scanned, encoded, failed, batchLimit, ms);
 
-            // Clear game cache, to allow the FE to pull new screenshot data.
+            // Clear game cache once so the FE can pull new screenshot blur data.
             if (encoded > 0) {
                 final Cache cache = cacheManager.getCache("review-game");
                 if (cache != null) {
@@ -197,5 +209,3 @@ public class BlurhashScreenshotsJob implements Job {
         int failed;
     }
 }
-
-

--- a/backend/src/main/java/org/steam5/repository/GuessRepository.java
+++ b/backend/src/main/java/org/steam5/repository/GuessRepository.java
@@ -559,9 +559,10 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
     List<AllTimeStatsRow> aggregateAllTimeStats();
 
     /**
-     * Same metrics as {@link #aggregateAllTimeStats()} but restricted in SQL to players
-     * with at least {@code minRounds} guesses — avoids scanning/aggregating the full table
-     * when only established players are needed (e.g. PlayerSpotlight eligibility).
+     * Same metrics as {@link #aggregateAllTimeStats()} but filters results to players
+     * with at least {@code minRounds} guesses using a HAVING clause. Note that the HAVING
+     * condition limits which aggregated groups are returned to Java, but does not avoid
+     * scanning or aggregating the full table at the database level.
      */
     @Query(value = """
             SELECT

--- a/backend/src/main/java/org/steam5/repository/GuessRepository.java
+++ b/backend/src/main/java/org/steam5/repository/GuessRepository.java
@@ -557,6 +557,34 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
             ORDER BY SUM(g.points) DESC
             """, nativeQuery = true)
     List<AllTimeStatsRow> aggregateAllTimeStats();
+
+    /**
+     * Same metrics as {@link #aggregateAllTimeStats()} but restricted in SQL to players
+     * with at least {@code minRounds} guesses — avoids scanning/aggregating the full table
+     * when only established players are needed (e.g. PlayerSpotlight eligibility).
+     */
+    @Query(value = """
+            SELECT
+                g.steam_id                                                          AS steamId,
+                SUM(g.points)                                                       AS totalPoints,
+                COUNT(*)                                                            AS rounds,
+                SUM(CASE WHEN g.selected_bucket = g.actual_bucket THEN 1 ELSE 0 END) AS hits,
+                SUM(CASE WHEN g.points = 0 THEN 1 ELSE 0 END)                      AS flops,
+                SUM(CASE WHEN
+                    CAST(NULLIF(regexp_replace(g.selected_bucket, '^(\\d+).*', '\\1'), '') AS BIGINT) >
+                    CAST(NULLIF(regexp_replace(g.actual_bucket,   '^(\\d+).*', '\\1'), '') AS BIGINT)
+                THEN 1 ELSE 0 END)                                                  AS tooHigh,
+                SUM(CASE WHEN
+                    CAST(NULLIF(regexp_replace(g.selected_bucket, '^(\\d+).*', '\\1'), '') AS BIGINT) <
+                    CAST(NULLIF(regexp_replace(g.actual_bucket,   '^(\\d+).*', '\\1'), '') AS BIGINT)
+                THEN 1 ELSE 0 END)                                                  AS tooLow,
+                AVG(g.points)                                                       AS avgPoints
+            FROM guesses g
+            GROUP BY g.steam_id
+            HAVING COUNT(*) >= :minRounds
+            ORDER BY SUM(g.points) DESC
+            """, nativeQuery = true)
+    List<AllTimeStatsRow> aggregateAllTimeStatsHavingMinRounds(@Param("minRounds") long minRounds);
 }
 
 

--- a/backend/src/main/java/org/steam5/repository/details/ScreenshotRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/ScreenshotRepository.java
@@ -15,6 +15,9 @@ public interface ScreenshotRepository extends JpaRepository<Screenshot, Long> {
     @Query("select s from Screenshot s where (s.blurhashThumb is null or s.blurhashThumb = '' or s.blurhashFull is null or s.blurhashFull = '') order by s.id asc")
     Page<Screenshot> findPageWithoutBlurhash(Pageable pageable);
 
+    @Query("select s from Screenshot s where s.id > :cursorId and (s.blurhashThumb is null or s.blurhashThumb = '' or s.blurhashFull is null or s.blurhashFull = '') order by s.id asc")
+    List<Screenshot> findPageWithoutBlurhash(@Param("cursorId") long cursorId, Pageable pageable);
+
     @Query("select s from Screenshot s where s.appId.appId = :appId and (s.blurhashThumb is null or s.blurhashThumb = '' or s.blurhashFull is null or s.blurhashFull = '') order by s.id asc")
     List<Screenshot> findMissingForApp(@Param("appId") Long appId);
 }

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -373,9 +373,9 @@ public class PlayerSpotlightService {
 
     private List<Candidate> findEligibleCandidates(final LocalDate today, final long minTotalRounds,
                                                      final long minRoundsInRecencyWindow) {
-        final Map<String, GuessRepository.AllTimeStatsRow> eligibleAllTime = guessRepository.aggregateAllTimeStats()
+        final Map<String, GuessRepository.AllTimeStatsRow> eligibleAllTime = guessRepository
+                .aggregateAllTimeStatsHavingMinRounds(minTotalRounds)
                 .stream()
-                .filter(row -> row.getRounds() != null && row.getRounds() >= minTotalRounds)
                 .collect(Collectors.toMap(GuessRepository.AllTimeStatsRow::getSteamId, Function.identity()));
 
         if (eligibleAllTime.isEmpty()) {

--- a/backend/src/main/java/org/steam5/service/SteamAppDetailsFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppDetailsFetcher.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.steam5.config.JobsConfig;
 import org.steam5.config.SteamAppsConfig;
 import org.steam5.domain.IngestState;
 import org.steam5.domain.SteamAppIndex;
@@ -27,13 +28,15 @@ public class SteamAppDetailsFetcher implements Fetcher {
     private final IngestStateRepository ingestStateRepository;
     private final SteamAppIndexRepository appIndexRepository;
     private final SteamAppDetailService service;
+    private final JobsConfig jobsConfig;
 
-    public SteamAppDetailsFetcher(final SteamAppsConfig properties, final JsonHttpClient jsonHttpClient, final IngestStateRepository ingestStateRepository, final SteamAppIndexRepository appIndexRepository, final SteamAppDetailService service) {
+    public SteamAppDetailsFetcher(final SteamAppsConfig properties, final JsonHttpClient jsonHttpClient, final IngestStateRepository ingestStateRepository, final SteamAppIndexRepository appIndexRepository, final SteamAppDetailService service, final JobsConfig jobsConfig) {
         this.properties = properties;
         this.jsonHttpClient = jsonHttpClient;
         this.ingestStateRepository = ingestStateRepository;
         this.appIndexRepository = appIndexRepository;
         this.service = service;
+        this.jobsConfig = jobsConfig;
     }
 
     @Override
@@ -43,18 +46,22 @@ public class SteamAppDetailsFetcher implements Fetcher {
         }
 
         final long lastAppId = ingestStateRepository.findById("steam_app_details").map(IngestState::getLastAppId).orElse(0L);
-        log.info("Starting details ingestion from appId > {}", lastAppId);
+        final int batchLimit = Math.max(1, jobsConfig.getSteamAppDetails().getBatchLimit());
+        log.info("Starting details ingestion from appId > {} (batchLimit={})", lastAppId, batchLimit);
 
         long processed = 0L;
         Long cursor = lastAppId;
         final int pageSize = 500; // single HTTP call per app, moderate batch size
         boolean more = true;
-        while (more) {
+        while (more && processed < batchLimit) {
             final Page<SteamAppIndex> page = appIndexRepository.findByAppIdGreaterThan(cursor, PageRequest.of(0, pageSize, Sort.by("appId").ascending()));
             if (page.isEmpty()) {
                 break;
             }
             for (SteamAppIndex idx : page) {
+                if (processed >= batchLimit) {
+                    break;
+                }
                 final Long appId = idx.getAppId();
                 if (appId == null) continue;
                 try {
@@ -69,10 +76,10 @@ public class SteamAppDetailsFetcher implements Fetcher {
                 processed++;
                 cursor = appId;
             }
-            more = page.hasNext();
+            more = page.hasNext() && processed < batchLimit;
         }
 
-        log.info("Details ingestion finished. processed={} starting_after={}", processed, lastAppId);
+        log.info("Details ingestion finished. processed={} batchLimit={} starting_after={}", processed, batchLimit, lastAppId);
     }
 
     public boolean fetchForAppId(final Long appId) throws IOException {

--- a/backend/src/main/java/org/steam5/service/SteamAppListFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppListFetcher.java
@@ -3,6 +3,7 @@ package org.steam5.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.steam5.config.JobsConfig;
 import org.steam5.config.SteamAppsConfig;
 import org.steam5.domain.IngestState;
 import org.steam5.domain.SteamAppIndex;
@@ -22,15 +23,18 @@ public class SteamAppListFetcher implements Fetcher {
     private final JsonHttpClient jsonHttpClient;
     private final SteamAppIndexRepository appIndexRepository;
     private final IngestStateRepository ingestStateRepository;
+    private final JobsConfig jobsConfig;
 
     public SteamAppListFetcher(SteamAppsConfig properties,
                                SteamAppIndexRepository appIndexRepository,
                                IngestStateRepository ingestStateRepository,
-                               JsonHttpClient jsonHttpClient) {
+                               JsonHttpClient jsonHttpClient,
+                               JobsConfig jobsConfig) {
         this.properties = properties;
         this.appIndexRepository = appIndexRepository;
         this.ingestStateRepository = ingestStateRepository;
         this.jsonHttpClient = jsonHttpClient;
+        this.jobsConfig = jobsConfig;
     }
 
     @Override
@@ -41,13 +45,14 @@ public class SteamAppListFetcher implements Fetcher {
 
         boolean haveMore = true;
         long lastAppId = ingestStateRepository.findById("steam_app_list").map(IngestState::getLastAppId).orElse(0L);
+        final int pageLimit = Math.max(1, jobsConfig.getSteamAppList().getBatchLimit());
         int page = 0;
         long totalApps = 0;
 
-        while (haveMore) {
+        while (haveMore && page < pageLimit) {
             page++;
             final String url = buildUrl(lastAppId);
-            log.info("Fetching Steam app list page {} with last_appid={} ...", page, lastAppId);
+            log.info("Fetching Steam app list page {} of {} with last_appid={} ...", page, pageLimit, lastAppId);
 
             final JsonNode root = jsonHttpClient.getJson(url);
             final JsonNode response = root.path("response");
@@ -75,9 +80,14 @@ public class SteamAppListFetcher implements Fetcher {
 
             log.info("Persisted page {} (apps processed: {} of {}), have_more_results={}, next last_appid={}",
                     page, batchCount, apps.isArray() ? apps.size() : -1, haveMore, lastAppId);
+
+            if (page >= pageLimit && haveMore) {
+                log.info("Steam app list page limit reached ({}); cursor saved for next run", pageLimit);
+                break;
+            }
         }
 
-        log.info("Steam app list ingestion finished. pages={}, total_apps_seen={}", page, totalApps);
+        log.info("Steam app list ingestion finished. pages={} pageLimit={} total_apps_seen={}", page, pageLimit, totalApps);
     }
 
     private String buildUrl(long lastAppId) {

--- a/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.steam5.config.JobsConfig;
 import org.steam5.config.SteamAppsConfig;
 import org.steam5.domain.IngestState;
 import org.steam5.domain.SteamAppIndex;
@@ -30,19 +31,22 @@ public class SteamAppReviewsFetcher implements Fetcher {
     private final SteamAppReviewsRepository reviewsRepository;
     private final IngestStateRepository ingestStateRepository;
     private final CacheManager cacheManager;
+    private final JobsConfig jobsConfig;
 
     public SteamAppReviewsFetcher(SteamAppsConfig properties,
                                   JsonHttpClient jsonHttpClient,
                                   SteamAppIndexRepository appIndexRepository,
                                   SteamAppReviewsRepository reviewsRepository,
                                   IngestStateRepository ingestStateRepository,
-                                  CacheManager cacheManager) {
+                                  CacheManager cacheManager,
+                                  JobsConfig jobsConfig) {
         this.properties = properties;
         this.jsonHttpClient = jsonHttpClient;
         this.appIndexRepository = appIndexRepository;
         this.reviewsRepository = reviewsRepository;
         this.ingestStateRepository = ingestStateRepository;
         this.cacheManager = cacheManager;
+        this.jobsConfig = jobsConfig;
     }
 
     @Override
@@ -52,18 +56,22 @@ public class SteamAppReviewsFetcher implements Fetcher {
         }
 
         final long lastAppId = ingestStateRepository.findById("steam_app_reviews").map(IngestState::getLastAppId).orElse(0L);
-        log.info("Starting reviews ingestion from appId > {}", lastAppId);
+        final int batchLimit = Math.max(1, jobsConfig.getSteamAppReviews().getBatchLimit());
+        log.info("Starting reviews ingestion from appId > {} (batchLimit={})", lastAppId, batchLimit);
 
         long processed = 0L;
         Long cursor = lastAppId;
         final int pageSize = 1000; // large batches; single HTTP call per app
         boolean more = true;
-        while (more) {
+        while (more && processed < batchLimit) {
             final Page<SteamAppIndex> page = appIndexRepository.findByAppIdGreaterThan(cursor, PageRequest.of(0, pageSize, Sort.by("appId").ascending()));
             if (page.isEmpty()) {
                 break;
             }
             for (SteamAppIndex idx : page) {
+                if (processed >= batchLimit) {
+                    break;
+                }
                 final Long appId = idx.getAppId();
                 if (appId == null) continue;
                 fetchForAppId(appId);
@@ -71,10 +79,10 @@ public class SteamAppReviewsFetcher implements Fetcher {
                 processed++;
                 cursor = appId;
             }
-            more = page.hasNext();
+            more = page.hasNext() && processed < batchLimit;
         }
 
-        log.info("Reviews ingestion finished. processed={} starting_after={}", processed, lastAppId);
+        log.info("Reviews ingestion finished. processed={} batchLimit={} starting_after={}", processed, batchLimit, lastAppId);
     }
 
     public boolean fetchForAppId(Long appId) throws IOException {

--- a/backend/src/main/resources/application-coolify.yml
+++ b/backend/src/main/resources/application-coolify.yml
@@ -7,6 +7,8 @@ spring:
     hikari:
       # Surface connection leaks in prod logs (0 disables detection)
       leak-detection-threshold: ${DB_POOL_LEAK_DETECTION_MS:60000}
+      # Kill runaway queries from broken jobs; normal gameplay queries finish in ms.
+      connection-init-sql: SET statement_timeout = '${DB_STATEMENT_TIMEOUT:120s}'
 # Presence WebSocket caps tuned for small Coolify/VPS heaps. Override via PRESENCE_* env vars.
 # Open tabs ping to stay alive; background tabs stop pinging so idle sweep can reclaim them.
 presence:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
       mode: always
       platform: postgres
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     show-sql: false
@@ -35,14 +36,14 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        jdbc.batch_size: 50
+        order_inserts: true
+        order_updates: true
+        default_batch_fetch_size: 16
   quartz:
     properties:
       org.quartz.scheduler.idleWaitTime: 1000 # 1000 is minimum
       org.quartz.threadPool.threadCount: 5
-      jdbc.batch_size: 50
-      order_inserts: true
-      order_updates: true
-      order_deletes: true
   web:
     error:
       include-message: always
@@ -110,14 +111,19 @@ season:
 jobs:
   steam-app-list:
     enabled: ${JOB_INGEST_LIST:false}
+    # Max Steam API list pages per run (each page may contain up to 50k apps as JSON).
+    batch-limit: ${JOB_INGEST_LIST_BATCH_LIMIT:1}
   steam-app-reviews:
     enabled: ${JOB_INGEST_REVIEWS:false}
+    batch-limit: ${JOB_INGEST_REVIEWS_BATCH_LIMIT:1000}
   steam-app-details:
     enabled: ${JOB_INGEST_DETAILS:false}
+    batch-limit: ${JOB_INGEST_DETAILS_BATCH_LIMIT:500}
   review-game-state:
     enabled: ${JOB_GENERATE_REVIEW_STATE:false}
   blurhash:
     enabled: ${JOB_BLURHASH:false}
+    batch-limit: ${JOB_BLURHASH_BATCH_LIMIT:100}
   blurhashAvatar:
     enabled: ${JOB_BLURHASH_AVATAR:false}
   reviews-refresh:

--- a/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/PlayerSpotlightServiceTest.java
@@ -105,7 +105,12 @@ class PlayerSpotlightServiceTest {
     }
 
     private void stubAllTimeStats(GuessRepository.AllTimeStatsRow... rows) {
-        when(guessRepository.aggregateAllTimeStats()).thenReturn(List.of(rows));
+        when(guessRepository.aggregateAllTimeStatsHavingMinRounds(anyLong())).thenAnswer(invocation -> {
+            final long minRounds = invocation.getArgument(0);
+            return java.util.Arrays.stream(rows)
+                    .filter(row -> row.getRounds() != null && row.getRounds() >= minRounds)
+                    .toList();
+        });
     }
 
     /**
@@ -334,7 +339,7 @@ class PlayerSpotlightServiceTest {
 
         service.computeAndPersistForToday();
 
-        verify(guessRepository, never()).aggregateAllTimeStats();
+        verify(guessRepository, never()).aggregateAllTimeStatsHavingMinRounds(anyLong());
         verify(playerSpotlightRepository, never()).save(any());
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #98. Implements defensive measures 2–7 without affecting gameplay (scoring, guesses, round content, or active play).

## Changes

### 2. Cap unbounded Steam ingest loops
- New `JobsConfig` with per-run batch limits (env-overridable):
  - `JOB_INGEST_LIST_BATCH_LIMIT` — pages per run (default **1**; each page can be 50k apps)
  - `JOB_INGEST_REVIEWS_BATCH_LIMIT` — apps per run (default **1000**)
  - `JOB_INGEST_DETAILS_BATCH_LIMIT` — apps per run (default **500**)
  - `JOB_BLURHASH_BATCH_LIMIT` — screenshots per run (default **100**)
- Cursors in `ingest_state` resume on the next scheduled run

### 3. Stagger midnight UTC maintenance jobs
| Job | Was | Now |
|-----|-----|-----|
| ReviewGameState | 00:01 | 00:01 (unchanged) |
| SeasonBackfill | 00:05 | **00:20** |
| SeasonFinalizer | 00:10 | **00:25** |
| PlayerSpotlight | 00:15 | **00:35** |
| ReviewsRefresh | 02:00 | 02:00 (unchanged) |

### 4. Spotlight eligibility SQL filter
- New `aggregateAllTimeStatsHavingMinRounds(minRounds)` with `HAVING COUNT(*) >= :minRounds`
- `PlayerSpotlightService` uses it instead of full-table aggregate + Java filter

### 5. Hibernate batch settings + disable OSIV
- Moved `jdbc.batch_size`, `order_inserts`, `order_updates` to `spring.jpa.properties.hibernate`
- Added `default_batch_fetch_size: 16`
- Set `spring.jpa.open-in-view: false`
- Removed misplaced batch keys from `spring.quartz.properties`

### 6. Postgres statement timeout (Coolify)
- `connection-init-sql: SET statement_timeout = '${DB_STATEMENT_TIMEOUT:120s}'`
- Override via `DB_STATEMENT_TIMEOUT` env var

### 7. Blurhash job hardening
- `@DisallowConcurrentExecution`
- Per-run batch limit
- Removed `System.gc()` loop
- Targeted runs use `DomainCacheEvictor.evictAppDetail(appId)`

## Ops notes for your Coolify env

Your explicit `JOB_*` vars are fine — no change needed unless you want to tune batch limits:

```
JOB_INGEST_LIST_BATCH_LIMIT=1        # recommended (each page is huge)
JOB_BLURHASH_BATCH_LIMIT=100         # optional override
DB_STATEMENT_TIMEOUT=120s            # optional override
```

## Testing

- `PlayerSpotlightServiceTest`, `LeaderboardServiceTest`, and 136 other unit tests pass
- `Steam5ApplicationTests` requires local PostgreSQL (pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f82ed-5d98-79ba-ac9e-3389cc31a79c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f82ed-5d98-79ba-ac9e-3389cc31a79c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

