### PR TITLE
Stabilize leaderboard column layout and truncate long player names

### DIFF
--- a/frontend/src/components/AchievementsTable.tsx
+++ b/frontend/src/components/AchievementsTable.tsx
@@ -75,6 +75,7 @@ export default function AchievementsTable({
                                             <a
                                                 href={`/profile/${encodeURIComponent(achievement.steamId)}`}
                                                 className="leaderboard__profile-link"
+                                                title={entry.personaName || achievement.steamId}
                                             >
                                                 {entry.personaName || achievement.steamId}
                                             </a>

--- a/frontend/src/components/LeaderboardTable.tsx
+++ b/frontend/src/components/LeaderboardTable.tsx
@@ -221,12 +221,13 @@ export default function LeaderboardTable(props: {
                     <tbody>
                     {sorted.map((entry, i) => (
                         <tr key={entry.profileUrl}>
-                            <td>{i + 1}</td>
+                            <td className="num">{i + 1}</td>
                             <td>
                                 <div className="leaderboard__player">
                                     <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
                                     <a href={`/profile/${encodeURIComponent(entry.steamId)}`}
-                                       className="leaderboard__profile-link">
+                                       className="leaderboard__profile-link"
+                                       title={entry.personaName || 'no-name'}>
                                         <strong>{entry.personaName || 'no-name'}</strong>
                                     </a>
                                     {(() => {

--- a/frontend/src/components/PerfectDaysTable.tsx
+++ b/frontend/src/components/PerfectDaysTable.tsx
@@ -96,7 +96,7 @@ export default function PerfectDaysTable(props: {
                             <td>
                                 <div className="leaderboard__player">
                                     <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
-                                    <span className="leaderboard__profile-link">{entry.personaName}</span>
+                                    <span className="leaderboard__profile-link" title={entry.personaName}>{entry.personaName}</span>
                                 </div>
                             </td>
                             <td>{formatDate(entry.gameDate)}</td>
@@ -136,7 +136,7 @@ export default function PerfectDaysTable(props: {
                             <td>
                                 <div className="leaderboard__player">
                                     <Avatar src={player.avatar} name={player.name} size={29}/>
-                                    <span className="leaderboard__profile-link">{player.name}</span>
+                                    <span className="leaderboard__profile-link" title={player.name}>{player.name}</span>
                                 </div>
                             </td>
                             <td className="num">{player.count}</td>

--- a/frontend/src/styles/components/leaderboard.css
+++ b/frontend/src/styles/components/leaderboard.css
@@ -77,6 +77,7 @@ html:has(.leaderboard-layout) {
 .leaderboard__table {
     width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
     min-width: 320px;
 }
 
@@ -89,9 +90,22 @@ html:has(.leaderboard-layout) {
     white-space: nowrap;
 }
 
-.leaderboard__table th:first-child,
-.leaderboard__table td:first-child {
-    width: 0;
+/* Rank column — only when the first column is a numeric rank (#) */
+.leaderboard__table th:first-child.num,
+.leaderboard__table td:first-child.num {
+    width: 36px;
+}
+
+/* Player / name column (also Winner in achievements, Game in hardest) */
+.leaderboard__table th:nth-child(2),
+.leaderboard__table td:nth-child(2) {
+    width: 220px;
+}
+
+/* Numeric metric columns (exclude the rank column above) */
+.leaderboard__table th.num:not(:first-child),
+.leaderboard__table td.num:not(:first-child) {
+    width: 4.5rem;
 }
 
 .leaderboard__table .num {
@@ -102,8 +116,7 @@ html:has(.leaderboard-layout) {
     display: flex;
     align-items: center;
     gap: 0.4rem;
-    content-visibility: auto;
-    contain-intrinsic-size: 0 29px;
+    min-width: 0;
 }
 
 .leaderboard__table thead tr th {
@@ -156,6 +169,18 @@ html:has(.leaderboard-layout) {
     text-decoration: underline;
     text-underline-offset: 2px;
     font-weight: 600;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.leaderboard__profile-link strong {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .leaderboard__profile-link:hover {
@@ -188,6 +213,21 @@ html:has(.leaderboard-layout) {
 
     .leaderboard__toggle .leaderboard__toggle-btn:last-child:nth-child(even) {
         grid-column: 1 / -1;
+    }
+
+    .leaderboard__table th:first-child.num,
+    .leaderboard__table td:first-child.num {
+        width: 26px;
+    }
+
+    .leaderboard__table th:nth-child(2),
+    .leaderboard__table td:nth-child(2) {
+        width: 140px;
+    }
+
+    .leaderboard__table th.num:not(:first-child),
+    .leaderboard__table td.num:not(:first-child) {
+        width: 3rem;
     }
 
     /* Hide Flops, Too High, and Too Low on mobile to save space */

--- a/frontend/src/styles/components/leaderboard.css
+++ b/frontend/src/styles/components/leaderboard.css
@@ -117,6 +117,8 @@ html:has(.leaderboard-layout) {
     align-items: center;
     gap: 0.4rem;
     min-width: 0;
+    content-visibility: auto;
+    contain-intrinsic-size: 0 29px;
 }
 
 .leaderboard__table thead tr th {

--- a/frontend/src/styles/shared.css
+++ b/frontend/src/styles/shared.css
@@ -96,3 +96,10 @@ button:disabled {
     border-radius: 0.5rem;
     object-fit: cover;
 }
+
+.truncate {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #119

## Summary
Stops leaderboard columns from shifting during sort, refresh, or scroll by locking table layout, and truncates long player names inside the fixed player column with full-name hover tooltips.

## Changes
- Set `table-layout: fixed` on `.leaderboard__table` with explicit widths for rank (`36px` / `26px` mobile), player (`220px` / `140px` mobile), and numeric columns
- Kept `min-width: 320px` and `.leaderboard__scroll` so narrow viewports still scroll horizontally
- Preserved the `max-width: 640px` media query that hides Flops / Too High / Too Low
- Restored `content-visibility: auto` + `contain-intrinsic-size: 0 29px` on `.leaderboard__player` for off-screen paint deferral; fixed column widths keep layout stable during scroll
- Added shared `.truncate` utility in `shared.css`
- Applied truncation + `min-width: 0` on `.leaderboard__player` / `.leaderboard__profile-link` (covers Leaderboard, Perfect Days ×2, Achievements)
- Added `title` attributes on player name elements for hover access to the full name

## Testing
- [x] `pnpm build` (vitest + Next.js build / TypeScript) passed
- [x] vitest after content-visibility restore (162 tests)
- Avatar `flex-shrink: 0` unchanged in `avatar.css`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd34e-33d5-7869-b2fa-8c98922479ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd34e-33d5-7869-b2fa-8c98922479ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

