### PR TITLE
Unify avatar styling across the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.19.0] - 2026-08-03
+
+### Added
+
+- Added day comments with emoji reactions, letting signed-in players discuss and react to each day's games once they've finished all rounds
+- Added @mention autocomplete in the comment composer to search for and tag other players
+- Added day-game chips in the comment composer to quickly insert links to that day's games
+- Added a "yesterday's top comment" spotlight alongside the player spotlight
+
+### Fixed
+
+- Unified avatars across the header, leaderboards, "playing now", and comments into one consistent style, and fixed leaderboard rows not being vertically centered
+- Fixed a hydration error on the leaderboard caused by a timezone/locale mismatch between server and client
+- Fixed comment composer alignment, reaction popover stacking order, and the archive reset row layout
+- Fixed avatars below 40x40 showing a Next.js blur-placeholder warning
+
+### Changed
+
+- Added intraday refresh triggers for the Perfect Days, Hardest Games, and Season leaderboards so they update more frequently throughout the day
+- Stopped preloading archive pages from the Perfect Days and Hardest Games leaderboard tabs to reduce unnecessary requests
+
 ## [1.18.1] - 2026-07-24
 
 ### Fixed

--- a/backend/src/main/java/org/steam5/service/CommentService.java
+++ b/backend/src/main/java/org/steam5/service/CommentService.java
@@ -229,7 +229,7 @@ public class CommentService {
 
     private static AuthorDto toAuthor(final String steamId, final User user) {
         if (user == null) {
-            return new AuthorDto(steamId, steamId, null, null);
+            return new AuthorDto(steamId, steamId, null);
         }
         final String personaName = (user.getPersonaName() != null && !user.getPersonaName().isBlank())
                 ? user.getPersonaName()
@@ -237,10 +237,7 @@ public class CommentService {
         final String avatar = (user.getAvatarFull() != null && !user.getAvatarFull().isBlank())
                 ? user.getAvatarFull()
                 : user.getAvatar();
-        final String avatarBlurdata = (user.getBlurdataAvatarFull() != null && !user.getBlurdataAvatarFull().isBlank())
-                ? user.getBlurdataAvatarFull()
-                : user.getBlurdataAvatar();
-        return new AuthorDto(user.getSteamId(), personaName, avatar, avatarBlurdata);
+        return new AuthorDto(user.getSteamId(), personaName, avatar);
     }
 
     private static List<ReactionDto> reactionDtos(final Map<ReactionType, Long> counts,
@@ -269,7 +266,7 @@ public class CommentService {
         }
     }
 
-    public record AuthorDto(String steamId, String personaName, String avatar, String avatarBlurdata) {
+    public record AuthorDto(String steamId, String personaName, String avatar) {
     }
 
     public record ReactionDto(String reactionType, long count, boolean reactedByViewer) {

--- a/backend/src/main/java/org/steam5/service/LeaderboardService.java
+++ b/backend/src/main/java/org/steam5/service/LeaderboardService.java
@@ -131,7 +131,6 @@ public class LeaderboardService {
                             row.getAvgPoints() != null ? row.getAvgPoints() : 0.0,
                             streak,
                             blankToNull(row.getAvatarFull()),
-                            blankToNull(row.getBlurdataAvatarFull()),
                             blankToNull(row.getProfileUrl())
                     );
                 })
@@ -174,9 +173,8 @@ public class LeaderboardService {
     private LeaderEntry getLeaderEntry(final String steamId, final long totalPoints, final long rounds, final long hits, final long flops, final long tooHigh, final long tooLow, final double avgPoints, final int streak, final User user) {
         final String personaName = user != null && user.getPersonaName() != null && !user.getPersonaName().isBlank() ? user.getPersonaName() : steamId;
         final String avatar = user != null ? blankToNull(user.getAvatarFull()) : null;
-        final String avatarBlurdata = user != null ? blankToNull(user.getBlurdataAvatarFull()) : null;
         final String profileUrl = user != null ? blankToNull(user.getProfileUrl()) : null;
-        return new LeaderEntry(steamId, personaName, totalPoints, rounds, hits, flops, tooHigh, tooLow, avgPoints, streak, avatar, avatarBlurdata, profileUrl);
+        return new LeaderEntry(steamId, personaName, totalPoints, rounds, hits, flops, tooHigh, tooLow, avgPoints, streak, avatar, profileUrl);
     }
 
     public record LeaderEntry(String steamId,
@@ -186,7 +184,6 @@ public class LeaderboardService {
                               double avgPoints,
                               int streak,
                               String avatar,
-                              String avatarBlurdata,
                               String profileUrl) {
     }
 }

--- a/backend/src/main/java/org/steam5/service/StatisticsService.java
+++ b/backend/src/main/java/org/steam5/service/StatisticsService.java
@@ -303,7 +303,6 @@ public class StatisticsService {
                         row.getSteamId(),
                         row.getPersonaName(),
                         row.getAvatarFull(),
-                        row.getBlurdataAvatarFull(),
                         row.getProfileUrl(),
                         row.getGameDate(),
                         row.getAppNames() != null ? List.of(row.getAppNames().split(", ")) : List.of()
@@ -430,7 +429,6 @@ public class StatisticsService {
             String steamId,
             String personaName,
             String avatar,
-            String avatarBlurdata,
             String profileUrl,
             LocalDate gameDate,
             List<String> appNames

--- a/backend/src/main/java/org/steam5/web/AuthController.java
+++ b/backend/src/main/java/org/steam5/web/AuthController.java
@@ -162,7 +162,6 @@ public class AuthController {
         final User user = userRepository.findById(steamId).orElse(null);
         if (user != null) {
             body.put("avatar", user.getAvatar());
-            body.put("avatarBlurdata", user.getBlurdataAvatar());
         }
         // Token validation is per-user and must never be stored by any cache.
         return ResponseEntity.ok()

--- a/backend/src/test/java/org/steam5/service/StatisticsServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/StatisticsServiceTest.java
@@ -118,7 +118,6 @@ class StatisticsServiceTest {
         assertEquals("76561198000000001", entry.steamId());
         assertEquals("Alice", entry.personaName());
         assertEquals("https://avatar/full.jpg", entry.avatar());
-        assertEquals("data:blur", entry.avatarBlurdata());
         assertEquals("https://steamcommunity.com/id/alice", entry.profileUrl());
         assertEquals(LocalDate.of(2026, 1, 15), entry.gameDate());
         assertEquals(List.of("Half-Life", "Portal 2", "Left 4 Dead"), entry.appNames());

--- a/backend/src/test/java/org/steam5/web/CommentControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/CommentControllerTest.java
@@ -154,7 +154,7 @@ class CommentControllerTest {
         LocalDate today = GameDate.todayUtc();
         CommentService.CommentDto dto = new CommentService.CommentDto(
                 1L, "hi", today + "T12:00:00Z",
-                new CommentService.AuthorDto("u1", "Alice", null, null),
+                new CommentService.AuthorDto("u1", "Alice", null),
                 List.of()
         );
         when(commentService.createComment(eq("u1"), eq(today), eq("hi"))).thenReturn(dto);

--- a/backend/src/test/java/org/steam5/web/LeaderboardControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/LeaderboardControllerTest.java
@@ -69,7 +69,7 @@ public class LeaderboardControllerTest {
         when(guessRepository.findAllByDate(pickDate)).thenReturn(guesses);
 
         List<LeaderboardService.LeaderEntry> canned = List.of(
-                new LeaderboardService.LeaderEntry("u1", "User One", 5L, 1L, 1L, 0L, 0L, 0L, 5.0, 1, null, null, null)
+                new LeaderboardService.LeaderEntry("u1", "User One", 5L, 1L, 1L, 0L, 0L, 0L, 5.0, 1, null, null)
         );
         when(leaderboardService.buildLeaderboard(guesses, pickDate)).thenReturn(canned);
 
@@ -87,8 +87,8 @@ public class LeaderboardControllerTest {
         LeaderboardController c = newController();
 
         List<LeaderboardService.LeaderEntry> canned = List.of(
-                new LeaderboardService.LeaderEntry("u1", "User One", 5L, 1L, 1L, 0L, 0L, 0L, 5.0, 1, null, null, null),
-                new LeaderboardService.LeaderEntry("u2", "u2", 1L, 1L, 0L, 0L, 1L, 0L, 1.0, 0, null, null, null)
+                new LeaderboardService.LeaderEntry("u1", "User One", 5L, 1L, 1L, 0L, 0L, 0L, 5.0, 1, null, null),
+                new LeaderboardService.LeaderEntry("u2", "u2", 1L, 1L, 0L, 0L, 1L, 0L, 1.0, 0, null, null)
         );
         when(leaderboardService.buildAllTimeLeaderboard(any(LocalDate.class))).thenReturn(canned);
 
@@ -120,7 +120,7 @@ public class LeaderboardControllerTest {
         when(reviewGameStateService.generateDailyPicks()).thenReturn(List.of());
 
         List<LeaderboardService.LeaderEntry> canned = List.of(
-                new LeaderboardService.LeaderEntry("u1", "User One", 7L, 2L, 1L, 0L, 0L, 1L, 3.5, 1, null, null, null)
+                new LeaderboardService.LeaderEntry("u1", "User One", 7L, 2L, 1L, 0L, 0L, 1L, 3.5, 1, null, null)
         );
         when(leaderboardService.buildWeeklyLeaderboard(any(LocalDate.class))).thenReturn(canned);
 
@@ -160,7 +160,7 @@ public class LeaderboardControllerTest {
         when(reviewGameStateService.generateDailyPicks()).thenReturn(List.of());
 
         List<LeaderboardService.LeaderEntry> canned = List.of(
-                new LeaderboardService.LeaderEntry("u1", "User One", 10L, 2L, 1L, 0L, 0L, 1L, 5.0, 1, null, null, null)
+                new LeaderboardService.LeaderEntry("u1", "User One", 10L, 2L, 1L, 0L, 0L, 1L, 5.0, 1, null, null)
         );
         when(leaderboardService.buildMonthlyLeaderboard(any(LocalDate.class))).thenReturn(canned);
 
@@ -193,7 +193,7 @@ public class LeaderboardControllerTest {
         when(cache.get(anyString())).thenReturn(null);
 
         List<LeaderboardService.LeaderEntry> canned = List.of(
-                new LeaderboardService.LeaderEntry("u1", "User One", 20L, 4L, 2L, 1L, 1L, 0L, 5.0, 1, null, null, null)
+                new LeaderboardService.LeaderEntry("u1", "User One", 20L, 4L, 2L, 1L, 1L, 0L, 5.0, 1, null, null)
         );
         when(leaderboardService.buildSeasonLeaderboard(any(LocalDate.class))).thenReturn(canned);
 
@@ -222,7 +222,7 @@ public class LeaderboardControllerTest {
         when(seasonService.findSeasonContaining(any(LocalDate.class))).thenReturn(Optional.of(season));
 
         List<LeaderboardService.LeaderEntry> cached = List.of(
-                new LeaderboardService.LeaderEntry("u1", "User One", 20L, 4L, 2L, 1L, 1L, 0L, 5.0, 1, null, null, null)
+                new LeaderboardService.LeaderEntry("u1", "User One", 20L, 4L, 2L, 1L, 1L, 0L, 5.0, 1, null, null)
         );
         Cache cache = mock(Cache.class);
         when(cacheManager.getCache("leaderboard-static")).thenReturn(cache);

--- a/backend/src/test/java/org/steam5/web/StatisticsControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/StatisticsControllerTest.java
@@ -76,7 +76,7 @@ class StatisticsControllerTest {
     @Test
     void perfectDays_setsRefreshedAtHeaderWhenStateExists() {
         List<StatisticsService.PerfectDayEntry> canned = List.of(
-                new StatisticsService.PerfectDayEntry("76561198000000001", "Alice", "avatar.jpg", "blur",
+                new StatisticsService.PerfectDayEntry("76561198000000001", "Alice", "avatar.jpg",
                         "https://steamcommunity.com/id/alice", java.time.LocalDate.of(2026, 1, 15), List.of("Portal"))
         );
         when(statisticsService.getPerfectDays()).thenReturn(canned);

--- a/frontend/app/api/auth/me/route.ts
+++ b/frontend/app/api/auth/me/route.ts
@@ -22,7 +22,6 @@ export async function GET(req: NextRequest) {
             signedIn: Boolean(data.valid),
             steamId: data.steamId,
             avatar: data.avatar ?? null,
-            avatarBlurdata: data.avatarBlurdata ?? null,
         }, {status: 200, headers: NO_STORE});
     } catch {
         return NextResponse.json({signedIn: false}, {status: 200, headers: NO_STORE});

--- a/frontend/app/opengraph-image.tsx
+++ b/frontend/app/opengraph-image.tsx
@@ -49,7 +49,6 @@ export default async function Image(req: Request) {
         steamId: string;
         personaName?: string | null;
         avatar?: string | null;
-        avatarBlurdata?: string | null;
         profileUrl?: string | null;
         stats: { totalPoints: number; rounds: number; hits: number; tooHigh: number; tooLow: number; avgPoints: number };
         days: Array<{ date: string; rounds: Array<{ points: number; selectedBucket: string; actualBucket: string }> }>;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "steam5",
-    "version": "1.18.1",
+    "version": "1.19.0",
     "private": true,
     "homepage": "https://steam5.org",
     "scripts": {

--- a/frontend/src/components/AchievementsTable.tsx
+++ b/frontend/src/components/AchievementsTable.tsx
@@ -16,6 +16,13 @@ type LeaderEntry = {
     avatarBlurdata?: string | null;
 };
 
+/**
+ * Renders the achievements leaderboard table.
+ *
+ * @param achievements - Achievement records to display
+ * @param serverOffsetMinutes - Server time offset used to calculate achievement metrics and titles
+ * @param leaderboardEntries - Leaderboard players matched to achievement winners
+ */
 export default function AchievementsTable({
     achievements,
     serverOffsetMinutes,

--- a/frontend/src/components/AchievementsTable.tsx
+++ b/frontend/src/components/AchievementsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import {
     ACHIEVEMENT_LABELS,
     ACHIEVEMENT_ICONS,
@@ -66,19 +66,7 @@ export default function AchievementsTable({
                                     <td>
                                         <div className="leaderboard__player">
                                             {entry.avatar && (
-                                                <div
-                                                    className="leaderboard__avatar-wrap"
-                                                    style={{backgroundImage: entry.avatarBlurdata ? `url(${entry.avatarBlurdata})` : undefined}}
-                                                >
-                                                    <Image
-                                                        className="leaderboard__avatar"
-                                                        src={entry.avatar}
-                                                        placeholder="empty"
-                                                        alt=""
-                                                        width={24}
-                                                        height={24}
-                                                    />
-                                                </div>
+                                                <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
                                             )}
                                             <a
                                                 href={`/profile/${encodeURIComponent(achievement.steamId)}`}

--- a/frontend/src/components/AchievementsTable.tsx
+++ b/frontend/src/components/AchievementsTable.tsx
@@ -13,7 +13,6 @@ type LeaderEntry = {
     steamId: string;
     personaName: string;
     avatar?: string | null;
-    avatarBlurdata?: string | null;
 };
 
 /**
@@ -72,9 +71,7 @@ export default function AchievementsTable({
                                     </td>
                                     <td>
                                         <div className="leaderboard__player">
-                                            {entry.avatar && (
-                                                <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
-                                            )}
+                                            <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
                                             <a
                                                 href={`/profile/${encodeURIComponent(achievement.steamId)}`}
                                                 className="leaderboard__profile-link"

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -1,0 +1,45 @@
+import type {CSSProperties} from "react";
+import "@/styles/components/avatar.css";
+
+function initialsFor(name?: string | null): string {
+    const trimmed = name?.trim();
+    return trimmed ? trimmed.charAt(0).toUpperCase() : "?";
+}
+
+/**
+ * Renders a player avatar image, or an initials fallback when no avatar is available.
+ * Shared across the header, leaderboards, "playing now", and comments so every
+ * avatar in the app looks and behaves the same.
+ */
+export default function Avatar({src, name, size = 32, className}: {
+    src?: string | null;
+    name?: string | null;
+    size?: number;
+    className?: string;
+}): React.ReactElement {
+    const style: CSSProperties = {width: size, height: size};
+    const title = name || "Player";
+    const classes = `avatar${className ? ` ${className}` : ""}`;
+
+    if (src) {
+        return (
+            <img
+                className={classes}
+                style={style}
+                src={src}
+                alt=""
+                title={title}
+                width={size}
+                height={size}
+                loading="lazy"
+                referrerPolicy="no-referrer"
+            />
+        );
+    }
+
+    return (
+        <span className={classes} style={style} title={title} aria-hidden="true">
+            {initialsFor(name)}
+        </span>
+    );
+}

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -1,15 +1,24 @@
 import type {CSSProperties} from "react";
 import "@/styles/components/avatar.css";
 
+/**
+ * Extracts the uppercase initial from a name.
+ *
+ * @param name - The name from which to derive the initial
+ * @returns The uppercase first character of the trimmed name, or `"?"` when the name is absent or blank
+ */
 function initialsFor(name?: string | null): string {
     const trimmed = name?.trim();
     return trimmed ? trimmed.charAt(0).toUpperCase() : "?";
 }
 
 /**
- * Renders a player avatar image, or an initials fallback when no avatar is available.
- * Shared across the header, leaderboards, "playing now", and comments so every
- * avatar in the app looks and behaves the same.
+ * Renders an avatar image or an initials fallback.
+ *
+ * @param src - The avatar image URL
+ * @param name - The name used for the title and initials fallback
+ * @param size - The avatar dimensions in pixels
+ * @param className - Additional CSS classes
  */
 export default function Avatar({src, name, size = 32, className}: {
     src?: string | null;

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import React, {useEffect, useRef} from "react";
+import "@/styles/components/confirmModal.css";
+
+type ConfirmModalProps = {
+    isOpen: boolean;
+    title: string;
+    message?: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+};
+
+/**
+ * Generic accessible confirm/cancel dialog, following the same backdrop,
+ * focus-trap, and Escape-to-close behavior as AuthWarningModal.
+ */
+export default function ConfirmModal({
+    isOpen,
+    title,
+    message,
+    confirmLabel = "Confirm",
+    cancelLabel = "Cancel",
+    onConfirm,
+    onCancel,
+}: Readonly<ConfirmModalProps>): React.ReactElement | null {
+    const modalRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const modal = modalRef.current;
+        if (!modal) return;
+
+        const getFocusableElements = () =>
+            Array.from(
+                modal.querySelectorAll<HTMLElement>(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                )
+            ).filter((element) => !element.hasAttribute("disabled"));
+
+        const focusFirstElement = () => {
+            const focusables = getFocusableElements();
+            const fallback = modal.querySelector<HTMLElement>("#confirm-modal-title");
+            const target = focusables[0] ?? fallback ?? modal;
+            target?.focus();
+        };
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onCancel();
+                return;
+            }
+
+            if (event.key !== "Tab") return;
+
+            const focusables = getFocusableElements();
+            if (focusables.length === 0) {
+                event.preventDefault();
+                modal.focus();
+                return;
+            }
+
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            const active = document.activeElement as HTMLElement | null;
+
+            if (event.shiftKey) {
+                if (!active || !modal.contains(active) || active === first) {
+                    event.preventDefault();
+                    last.focus();
+                }
+                return;
+            }
+
+            if (!active || !modal.contains(active) || active === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        const raf = requestAnimationFrame(() => {
+            if (!modal.contains(document.activeElement)) {
+                focusFirstElement();
+            }
+        });
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            cancelAnimationFrame(raf);
+        };
+    }, [isOpen, onCancel]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div
+            className="confirm-modal__backdrop"
+            role="presentation"
+            onClick={onCancel}
+            onKeyDown={(event) => { if (event.key === "Escape") onCancel(); }}
+        >
+            <div
+                className="confirm-modal__card"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="confirm-modal-title"
+                ref={modalRef}
+                tabIndex={-1}
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={(event) => event.stopPropagation()}
+            >
+                <h2 id="confirm-modal-title" tabIndex={-1}>{title}</h2>
+                {message && <p className="text-muted">{message}</p>}
+                <div className="confirm-modal__actions">
+                    <button type="button" className="btn-cta" onClick={onConfirm}>
+                        {confirmLabel}
+                    </button>
+                    <button type="button" className="btn-ghost" onClick={onCancel}>
+                        {cancelLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -41,10 +41,13 @@ export default function ConfirmModal({
                 )
             ).filter((element) => !element.hasAttribute("disabled"));
 
-        const focusFirstElement = () => {
+        const focusInitialElement = () => {
             const focusables = getFocusableElements();
             const fallback = modal.querySelector<HTMLElement>("#confirm-modal-title");
-            const target = focusables[0] ?? fallback ?? modal;
+            // Default focus to the last action (Cancel) rather than the first
+            // (Confirm), so an accidental Enter can't trigger a destructive
+            // action — per WAI-ARIA guidance for confirmation dialogs.
+            const target = focusables[focusables.length - 1] ?? fallback ?? modal;
             target?.focus();
         };
 
@@ -85,7 +88,7 @@ export default function ConfirmModal({
         document.addEventListener("keydown", handleKeyDown);
         const raf = requestAnimationFrame(() => {
             if (!modal.contains(document.activeElement)) {
-                focusFirstElement();
+                focusInitialElement();
             }
         });
 

--- a/frontend/src/components/DayComments.tsx
+++ b/frontend/src/components/DayComments.tsx
@@ -9,6 +9,7 @@ import {ArchiveIcon, GameControllerIcon, PaperPlaneRightIcon} from "@phosphor-ic
 import {useAuth} from "@/contexts/AuthContext";
 import {buildSteamLoginUrl} from "@/components/SteamLoginButton";
 import ReactionBar from "@/components/ReactionBar";
+import Avatar from "@/components/Avatar";
 import {
     COMMENT_MODERATOR_STEAM_ID,
     archiveComment,
@@ -126,19 +127,6 @@ export function CommentBodyText({body}: {body: string}): React.ReactElement {
 }
 
 /**
- * Gets the uppercase initial for a name.
- *
- * @param name - The name to extract an initial from
- * @returns The uppercase first character of the trimmed name, or `"?"` when the name is missing or blank
- */
-function initialsFor(name: string | null | undefined): string {
-    if (!name) return "?";
-    const trimmed = name.trim();
-    if (!trimmed) return "?";
-    return trimmed.charAt(0).toUpperCase();
-}
-
-/**
  * Renders a profile link with a user's avatar or name initials fallback.
  *
  * @param props - The user's Steam ID, display name, and optional avatar URL.
@@ -151,25 +139,9 @@ function CommentAvatar(props: {
     const {steamId, personaName, avatar} = props;
     const displayName = personaName || "Player";
     const profileUrl = `/profile/${steamId}`;
-    const content = avatar ? (
-        <img
-            className="day-comments__avatar"
-            src={avatar}
-            alt=""
-            title={displayName}
-            width={32}
-            height={32}
-            loading="lazy"
-            referrerPolicy="no-referrer"
-        />
-    ) : (
-        <span className="day-comments__avatar" title={displayName} aria-hidden="true">
-            {initialsFor(personaName)}
-        </span>
-    );
     return (
         <Link href={profileUrl} className="day-comments__avatar-link" aria-label={`View ${displayName}'s profile`}>
-            {content}
+            <Avatar src={avatar} name={personaName} size={32} className="day-comments__avatar"/>
         </Link>
     );
 }
@@ -396,15 +368,7 @@ function MentionMenu(props: {
                     onClick={() => onPick(candidate)}
                 >
                     {candidate.avatar && (
-                        <img
-                            className="comment-composer__mention-avatar"
-                            src={candidate.avatar}
-                            alt=""
-                            width={20}
-                            height={20}
-                            loading="lazy"
-                            referrerPolicy="no-referrer"
-                        />
+                        <Avatar src={candidate.avatar} name={candidate.personaName} size={20} className="comment-composer__mention-avatar"/>
                     )}
                     <span>{candidate.personaName}</span>
                 </button>

--- a/frontend/src/components/DayComments.tsx
+++ b/frontend/src/components/DayComments.tsx
@@ -65,7 +65,10 @@ type BodyMatch = {
 };
 
 /**
- * Renders comment body text with Steam game refs and @mentions as links.
+ * Renders comment text with valid Steam game references and user mentions as links.
+ *
+ * @param body - The comment text to render
+ * @returns The rendered comment text
  */
 export function CommentBodyText({body}: {body: string}): React.ReactElement {
     const matches: BodyMatch[] = [];
@@ -127,9 +130,9 @@ export function CommentBodyText({body}: {body: string}): React.ReactElement {
 }
 
 /**
- * Renders a profile link with a user's avatar or name initials fallback.
+ * Links the comment author's avatar to their profile.
  *
- * @param props - The user's Steam ID, display name, and optional avatar URL.
+ * @param props - The author's Steam ID, display name, and optional avatar URL.
  */
 function CommentAvatar(props: {
     steamId: string;

--- a/frontend/src/components/DayComments.tsx
+++ b/frontend/src/components/DayComments.tsx
@@ -10,6 +10,7 @@ import {useAuth} from "@/contexts/AuthContext";
 import {buildSteamLoginUrl} from "@/components/SteamLoginButton";
 import ReactionBar from "@/components/ReactionBar";
 import Avatar from "@/components/Avatar";
+import ConfirmModal from "@/components/ConfirmModal";
 import {
     COMMENT_MODERATOR_STEAM_ID,
     archiveComment,
@@ -370,9 +371,7 @@ function MentionMenu(props: {
                     title={candidate.personaName}
                     onClick={() => onPick(candidate)}
                 >
-                    {candidate.avatar && (
-                        <Avatar src={candidate.avatar} name={candidate.personaName} size={20} className="comment-composer__mention-avatar"/>
-                    )}
+                    <Avatar src={candidate.avatar} name={candidate.personaName} size={20} className="comment-composer__mention-avatar"/>
                     <span>{candidate.personaName}</span>
                 </button>
             ))}
@@ -564,6 +563,7 @@ export default function DayComments(props: {
     const {isSignedIn, steamId, refreshAuth} = useAuth();
     const canModerate = isSignedIn === true && steamId === COMMENT_MODERATOR_STEAM_ID;
     const [archivingId, setArchivingId] = useState<number | null>(null);
+    const [confirmArchiveId, setConfirmArchiveId] = useState<number | null>(null);
     const [openPickerCommentId, setOpenPickerCommentId] = useState<number | null>(null);
 
     const swrKey = gameDate ? commentsUrl(gameDate) : null;
@@ -604,6 +604,13 @@ export default function DayComments(props: {
             setArchivingId(null);
         }
     }, [archivingId, mutate, refreshAuth]);
+
+    const confirmArchive = useCallback(() => {
+        if (confirmArchiveId === null) return;
+        const id = confirmArchiveId;
+        setConfirmArchiveId(null);
+        void handleArchive(id);
+    }, [confirmArchiveId, handleArchive]);
 
     if (!gameDate) return null;
 
@@ -692,7 +699,7 @@ export default function DayComments(props: {
                                                     title="Archive comment"
                                                     aria-label="Archive comment"
                                                     disabled={archivingId !== null}
-                                                    onClick={() => void handleArchive(comment.id)}
+                                                    onClick={() => setConfirmArchiveId(comment.id)}
                                                 >
                                                     <ArchiveIcon size={14} weight="regular" aria-hidden="true"/>
                                                     <span>{archivingId === comment.id ? "…" : "Archive"}</span>
@@ -743,6 +750,16 @@ export default function DayComments(props: {
                     {" "}to leave a comment or react.
                 </p>
             ))}
+
+            <ConfirmModal
+                isOpen={confirmArchiveId !== null}
+                title="Archive this comment?"
+                message="The comment will be hidden from everyone. This can't be undone from here."
+                confirmLabel="Archive"
+                cancelLabel="Cancel"
+                onConfirm={confirmArchive}
+                onCancel={() => setConfirmArchiveId(null)}
+            />
         </section>
     );
 }

--- a/frontend/src/components/DayComments.tsx
+++ b/frontend/src/components/DayComments.tsx
@@ -144,7 +144,7 @@ function CommentAvatar(props: {
     const profileUrl = `/profile/${steamId}`;
     return (
         <Link href={profileUrl} className="day-comments__avatar-link" aria-label={`View ${displayName}'s profile`}>
-            <Avatar src={avatar} name={personaName} size={32} className="day-comments__avatar"/>
+            <Avatar src={avatar} name={personaName} size={32}/>
         </Link>
     );
 }

--- a/frontend/src/components/LeaderboardTable.tsx
+++ b/frontend/src/components/LeaderboardTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@/styles/components/leaderboard.css";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import useSWR from "swr";
 import {useCallback, useMemo, useState} from "react";
 import {
@@ -221,15 +221,7 @@ export default function LeaderboardTable(props: {
                             <td>
                                 <div className="leaderboard__player">
                                     {entry.avatar && (
-                                        <div className="leaderboard__avatar-wrap"
-                                             style={{backgroundImage: entry.avatarBlurdata ? `url(${entry.avatarBlurdata})` : undefined}}>
-                                            <Image className="leaderboard__avatar"
-                                                   src={entry.avatar}
-                                                   placeholder={'empty'}
-                                                   alt=""
-                                                   width={24}
-                                                   height={24}/>
-                                        </div>
+                                        <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
                                     )}
                                     <a href={`/profile/${encodeURIComponent(entry.steamId)}`}
                                        className="leaderboard__profile-link">

--- a/frontend/src/components/LeaderboardTable.tsx
+++ b/frontend/src/components/LeaderboardTable.tsx
@@ -25,7 +25,6 @@ type LeaderEntry = {
     avgPoints: number;
     streak: number;
     avatar?: string | null;
-    avatarBlurdata?: string | null;
     profileUrl?: string | null;
 };
 
@@ -225,9 +224,7 @@ export default function LeaderboardTable(props: {
                             <td>{i + 1}</td>
                             <td>
                                 <div className="leaderboard__player">
-                                    {entry.avatar && (
-                                        <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
-                                    )}
+                                    <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
                                     <a href={`/profile/${encodeURIComponent(entry.steamId)}`}
                                        className="leaderboard__profile-link">
                                         <strong>{entry.personaName || 'no-name'}</strong>

--- a/frontend/src/components/LeaderboardTable.tsx
+++ b/frontend/src/components/LeaderboardTable.tsx
@@ -41,6 +41,11 @@ const fetcher = async (url: string): Promise<LeaderboardFetchResult> => {
     return {data, refreshedAt: r.headers.get('X-Leaderboard-Refreshed-At')};
 };
 
+/**
+ * Displays a sortable leaderboard with player statistics, achievements, and average points.
+ *
+ * @param props - Leaderboard configuration, including the timeframe, refresh interval, accessibility label, and optional initial data.
+ */
 export default function LeaderboardTable(props: {
     mode: 'today' | 'weekly' | 'weekly-floating' | 'season' | 'all';
     refreshMs?: number;

--- a/frontend/src/components/OtherPlayersNow.tsx
+++ b/frontend/src/components/OtherPlayersNow.tsx
@@ -39,9 +39,9 @@ function presenceLabel(uniquePlayerCount: number, reconnecting: boolean): string
 }
 
 /**
- * Displays the number of players currently active in the round and their avatars when available.
+ * Displays current round presence information, including player avatars when available.
  *
- * @returns The presence indicator, or `null` when the round has no active presence to display.
+ * @returns The presence indicator, or `null` when disconnected without reconnecting or when no players are present.
  */
 export default function OtherPlayersNow(): React.ReactElement | null {
     const {uniquePlayerCount, players, connected, reconnecting} = useRoundPresenceContext();

--- a/frontend/src/components/OtherPlayersNow.tsx
+++ b/frontend/src/components/OtherPlayersNow.tsx
@@ -4,22 +4,10 @@ import React from "react";
 import Link from "next/link";
 import {useRoundPresenceContext} from "@/contexts/RoundPresenceContext";
 import type {PlayerInfo} from "@/lib/hooks/useRoundPresence";
+import Avatar from "@/components/Avatar";
 import "@/styles/components/otherPlayersNow.css";
 
 const MAX_VISIBLE_AVATARS = 8;
-
-/**
- * Generates a fallback initial for a player's name.
- *
- * @param name - The player's name, or `null` when unavailable
- * @returns The uppercase first character of the trimmed name, or `?` when no name is provided
- */
-function initialsFor(name: string | null): string {
-    if (!name) return "?";
-    const trimmed = name.trim();
-    if (!trimmed) return "?";
-    return trimmed.charAt(0).toUpperCase();
-}
 
 /**
  * Renders a player's avatar linked to their Steam profile.
@@ -30,29 +18,9 @@ function initialsFor(name: string | null): string {
 function PlayerAvatar({player}: {player: PlayerInfo}): React.ReactElement {
     const displayName = player.personaName || "Player";
     const profileUrl = `/profile/${player.steamId}`;
-    const content = player.avatar ? (
-        <img
-            className="other-players__avatar"
-            src={player.avatar}
-            alt={displayName}
-            title={displayName}
-            width={32}
-            height={32}
-            loading="lazy"
-            referrerPolicy="no-referrer"
-        />
-    ) : (
-        <span
-            className="other-players__avatar"
-            title={displayName}
-            aria-label={displayName}
-        >
-            {initialsFor(player.personaName)}
-        </span>
-    );
     return (
         <Link href={profileUrl} aria-label={`View ${displayName}'s Steam profile`}>
-            {content}
+            <Avatar src={player.avatar} name={player.personaName} size={32} className="other-players__avatar"/>
         </Link>
     );
 }
@@ -97,7 +65,8 @@ export default function OtherPlayersNow(): React.ReactElement | null {
                     ))}
                     {overflow > 0 && (
                         <span
-                            className="other-players__overflow"
+                            className="avatar other-players__overflow"
+                            style={{width: 32, height: 32}}
                             title={`${overflow} more player${overflow === 1 ? "" : "s"}`}
                             aria-label={`${overflow} more players`}
                         >

--- a/frontend/src/components/PerfectDaysTable.tsx
+++ b/frontend/src/components/PerfectDaysTable.tsx
@@ -23,6 +23,14 @@ const fetcher = async (url: string): Promise<PerfectDaysFetchResult> => {
     return {data, refreshedAt: r.headers.get('X-Leaderboard-Refreshed-At')};
 };
 
+/**
+ * Displays perfect-day records and player rankings.
+ *
+ * @param props - Configuration for initial data, refresh metadata, and refresh timing.
+ * @param props.initialData - Optional perfect-day records used while fetching updated data.
+ * @param props.initialRefreshedAt - Optional timestamp associated with the initial data.
+ * @param props.refreshMs - Optional interval, in milliseconds, for refreshing the records.
+ */
 export default function PerfectDaysTable(props: {
     initialData?: PerfectDay[] | null;
     initialRefreshedAt?: string | null;

--- a/frontend/src/components/PerfectDaysTable.tsx
+++ b/frontend/src/components/PerfectDaysTable.tsx
@@ -50,14 +50,14 @@ export default function PerfectDaysTable(props: {
     const lastUpdatedText = formatRefreshedAt(refreshedAt);
 
     const playerCounts = useMemo(() => {
-        const counts = new Map<string, { steamId: string; name: string; avatar?: string | null; avatarBlurdata?: string | null; count: number }>();
+        const counts = new Map<string, { steamId: string; name: string; avatar?: string | null; count: number }>();
         for (const entry of data ?? []) {
             const key = entry.steamId;
             const existing = counts.get(key);
             if (existing) {
                 existing.count++;
             } else {
-                counts.set(key, {steamId: entry.steamId, name: entry.personaName, avatar: entry.avatar, avatarBlurdata: entry.avatarBlurdata, count: 1});
+                counts.set(key, {steamId: entry.steamId, name: entry.personaName, avatar: entry.avatar, count: 1});
             }
         }
         return [...counts.values()].sort((a, b) => b.count - a.count);
@@ -95,9 +95,7 @@ export default function PerfectDaysTable(props: {
                             <td className="num">{i + 1}</td>
                             <td>
                                 <div className="leaderboard__player">
-                                    {entry.avatar && (
-                                        <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
-                                    )}
+                                    <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
                                     <span className="leaderboard__profile-link">{entry.personaName}</span>
                                 </div>
                             </td>
@@ -137,9 +135,7 @@ export default function PerfectDaysTable(props: {
                             <td className="num">{i + 1}</td>
                             <td>
                                 <div className="leaderboard__player">
-                                    {player.avatar && (
-                                        <Avatar src={player.avatar} name={player.name} size={29}/>
-                                    )}
+                                    <Avatar src={player.avatar} name={player.name} size={29}/>
                                     <span className="leaderboard__profile-link">{player.name}</span>
                                 </div>
                             </td>

--- a/frontend/src/components/PerfectDaysTable.tsx
+++ b/frontend/src/components/PerfectDaysTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@/styles/components/leaderboard.css";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import Link from "next/link";
 import useSWR from "swr";
 import {useMemo} from "react";
@@ -88,15 +88,7 @@ export default function PerfectDaysTable(props: {
                             <td>
                                 <div className="leaderboard__player">
                                     {entry.avatar && (
-                                        <div className="leaderboard__avatar-wrap">
-                                            <Image
-                                                className="leaderboard__avatar"
-                                                src={entry.avatar}
-                                                alt={`${entry.personaName}'s avatar`}
-                                                width={24}
-                                                height={24}
-                                            />
-                                        </div>
+                                        <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
                                     )}
                                     <span className="leaderboard__profile-link">{entry.personaName}</span>
                                 </div>
@@ -138,15 +130,7 @@ export default function PerfectDaysTable(props: {
                             <td>
                                 <div className="leaderboard__player">
                                     {player.avatar && (
-                                        <div className="leaderboard__avatar-wrap">
-                                            <Image
-                                                className="leaderboard__avatar"
-                                                src={player.avatar}
-                                                alt={`${player.name}'s avatar`}
-                                                width={24}
-                                                height={24}
-                                            />
-                                        </div>
+                                        <Avatar src={player.avatar} name={player.name} size={29}/>
                                     )}
                                     <span className="leaderboard__profile-link">{player.name}</span>
                                 </div>

--- a/frontend/src/components/SteamLoginButton.tsx
+++ b/frontend/src/components/SteamLoginButton.tsx
@@ -9,6 +9,11 @@ import Link from "next/link";
 import {useAuth} from "@/contexts/AuthContext";
 import Avatar from "@/components/Avatar";
 
+/**
+ * Builds the Steam login URL with the configured authentication callback.
+ *
+ * @returns The Steam login endpoint URL with an encoded callback URL.
+ */
 export function buildSteamLoginUrl(): string {
     const backend = process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
     const envBase = process.env.NEXT_PUBLIC_DOMAIN;
@@ -17,6 +22,11 @@ export function buildSteamLoginUrl(): string {
     return `${backend}/api/auth/steam/login?redirect=${encodeURIComponent(callback)}`;
 }
 
+/**
+ * Renders a Steam sign-in control or the signed-in user's profile link.
+ *
+ * @returns The Steam sign-in button or the user's profile link.
+ */
 export default function SteamLoginButton(): React.ReactElement {
     const {isSignedIn, steamId, avatar} = useAuth();
     const clearedRef = useRef(false);

--- a/frontend/src/components/SteamLoginButton.tsx
+++ b/frontend/src/components/SteamLoginButton.tsx
@@ -7,6 +7,7 @@ import SignInImage from "../../public/sign-in-through-steam.png"
 import {UserCheckIcon} from "@phosphor-icons/react/ssr";
 import Link from "next/link";
 import {useAuth} from "@/contexts/AuthContext";
+import Avatar from "@/components/Avatar";
 
 export function buildSteamLoginUrl(): string {
     const backend = process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
@@ -17,7 +18,7 @@ export function buildSteamLoginUrl(): string {
 }
 
 export default function SteamLoginButton(): React.ReactElement {
-    const {isSignedIn, steamId, avatar, avatarBlurdata} = useAuth();
+    const {isSignedIn, steamId, avatar} = useAuth();
     const clearedRef = useRef(false);
 
     useEffect(() => {
@@ -47,13 +48,7 @@ export default function SteamLoginButton(): React.ReactElement {
                       title="Your Profile">
                     <span className="mobile__hide">Profile</span>
                     {avatar ? (
-                        <span className="header__avatar-wrap">
-                            <Image className="header__avatar"
-                                   src={avatar}
-                                   alt=""
-                                   width={28}
-                                   height={28}/>
-                        </span>
+                        <Avatar src={avatar} size={28}/>
                     ) : (
                         <UserCheckIcon size={28}/>
                     )}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -9,7 +9,6 @@ type AuthState = {
     isSignedIn: boolean;
     steamId?: string | null;
     avatar?: string | null;
-    avatarBlurdata?: string | null;
     isLoading?: boolean;
 };
 
@@ -28,7 +27,6 @@ const authFetcher = async (url: string): Promise<AuthState> => {
         isSignedIn: Boolean(data?.signedIn),
         steamId: data?.steamId || null,
         avatar: data?.avatar || null,
-        avatarBlurdata: data?.avatarBlurdata || null,
     };
 };
 

--- a/frontend/src/lib/comments.test.ts
+++ b/frontend/src/lib/comments.test.ts
@@ -63,7 +63,7 @@ describe('fetchComments', () => {
             id: 1,
             body: 'hi',
             createdAt: '2026-07-31T12:00:00Z',
-            author: {steamId: 'u1', personaName: 'Alice', avatar: null, avatarBlurdata: null},
+            author: {steamId: 'u1', personaName: 'Alice', avatar: null},
             reactions: [],
         }];
         fetchMock.mockResolvedValue(mockResponse(true, comments));

--- a/frontend/src/lib/comments.ts
+++ b/frontend/src/lib/comments.ts
@@ -21,7 +21,6 @@ export type CommentAuthor = {
     steamId: string;
     personaName: string;
     avatar: string | null;
-    avatarBlurdata: string | null;
 };
 
 export type CommentReactionDto = {

--- a/frontend/src/lib/perfectDays.test.ts
+++ b/frontend/src/lib/perfectDays.test.ts
@@ -42,7 +42,6 @@ describe('fetchPerfectDays', () => {
             steamId: '76561198000000001',
             personaName: 'Alice',
             avatar: 'https://avatar/full.jpg',
-            avatarBlurdata: 'data:blur',
             profileUrl: 'https://steamcommunity.com/id/alice',
             gameDate: '2026-01-15',
             appNames: ['Half-Life', 'Portal 2'],

--- a/frontend/src/lib/perfectDays.ts
+++ b/frontend/src/lib/perfectDays.ts
@@ -4,7 +4,6 @@ export type PerfectDay = {
     steamId: string;
     personaName: string;
     avatar?: string | null;
-    avatarBlurdata?: string | null;
     profileUrl?: string | null;
     gameDate: string;
     appNames: string[];

--- a/frontend/src/styles/components/avatar.css
+++ b/frontend/src/styles/components/avatar.css
@@ -1,0 +1,16 @@
+.avatar {
+    border-radius: 0.5rem;
+    border: 2px solid var(--color-surface);
+    background: var(--color-surface-variant);
+    object-fit: cover;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text);
+    text-transform: uppercase;
+    overflow: hidden;
+}

--- a/frontend/src/styles/components/confirmModal.css
+++ b/frontend/src/styles/components/confirmModal.css
@@ -1,0 +1,25 @@
+.confirm-modal__backdrop {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 1000;
+}
+
+.confirm-modal__card {
+    width: min(92vw, 420px);
+    border: 1px solid var(--color-border);
+    padding: 16px;
+    background: var(--color-surface);
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.confirm-modal__actions {
+    margin-top: 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+}

--- a/frontend/src/styles/components/dayComments.css
+++ b/frontend/src/styles/components/dayComments.css
@@ -75,23 +75,6 @@
     text-decoration: none;
 }
 
-.day-comments__avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 2px solid var(--color-surface);
-    background: var(--color-surface-variant);
-    object-fit: cover;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: var(--color-text);
-    text-transform: uppercase;
-    overflow: hidden;
-}
-
 .day-comments__body {
     display: flex;
     flex-direction: column;
@@ -228,13 +211,14 @@
     margin-right: auto;
 }
 
-.comment-composer__game-trigger {
+.comment-composer__game-trigger,
+.reaction-bar__trigger {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 0.05rem;
-    width: 1.85rem;
-    height: 1.85rem;
+    width: 2.2rem;
+    height: 2.2rem;
     padding: 0;
     border: 1px solid var(--color-border);
     border-radius: 9999px;
@@ -245,12 +229,15 @@
 }
 
 .comment-composer__game-trigger:hover,
-.comment-composer__game-trigger--open {
+.comment-composer__game-trigger--open,
+.reaction-bar__trigger:hover:not(:disabled),
+.reaction-bar__trigger--open {
     color: var(--color-text);
     border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-border));
 }
 
-.comment-composer__game-trigger-plus {
+.comment-composer__game-trigger-plus,
+.reaction-bar__trigger-plus {
     font-size: 0.7rem;
     font-weight: 700;
     line-height: 1;
@@ -372,10 +359,6 @@
 
 .comment-composer__mention-avatar {
     flex: 0 0 auto;
-    width: 20px;
-    height: 20px;
-    border-radius: 9999px;
-    object-fit: cover;
 }
 
 .comment-composer__mention-status {
@@ -483,35 +466,6 @@ button.reaction-bar__chip:hover:not(:disabled) {
 
 .reaction-bar__picker-wrap {
     position: relative;
-}
-
-.reaction-bar__trigger {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.05rem;
-    width: 1.85rem;
-    height: 1.85rem;
-    padding: 0;
-    border: 1px solid var(--color-border);
-    border-radius: 9999px;
-    background: var(--color-surface);
-    color: var(--color-muted);
-    cursor: pointer;
-    transition: border-color 120ms ease, color 120ms ease, background-color 120ms ease;
-}
-
-.reaction-bar__trigger:hover:not(:disabled),
-.reaction-bar__trigger--open {
-    color: var(--color-text);
-    border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-border));
-}
-
-.reaction-bar__trigger-plus {
-    font-size: 0.7rem;
-    font-weight: 700;
-    line-height: 1;
-    margin-left: -0.1rem;
 }
 
 .reaction-bar__picker {

--- a/frontend/src/styles/components/header.css
+++ b/frontend/src/styles/components/header.css
@@ -161,22 +161,3 @@ header .archive-link {
         margin-left: 0.75rem;
     }
 }
-
-/* User avatar in the Profile link — replaces the check icon when available.
-   Matches the 28px icon footprint so the header stays compact on mobile. */
-.header__avatar-wrap {
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    overflow: hidden;
-    flex-shrink: 0;
-    border: 1px solid var(--color-border);
-}
-
-.header__avatar {
-    width: 28px;
-    height: 28px;
-    object-fit: cover;
-    border-radius: 50%;
-    display: block;
-}

--- a/frontend/src/styles/components/leaderboard.css
+++ b/frontend/src/styles/components/leaderboard.css
@@ -85,6 +85,7 @@ html:has(.leaderboard-layout) {
     border-bottom: 1px solid var(--color-border);
     padding: 0.5rem 0.6rem;
     text-align: left;
+    vertical-align: middle;
     white-space: nowrap;
 }
 
@@ -98,7 +99,7 @@ html:has(.leaderboard-layout) {
 }
 
 .leaderboard__player {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 0.4rem;
 }
@@ -137,22 +138,6 @@ html:has(.leaderboard-layout) {
 .leaderboard__table th[aria-sort="ascending"] button.sortable .sort-indicator,
 .leaderboard__table th[aria-sort="descending"] button.sortable .sort-indicator {
     opacity: 1;
-}
-
-.leaderboard__avatar-wrap {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    background-size: cover;
-    background-position: center;
-    overflow: hidden;
-}
-
-.leaderboard__avatar {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    object-fit: cover;
 }
 
 .leaderboard__profile {

--- a/frontend/src/styles/components/leaderboard.css
+++ b/frontend/src/styles/components/leaderboard.css
@@ -102,6 +102,8 @@ html:has(.leaderboard-layout) {
     display: flex;
     align-items: center;
     gap: 0.4rem;
+    content-visibility: auto;
+    contain-intrinsic-size: 0 29px;
 }
 
 .leaderboard__table thead tr th {
@@ -163,8 +165,6 @@ html:has(.leaderboard-layout) {
 .leaderboard__profile-link:visited {
     color: var(--color-text);
 }
-
-/* No internal Next blur needed; using backgroundImage placeholder */
 
 .leaderboard__subline {
     margin-top: 0.4rem;

--- a/frontend/src/styles/components/otherPlayersNow.css
+++ b/frontend/src/styles/components/otherPlayersNow.css
@@ -14,20 +14,6 @@
 }
 
 .other-players__avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 2px solid var(--color-surface);
-    background: var(--color-surface-variant);
-    object-fit: cover;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: var(--color-text);
-    text-transform: uppercase;
-    overflow: hidden;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
@@ -37,17 +23,7 @@
 }
 
 .other-players__overflow {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 2px solid var(--color-surface);
-    background: var(--color-surface-variant);
-    color: var(--color-text);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
     font-size: 0.7rem;
-    font-weight: 600;
     line-height: 1;
 }
 

--- a/frontend/src/styles/shared.css
+++ b/frontend/src/styles/shared.css
@@ -92,7 +92,7 @@ button:disabled {
     background: var(--color-surface);
 }
 
-:not(header) > .container img {
+:not(header) > .container img:not(.avatar) {
     border-radius: 0.5rem;
     object-fit: cover;
 }


### PR DESCRIPTION
## Summary
- Introduces a shared `Avatar` component so the header, leaderboard/perfect-days/achievements tables, "playing now" presence, and day comments (including the @mention picker) all render avatars identically instead of each feature reimplementing its own markup and CSS.
- Fixes an accidental global CSS rule (`:not(header) > .container img`) that silently rounded some avatars into squircles while excluding the header's, causing the inconsistency.
- Fixes leaderboard row content not being vertically centered (`.leaderboard__player` was `inline-flex`, which centers against a line-box strut instead of the cell's padding box — changed to block-level `flex`).
- Bumps leaderboard avatars 24px → 29px and unifies the comment composer's game-trigger/reaction-trigger button sizing (1.85rem → 2.2rem).
- Includes CHANGELOG + version bump to v1.19.0 (tag already pushed).

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified live in dev server via Playwright measurements that leaderboard avatar/text are now pixel-centered in their cells
- [x] Screenshot-verified header, leaderboard, and comments avatars render consistently
- [ ] Manual smoke test on mobile viewport widths