### PR TITLE
Render theme-init, JSON-LD, and preconnects without next/head

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,7 +7,6 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { AuthProvider } from "@/contexts/AuthContext";
 import localFont from "next/font/local";
-import Head from "next/head";
 
 const krypton = localFont({
     src: [
@@ -234,20 +233,18 @@ export default async function RootLayout({
             suppressHydrationWarning
             {...(serverTheme === 'dark' ? { 'data-theme': 'dark' } : {})}
         >
-        <Head>
-            <Script src="/theme-init.js" strategy="beforeInteractive"/>
-            <link rel="preconnect" href={origin}/>
-            <link rel="dns-prefetch" href={origin}/>
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{__html: JSON.stringify(websiteSchema)}}
-            />
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{__html: JSON.stringify(organizationSchema)}}
-            />
-        </Head>
         <body>
+        <Script src="/theme-init.js" strategy="beforeInteractive"/>
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{__html: JSON.stringify(websiteSchema)}}
+        />
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{__html: JSON.stringify(organizationSchema)}}
+        />
+        <link rel="preconnect" href={origin}/>
+        <link rel="dns-prefetch" href={origin}/>
         <AuthProvider initialAuth={authState}>
             <Header/>
             <main>


### PR DESCRIPTION
Closes #121

## Problem
`<Head>` from `next/head` renders nothing in the App Router (HeadManagerContext is `{ appDir: true }`), so the pre-hydration `/theme-init.js` script, both `application/ld+json` structured-data blocks, and the preconnect/dns-prefetch hints were never emitted. Dark-mode users without a theme cookie got a white flash on every load and all schema.org rich results were lost.

## Fix
Removed the `next/head` import and the `<Head>` wrapper in `app/layout.tsx`. The theme-init script is now a direct `<Script strategy="beforeInteractive">` child of the root layout, and the JSON-LD scripts and preconnect links render directly in the layout body. Verified against the served HTML: `theme-init.js`, `"@type":"WebSite"`, `"@type":"Organization"`, and `rel="preconnect"` all appear.

## Tests
- `pnpm install --frozen-lockfile` (synced next to the lockfile-pinned 16.3.1-canary.4): ok
- `pnpm build` (vitest 20 files / 162 tests + next build + type check): passed
- Served the production build locally and confirmed the tags in the rendered HTML