### PR TITLE
Fix comment composer alignment, reaction popover stacking, and archive reset row

### DIFF
--- a/frontend/app/review-guesser/archive/[date]/page.tsx
+++ b/frontend/app/review-guesser/archive/[date]/page.tsx
@@ -111,9 +111,7 @@ export default async function ArchivePage({params}: { params: Promise<{ date: st
                     <GameInfoSection pick={pick}/>
                 </div>
             ))}
-            <div className="archive__reset">
-                <ArchiveResetForDay date={date}/>
-            </div>
+            <ArchiveResetForDay date={date}/>
         </section>
     );
 }

--- a/frontend/src/components/DayComments.tsx
+++ b/frontend/src/components/DayComments.tsx
@@ -19,6 +19,7 @@ import {
     type DayComment,
 } from "@/lib/comments";
 import {formatRelativeTime} from "@/lib/format";
+import {nextOpenPickerId} from "@/lib/reactionPicker";
 import type {RoundResult, StoredDay} from "@/lib/storage";
 import {
     postCommentAction,
@@ -498,9 +499,9 @@ export default function DayComments(props: {
                                             readOnly={readOnly}
                                             onToggled={handlePosted}
                                             onUnauthorized={handleUnauthorized}
+                                            open={openPickerCommentId === comment.id}
                                             onPickerOpenChange={(isOpen) => {
-                                                setOpenPickerCommentId((prev) =>
-                                                    isOpen ? comment.id : (prev === comment.id ? null : prev));
+                                                setOpenPickerCommentId((prev) => nextOpenPickerId(prev, comment.id, isOpen));
                                             }}
                                         />
                                     </div>

--- a/frontend/src/components/DayComments.tsx
+++ b/frontend/src/components/DayComments.tsx
@@ -356,6 +356,7 @@ export default function DayComments(props: {
     const {isSignedIn, steamId, refreshAuth} = useAuth();
     const canModerate = isSignedIn === true && steamId === COMMENT_MODERATOR_STEAM_ID;
     const [archivingId, setArchivingId] = useState<number | null>(null);
+    const [openPickerCommentId, setOpenPickerCommentId] = useState<number | null>(null);
 
     const swrKey = gameDate ? commentsUrl(gameDate) : null;
     // Long browser cache only for anonymous archive views (no reactedByViewer).
@@ -443,13 +444,16 @@ export default function DayComments(props: {
             )}
 
             {data && data.length > 0 && (
-                <ul className="day-comments__list">
+                <ul className={`day-comments__list${openPickerCommentId !== null ? " day-comments__list--picker-open" : ""}`}>
                     {data.map((comment) => {
                         const author = comment.author;
                         const displayName = author.personaName || author.steamId;
                         const relative = comment.createdAt ? formatRelativeTime(comment.createdAt) : "";
                         return (
-                            <li key={comment.id} className="day-comments__item">
+                            <li
+                                key={comment.id}
+                                className={`day-comments__item${openPickerCommentId === comment.id ? " day-comments__item--picker-open" : ""}`}
+                            >
                                 <CommentAvatar
                                     steamId={author.steamId}
                                     personaName={displayName}
@@ -494,6 +498,10 @@ export default function DayComments(props: {
                                             readOnly={readOnly}
                                             onToggled={handlePosted}
                                             onUnauthorized={handleUnauthorized}
+                                            onPickerOpenChange={(isOpen) => {
+                                                setOpenPickerCommentId((prev) =>
+                                                    isOpen ? comment.id : (prev === comment.id ? null : prev));
+                                            }}
                                         />
                                     </div>
                                     <p className="day-comments__text">

--- a/frontend/src/components/ReactionBar.tsx
+++ b/frontend/src/components/ReactionBar.tsx
@@ -27,12 +27,24 @@ export default function ReactionBar(props: {
     onUnauthorized?: () => void;
     /** When true, show reaction counts only — no picker or toggle controls. */
     readOnly?: boolean;
+    /** Notifies the parent list item when the reaction picker opens or closes. */
+    onPickerOpenChange?: (open: boolean) => void;
 }) {
-    const {commentId, reactions, canReact, onToggled, onUnauthorized, readOnly = false} = props;
+    const {commentId, reactions, canReact, onToggled, onUnauthorized, readOnly = false, onPickerOpenChange} = props;
     const [pending, setPending] = useState<ReactionType | null>(null);
     const [open, setOpen] = useState(false);
     const rootRef = useRef<HTMLDivElement>(null);
     const pickerId = useId();
+
+    // Kept in a ref so the effect below only re-runs when `open` changes,
+    // not on every parent render (the callback is typically a fresh closure).
+    const onPickerOpenChangeRef = useRef(onPickerOpenChange);
+    onPickerOpenChangeRef.current = onPickerOpenChange;
+
+    useEffect(() => {
+        onPickerOpenChangeRef.current?.(open);
+        return () => onPickerOpenChangeRef.current?.(false);
+    }, [open]);
 
     const byType = new Map<string, CommentReactionDto>();
     for (const reaction of reactions) {

--- a/frontend/src/components/ReactionBar.tsx
+++ b/frontend/src/components/ReactionBar.tsx
@@ -27,24 +27,30 @@ export default function ReactionBar(props: {
     onUnauthorized?: () => void;
     /** When true, show reaction counts only — no picker or toggle controls. */
     readOnly?: boolean;
-    /** Notifies the parent list item when the reaction picker opens or closes. */
+    /** Whether the picker is open. Owned by the parent so only one picker across the list is ever open. */
+    open?: boolean;
+    /** Requests that the picker be opened or closed. */
     onPickerOpenChange?: (open: boolean) => void;
 }) {
-    const {commentId, reactions, canReact, onToggled, onUnauthorized, readOnly = false, onPickerOpenChange} = props;
+    const {
+        commentId, reactions, canReact, onToggled, onUnauthorized, readOnly = false,
+        open = false, onPickerOpenChange,
+    } = props;
     const [pending, setPending] = useState<ReactionType | null>(null);
-    const [open, setOpen] = useState(false);
     const rootRef = useRef<HTMLDivElement>(null);
     const pickerId = useId();
 
-    // Kept in a ref so the effect below only re-runs when `open` changes,
-    // not on every parent render (the callback is typically a fresh closure).
+    // Kept in a ref so the outside-click/Escape effect below only re-subscribes
+    // when `open` changes, not on every parent render (the callback is
+    // typically a fresh closure), and so unmount cleanup calls the latest one.
     const onPickerOpenChangeRef = useRef(onPickerOpenChange);
-    onPickerOpenChangeRef.current = onPickerOpenChange;
+    useEffect(() => {
+        onPickerOpenChangeRef.current = onPickerOpenChange;
+    }, [onPickerOpenChange]);
 
     useEffect(() => {
-        onPickerOpenChangeRef.current?.(open);
         return () => onPickerOpenChangeRef.current?.(false);
-    }, [open]);
+    }, []);
 
     const byType = new Map<string, CommentReactionDto>();
     for (const reaction of reactions) {
@@ -70,11 +76,11 @@ export default function ReactionBar(props: {
         const onPointerDown = (event: MouseEvent | TouchEvent) => {
             const target = event.target as Node | null;
             if (rootRef.current && target && !rootRef.current.contains(target)) {
-                setOpen(false);
+                onPickerOpenChangeRef.current?.(false);
             }
         };
         const onKeyDown = (event: KeyboardEvent) => {
-            if (event.key === "Escape") setOpen(false);
+            if (event.key === "Escape") onPickerOpenChangeRef.current?.(false);
         };
 
         document.addEventListener("mousedown", onPointerDown);
@@ -97,7 +103,7 @@ export default function ReactionBar(props: {
         try {
             await toggleReaction(commentId, reactionType);
             await onToggled();
-            setOpen(false);
+            onPickerOpenChange?.(false);
         } catch (e) {
             const message = e instanceof Error ? e.message : "";
             if (
@@ -120,7 +126,7 @@ export default function ReactionBar(props: {
             window.location.href = buildSteamLoginUrl();
             return;
         }
-        setOpen((value) => !value);
+        onPickerOpenChange?.(!open);
     };
 
     if (readOnly) {

--- a/frontend/src/lib/reactionPicker.test.ts
+++ b/frontend/src/lib/reactionPicker.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+import {nextOpenPickerId} from './reactionPicker';
+
+describe('nextOpenPickerId', () => {
+    it('opens picker A from a closed state', () => {
+        expect(nextOpenPickerId(null, 1, true)).toBe(1);
+    });
+
+    it('switches from picker A to picker B without an explicit close of A', () => {
+        // Simulates keyboard activation of B's trigger: B reports isOpen=true
+        // while A is still recorded as open, and no close-A signal ever fires
+        // (Tab+Enter on B's button doesn't dispatch the mousedown/touchstart
+        // event that the outside-click listener relies on).
+        const afterAOpens = nextOpenPickerId(null, 1, true);
+        const afterBOpens = nextOpenPickerId(afterAOpens, 2, true);
+        expect(afterBOpens).toBe(2);
+    });
+
+    it('closes picker B when it reports isOpen=false', () => {
+        const state = nextOpenPickerId(2, 2, false);
+        expect(state).toBeNull();
+    });
+
+    it('ignores a stale close signal from a picker that is no longer active', () => {
+        // A's unmount/outside-click cleanup can fire after B has already
+        // become the active picker; that stale signal must not clear B.
+        const afterBOpen = nextOpenPickerId(1, 2, true);
+        const afterStaleAClose = nextOpenPickerId(afterBOpen, 1, false);
+        expect(afterStaleAClose).toBe(2);
+    });
+});

--- a/frontend/src/lib/reactionPicker.ts
+++ b/frontend/src/lib/reactionPicker.ts
@@ -1,0 +1,19 @@
+/**
+ * Computes the next "which comment's reaction picker is open" id.
+ *
+ * Only one picker may be open across a comment list at a time. Opening a
+ * picker always wins outright (covers switching focus from picker A to
+ * picker B via keyboard activation, which never fires the outside-click
+ * listener that would otherwise close A). A close signal only takes effect
+ * when it comes from the picker that is currently open — a stale close
+ * signal from a picker that already lost focus must not clobber a
+ * different picker that has since opened.
+ */
+export function nextOpenPickerId(
+    prev: number | null,
+    commentId: number,
+    isOpen: boolean,
+): number | null {
+    if (isOpen) return commentId;
+    return prev === commentId ? null : prev;
+}

--- a/frontend/src/styles/components/archive.css
+++ b/frontend/src/styles/components/archive.css
@@ -29,6 +29,7 @@
 .archive__reset {
     margin: 1rem 0;
     display: flex;
+    align-items: center;
     gap: 0.5rem;
 }
 

--- a/frontend/src/styles/components/dayComments.css
+++ b/frontend/src/styles/components/dayComments.css
@@ -40,6 +40,10 @@
     content-visibility: auto;
 }
 
+.day-comments__list--picker-open {
+    content-visibility: visible;
+}
+
 .day-comments__item {
     display: grid;
     grid-template-columns: auto 1fr;
@@ -58,6 +62,12 @@
 
 .day-comments__item:last-child {
     padding-bottom: 0.15rem;
+}
+
+.day-comments__item--picker-open {
+    content-visibility: visible;
+    isolation: isolate;
+    z-index: 10;
 }
 
 .day-comments__avatar-link {
@@ -306,14 +316,15 @@
     font-size: 0.74rem;
     color: var(--color-muted);
     font-variant-numeric: tabular-nums;
-}
-
-.comment-composer__actions > .comment-composer__count:first-child {
     margin-right: auto;
 }
 
 .comment-composer__count--warn {
     color: var(--color-error);
+}
+
+.comment-composer__submit {
+    justify-content: flex-end;
 }
 
 .comment-composer__posted {
@@ -356,6 +367,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.18rem;
+    min-height: 1.85rem;
     padding: 0.1rem 0.32rem;
     border: 1px solid transparent;
     border-radius: 0.4rem;


### PR DESCRIPTION
Closes #112 

## Summary
- Right-aligns the Post button label/icon (`.comment-composer__submit { justify-content: flex-end }`) and keeps the character counter pinned to the left of the composer actions row regardless of whether `GameLinkPicker` renders (`margin-right: auto` moved directly onto `.comment-composer__count`).
- Adds a `min-height` to `.reaction-bar__chip` matched to `.reaction-bar__trigger` (1.85rem) for visual balance.
- Fixes the reaction picker popover rendering behind the composer textarea: `.day-comments__item` (and `.day-comments__list`, which also uses `content-visibility: auto` and independently traps stacking) are promoted out of containment via a state-driven class while the picker is open, using `content-visibility: visible` + `isolation: isolate` + `z-index`. `ReactionBar` now reports open/closed state up to `DayComments` via a new `onPickerOpenChange` prop.
- Adds `align-items: center` to `.archive__reset` (matching the existing `archive-list.css` convention) and removes the redundant `<div className="archive__reset">` wrapper around `<ArchiveResetForDay/>` in the archive page, since that component already renders its own `.archive__reset` container.
- No changes to the shared `.btn-cta` rule in `shared.css`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vitest run` — 138/138 tests pass
- [x] Verified in a running dev server (via injected DOM matching the real markup/CSS) that the reaction popover on the last comment now paints above the composer textarea (confirmed with `elementFromPoint` and a screenshot)
- [x] Verified `.archive__reset` renders as a single element with `align-items: center` and no duplicated wrapper/margins