### PR TITLE
stop rsc preload of archive pages on perfect days and hardest games leaderboards

### DIFF
--- a/frontend/src/components/HardestGamesTable.tsx
+++ b/frontend/src/components/HardestGamesTable.tsx
@@ -91,7 +91,7 @@ export default function HardestGamesTable(props: {
                                         Steam ↗
                                     </a>
                                     {" · "}
-                                    <Link href={`/review-guesser/archive/${game.latestPickDate}`}>
+                                    <Link href={`/review-guesser/archive/${game.latestPickDate}`} prefetch={false}>
                                         Archive
                                     </Link>
                                 </span>

--- a/frontend/src/components/PerfectDaysTable.tsx
+++ b/frontend/src/components/PerfectDaysTable.tsx
@@ -106,7 +106,7 @@ export default function PerfectDaysTable(props: {
                                 {entry.appNames.join(', ')}
                             </td>
                             <td>
-                                <Link href={`/review-guesser/archive/${entry.gameDate}`}>
+                                <Link href={`/review-guesser/archive/${entry.gameDate}`} prefetch={false}>
                                     View
                                 </Link>
                             </td>


### PR DESCRIPTION
Adds `prefetch={false}` to archive `<Link>` components in `PerfectDaysTable` and `HardestGamesTable` to prevent Next.js from prefetching archive RSC payloads for every visible link on these leaderboard pages.

Each prefetch triggers backend calls (1 GET + N POSTs per archive date), causing unnecessary load. This matches the pattern already used by `LeaderboardTable` (plain `<a>`) and the archive index page.

Closes #108