### PR TITLE
Fix audit LOW findings: hardening, error handling, SEO hygiene

### DIFF
--- a/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
+++ b/backend/src/main/java/org/steam5/web/ws/PresenceHandshakeInterceptor.java
@@ -33,6 +33,13 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
 
     public static final Pattern SCOPE_KEY_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}(:\\d+:\\d+)?$");
 
+    /**
+     * Subprotocol prefix used to pass the presence ticket during the WebSocket
+     * handshake instead of a URL query parameter, keeping the ticket out of
+     * access logs and proxy log pipelines.
+     */
+    public static final String TICKET_SUBPROTOCOL_PREFIX = "s5ticket.";
+
     private final List<String> allowedOrigins;
     private final PresenceRateLimiter presenceRateLimiter;
     private final PresenceMetrics presenceMetrics;
@@ -84,7 +91,19 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
         final URI uri = request.getURI();
         final String query = uri.getRawQuery();
         final String scopeKey = extractParam(query, "scopeKey");
-        final String ticket = extractParam(query, "ticket");
+        String ticket = extractParam(query, "ticket");
+
+        // The client may pass the ticket as a WebSocket subprotocol instead of a URL
+        // query parameter so it does not leak into access logs. When offered, echo the
+        // selected subprotocol back so the handshake completes. The query parameter
+        // takes precedence for backward compatibility.
+        if (ticket == null || ticket.isBlank()) {
+            final String selected = ticketSubprotocol(request.getHeaders().getFirst("Sec-WebSocket-Protocol"));
+            if (selected != null) {
+                response.getHeaders().set("Sec-WebSocket-Protocol", selected);
+                ticket = selected.substring(TICKET_SUBPROTOCOL_PREFIX.length());
+            }
+        }
 
         if (scopeKey == null || scopeKey.isBlank()) {
             log.debug("Rejecting presence handshake — missing scopeKey");
@@ -180,5 +199,23 @@ public class PresenceHandshakeInterceptor implements HandshakeInterceptor {
                 .getQueryParams()
                 .get(name);
         return (values != null && !values.isEmpty()) ? values.get(0) : null;
+    }
+
+    /**
+     * Finds the offered WebSocket subprotocol that carries the presence ticket.
+     *
+     * @param subprotocolHeader the raw {@code Sec-WebSocket-Protocol} header value
+     * @return the full matched subprotocol token (e.g. {@code s5ticket.eyJ...}), or
+     *         {@code null} when the header is absent or carries no ticket subprotocol
+     */
+    static String ticketSubprotocol(final String subprotocolHeader) {
+        if (subprotocolHeader == null) return null;
+        for (final String candidate : subprotocolHeader.split(",")) {
+            final String value = candidate.trim();
+            if (value.startsWith(TICKET_SUBPROTOCOL_PREFIX) && value.length() > TICKET_SUBPROTOCOL_PREFIX.length()) {
+                return value;
+            }
+        }
+        return null;
     }
 }

--- a/backend/src/test/java/org/steam5/web/ws/PresenceHandshakeInterceptorTest.java
+++ b/backend/src/test/java/org/steam5/web/ws/PresenceHandshakeInterceptorTest.java
@@ -30,6 +30,28 @@ class PresenceHandshakeInterceptorTest {
     }
 
     @Test
+    void ticketSubprotocolExtractsPrefixedToken() {
+        assertEquals("s5ticket.jwt.value",
+                PresenceHandshakeInterceptor.ticketSubprotocol("s5ticket.jwt.value"));
+    }
+
+    @Test
+    void ticketSubprotocolHandlesMultipleOfferedProtocols() {
+        assertEquals("s5ticket.jwt.value",
+                PresenceHandshakeInterceptor.ticketSubprotocol("chat, s5ticket.jwt.value"));
+        assertEquals("s5ticket.jwt.value",
+                PresenceHandshakeInterceptor.ticketSubprotocol("s5ticket.jwt.value, chat"));
+    }
+
+    @Test
+    void ticketSubprotocolReturnsNullWhenAbsentOrEmpty() {
+        assertNull(PresenceHandshakeInterceptor.ticketSubprotocol(null));
+        assertNull(PresenceHandshakeInterceptor.ticketSubprotocol("chat"));
+        assertNull(PresenceHandshakeInterceptor.ticketSubprotocol("s5ticket."));
+        assertNull(PresenceHandshakeInterceptor.ticketSubprotocol(""));
+    }
+
+    @Test
     void loggableClientRefHashesIpWithoutEchoingRawValue() {
         final String hashed = PresenceHandshakeInterceptor.loggableClientRef("203.0.113.10");
 

--- a/frontend/app/api/auth/logout/route.ts
+++ b/frontend/app/api/auth/logout/route.ts
@@ -1,7 +1,7 @@
 import {revalidatePath, revalidateTag} from 'next/cache';
 import {NextRequest, NextResponse} from 'next/server';
 
-export async function GET(req: NextRequest) {
+export async function POST(req: NextRequest) {
     const xfHost = req.headers.get('x-forwarded-host');
     const xfProto = req.headers.get('x-forwarded-proto') || 'https';
     const base = (xfHost ? `${xfProto}://${xfHost}` : new URL(req.url).origin);

--- a/frontend/app/api/auth/steam/callback/route.ts
+++ b/frontend/app/api/auth/steam/callback/route.ts
@@ -26,23 +26,22 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url);
     const base = resolveBase(req);
 
-    // Fix #6: verify the CSRF state token if the browser sent one.
-    // SteamLoginButton stores a random UUID in s5_state (max-age 300s) and appends
-    // it to the login URL.  The backend embeds it in openid.return_to; Steam carries
-    // it back here as a plain query param.  If the cookie is present, it MUST match
-    // the URL param — a mismatch indicates a login-CSRF attempt.
+    // Fix #6: verify the CSRF state token. SteamLoginButton stores a random UUID in
+    // s5_state (max-age 300s) and appends it to the login URL. The backend embeds it
+    // in openid.return_to; Steam carries it back here as a plain query param. Both the
+    // cookie and the URL param MUST be present and match — a missing cookie (expired
+    // mid-flow or cleared) is treated as a mismatch, otherwise the check would be
+    // silently skipped exactly when it matters (login-CSRF protection).
     const stateFromUrl = url.searchParams.get('state');
     const stateFromCookie = req.cookies.get('s5_state')?.value;
-    if (stateFromCookie) {
-        if (!stateFromUrl || stateFromUrl !== stateFromCookie) {
-            console.error('[steam5] CSRF state mismatch — possible login-CSRF attack', {
-                hasUrlState: Boolean(stateFromUrl),
-                hasCookieState: Boolean(stateFromCookie),
-            });
-            const resp = NextResponse.redirect(new URL('/review-guesser/1?auth=csrf_error', base));
-            clearStateCookie(resp, base);
-            return resp;
-        }
+    if (!stateFromCookie || !stateFromUrl || stateFromUrl !== stateFromCookie) {
+        console.error('[steam5] CSRF state mismatch — possible login-CSRF attack', {
+            hasUrlState: Boolean(stateFromUrl),
+            hasCookieState: Boolean(stateFromCookie),
+        });
+        const resp = NextResponse.redirect(new URL('/review-guesser/1?auth=csrf_error', base));
+        clearStateCookie(resp, base);
+        return resp;
     }
 
     const qs = url.searchParams.toString();

--- a/frontend/app/api/review-game/my/today/route.ts
+++ b/frontend/app/api/review-game/my/today/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
         return NextResponse.json(data, {status: res.status, headers: {"Cache-Control": "private, no-store"}});
     } catch (e) {
         console.error(e);
-        return NextResponse.json([], {status: 200, headers: {"Cache-Control": "private, no-store"}});
+        return NextResponse.json({error: "Failed to load today's guesses"}, {status: 502, headers: {"Cache-Control": "private, no-store"}});
     }
 }
 

--- a/frontend/app/api/ws/ticket/route.ts
+++ b/frontend/app/api/ws/ticket/route.ts
@@ -4,6 +4,12 @@ import {forwardedForHeaders} from '@/lib/backend';
 
 const BACKEND_ORIGIN = process.env.API_DOMAIN || process.env.NEXT_PUBLIC_API_DOMAIN || 'http://localhost:8080';
 const isDevelopment = process.env.NODE_ENV === 'development';
+// Explicitly trusted internal backend origins (e.g. 'http://backend:8080' in
+// docker/k8s deployments) that may serve tickets over plain HTTP in production.
+const ALLOWED_BACKEND_ORIGINS = (process.env.ALLOWED_BACKEND_ORIGINS || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
 
 // Per-user, short-lived — must never be cached by Next, a CDN, or a proxy.
 const NO_STORE = {"Cache-Control": "private, no-store"} as const;
@@ -50,9 +56,14 @@ export async function GET(request: NextRequest) {
     if (!token) return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
 
     // Bearer tokens must not cross the network in plaintext — but a loopback
-    // backend never leaves the host, so it's exempt from the HTTPS requirement.
-    if (!isDevelopment && !isLoopbackOrigin(BACKEND_ORIGIN) && !BACKEND_ORIGIN.startsWith('https://')) {
-        console.error('[ws-ticket] Backend origin must use HTTPS in production:', BACKEND_ORIGIN);
+    // backend never leaves the host, and explicitly allow-listed internal
+    // origins (ALLOWED_BACKEND_ORIGINS) are trusted, so both are exempt from
+    // the HTTPS requirement.
+    if (!isDevelopment
+        && !isLoopbackOrigin(BACKEND_ORIGIN)
+        && !BACKEND_ORIGIN.startsWith('https://')
+        && !ALLOWED_BACKEND_ORIGINS.includes(BACKEND_ORIGIN)) {
+        console.error('[ws-ticket] Backend origin must use HTTPS in production (or be listed in ALLOWED_BACKEND_ORIGINS):', BACKEND_ORIGIN);
         return NextResponse.json({ticket: null}, {status: 200, headers: NO_STORE});
     }
     try {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -105,6 +105,16 @@ const organizationSchema = {
     email: 'luca.nerlich@gmail.com'
 };
 
+const metadataBase = (() => {
+    try {
+        return new URL(origin);
+    } catch {
+        // Invalid NEXT_PUBLIC_DOMAIN (e.g. missing protocol) — omit metadataBase
+        // instead of crashing every page at build/SSR time.
+        return undefined;
+    }
+})();
+
 export const metadata: Metadata = {
     title: {
         default: 'Steam5',
@@ -131,7 +141,7 @@ export const metadata: Metadata = {
     alternates: {
         canonical: `/`,
     },
-    metadataBase: new URL((process.env.NEXT_PUBLIC_DOMAIN || 'https://steam5.org').replace(/\/$/, '')),
+    metadataBase,
     openGraph: {
         emails: 'luca.nerlich@gmail.com',
         title: 'Steam5',

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,8 @@
-import type {Metadata} from "next";
 import Link from "next/link";
 import {Routes} from "./routes";
 
+// This page never renders: next.config.ts permanently redirects '/' to
+// '/review-guesser/1'. It exists only to own the route.
 export default function Home() {
     return (
         <section>
@@ -16,36 +17,3 @@ export default function Home() {
         </section>
     );
 }
-
-export const metadata: Metadata = {
-    title: 'Play Review Guesser — Daily Steam review game',
-    description: 'Guess how many reviews a Steam game has. Five daily rounds, shareable results, and leaderboards on Steam5.',
-    alternates: {
-        canonical: '/',
-    },
-    keywords: [
-        'Steam',
-        'Steam reviews',
-        'guessing game',
-        'daily game',
-        'review counts',
-        'leaderboard',
-        'free',
-        'browser game',
-        'no download',
-        'web-based',
-        'daily puzzle'
-    ],
-    openGraph: {
-        title: 'Steam5 — Daily Steam Review Guesser',
-        description: 'Guess Steam review counts across five daily rounds. Share and compete on the leaderboard.',
-        url: '/',
-        images: ['/opengraph-image'],
-    },
-    twitter: {
-        card: 'summary_large_image',
-        title: 'Steam5 — Daily Steam Review Guesser',
-        description: 'Guess Steam review counts across five daily rounds. Share and compete on the leaderboard.',
-        images: ['/opengraph-image'],
-    },
-};

--- a/frontend/app/review-guesser/[round]/actions.test.ts
+++ b/frontend/app/review-guesser/[round]/actions.test.ts
@@ -108,4 +108,15 @@ describe('submitGuessAction without a session cookie (anonymous)', () => {
 
         expect(res).toEqual({ok: false, error: 'Upstream error 500'});
     });
+
+    it('does not leak fetch error details to the client', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:8080'));
+
+        const res = await submitGuessAction(undefined, form(10, 'Positive'));
+
+        expect(res).toEqual({ok: false, error: 'Could not reach the game server — try again'});
+        expect(JSON.stringify(res)).not.toContain('127.0.0.1');
+        consoleError.mockRestore();
+    });
 });

--- a/frontend/app/review-guesser/[round]/actions.ts
+++ b/frontend/app/review-guesser/[round]/actions.ts
@@ -50,7 +50,9 @@ export async function submitGuessAction(_prev: GuessActionState | undefined, for
         // sent to the anonymous endpoint (no cookie) is not saved to the leaderboard.
         return {ok: true, response: json, persisted: Boolean(token)};
     } catch (e) {
-        return {ok: false, error: e instanceof Error ? e.message : 'Unknown error'};
+        console.error('submitGuessAction failed', e);
+        // Do not surface fetch internals (hosts, ports, connection errors) to the client.
+        return {ok: false, error: 'Could not reach the game server — try again'};
     }
 }
 

--- a/frontend/app/review-guesser/comments/actions.test.ts
+++ b/frontend/app/review-guesser/comments/actions.test.ts
@@ -123,6 +123,17 @@ describe('postCommentAction happy path and upstream errors', () => {
         consoleError.mockRestore();
     });
 
+    it('treats gateway timeouts (502/503/504) as outcome-unknown instead of a definitive failure', async () => {
+        fetchMock.mockResolvedValue(mockResponse(502, {}));
+
+        const res = await postCommentAction(undefined, form('2026-07-31', 'hello'));
+
+        expect(res.ok).toBe(false);
+        expect(res.outcomeUnknown).toBe(true);
+        expect(res.error).toMatch(/could not confirm/i);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('maps day_not_complete from ApiError.message to a friendly error', async () => {
         fetchMock.mockResolvedValue(mockResponse(400, {
             error: 'Bad Request',

--- a/frontend/app/review-guesser/comments/actions.ts
+++ b/frontend/app/review-guesser/comments/actions.ts
@@ -76,6 +76,15 @@ export async function postCommentAction(
         if (res.status === 401) {
             return {ok: false, unauthorized: true, error: 'Sign in with Steam to post a comment.'};
         }
+        if (res.status === 502 || res.status === 503 || res.status === 504) {
+            // Gateway-level failure after the backend may have committed the comment:
+            // treat it like a network failure so the UI does not invite a duplicate post.
+            return {
+                ok: false,
+                outcomeUnknown: true,
+                error: 'We could not confirm whether your comment was posted. Check the list before posting again.',
+            };
+        }
         if (!res.ok) {
             const err = await res.json().catch(() => ({})) as {error?: string; message?: string};
             const code = upstreamErrorCode(err);

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -4,15 +4,22 @@ import {MetadataRoute} from 'next';
 export default function sitemap(): MetadataRoute.Sitemap {
     const baseUrl = (process.env.NEXT_PUBLIC_DOMAIN || 'https://steam5.org').replace(/\/$/, '');
 
-    const routes = Object.values(Routes).filter((route): route is string => typeof route === 'string');
+    // These routes redirect (308/307) and must not appear in the sitemap —
+    // search engines would waste crawl budget on the redirect hops.
+    const redirectingRoutes = new Set(['/', '/review-guesser', '/review-guesser/random']);
+    const routes = Object.values(Routes).filter(
+        (route): route is string => typeof route === 'string' && !redirectingRoutes.has(route)
+    );
     const now = new Date();
     const staticPageFrequency = 'weekly' as const;
 
-    // Build list of archive dates from 2025-08-14 (inclusive) until today (UTC)
+    // Build list of archive dates from 2025-08-14 (inclusive) until yesterday (UTC).
+    // Today's challenge is served by /review-guesser/*; its archive copy duplicates
+    // the live game and is excluded.
     const startDate = new Date(Date.UTC(2025, 7, 14)); // Aug is 7 (0-based)
-    const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const yesterdayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
     const reviewGuesserArchive: string[] = [];
-    for (let d = new Date(startDate); d <= todayUtc; d = new Date(d.getTime() + 24 * 60 * 60 * 1000)) {
+    for (let d = new Date(startDate); d <= yesterdayUtc; d = new Date(d.getTime() + 24 * 60 * 60 * 1000)) {
         reviewGuesserArchive.push(d.toISOString().slice(0, 10)); // yyyy-mm-dd
     }
 
@@ -22,7 +29,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
             url: `${baseUrl}${route}`,
             lastModified: now,
             changeFrequency: staticPageFrequency,
-            priority: route === '/' ? 1 : 0.8,
+            priority: route === '/review-guesser/1' ? 1 : 0.8,
             alternates: {
                 languages: {
                     en: `${baseUrl}${route}`,

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -45,12 +45,12 @@ const nextConfig: NextConfig = {
         return [
             {
                 source: '/',
-                destination: '/review-guesser',
+                destination: '/review-guesser/1',
                 permanent: true,
             },
             {
                 source: '/rg',
-                destination: '/review-guesser',
+                destination: '/review-guesser/1',
                 permanent: true,
             },
             {

--- a/frontend/src/components/AuthLogoutLink.tsx
+++ b/frontend/src/components/AuthLogoutLink.tsx
@@ -7,8 +7,11 @@ export default function AuthLogoutLink(): React.ReactElement | null {
     const signedIn = useAuthSignedIn();
 
     if (!signedIn) return null;
-    // Plain <a> — next/link would prefetch this API route and trigger logout
-    return <a href="/api/auth/logout" className="btn">Logout</a>;
+    // POST (not a link): SameSite=Lax cookies are not sent on cross-site POSTs,
+    // so a third-party page cannot force-logout the user with an <img>/GET.
+    return (
+        <form action="/api/auth/logout" method="POST">
+            <button type="submit" className="btn">Logout</button>
+        </form>
+    );
 }
-
-

--- a/frontend/src/components/performance/HitRateVsAverageCard.tsx
+++ b/frontend/src/components/performance/HitRateVsAverageCard.tsx
@@ -10,15 +10,21 @@ const WIDTH = 600;
 const PADDING = 24;
 const BAR_W = WIDTH - PADDING * 2 - 60;
 
-function Row({y, label, pct, color}: { y: number; label: string; pct: number; color: string }) {
+function Row({y, label, pct, color}: { y: number; label: string; pct: number | null; color: string }) {
     return (
         <g>
             <text x={PADDING} y={y - 2} fontSize="16" fill="var(--color-muted)" textAnchor="start">{label}</text>
             <rect x={PADDING} y={y} width={BAR_W} height={16} fill="var(--color-border)"/>
-            <rect x={PADDING} y={y} width={Math.max(0, Math.min(1, pct / 100)) * BAR_W} height={14} fill={color}/>
-            <text x={PADDING + BAR_W + 4} y={y + 12} fontSize="14" fill="var(--color-muted)"
-                  textAnchor="start">{Math.round(pct)}%
-            </text>
+            {pct === null ? (
+                <text x={PADDING} y={y + 12} fontSize="14" fill="var(--color-muted)" textAnchor="start">No data</text>
+            ) : (
+                <>
+                    <rect x={PADDING} y={y} width={Math.max(0, Math.min(1, pct / 100)) * BAR_W} height={14} fill={color}/>
+                    <text x={PADDING + BAR_W + 4} y={y + 12} fontSize="14" fill="var(--color-muted)"
+                          textAnchor="start">{Math.round(pct)}%
+                    </text>
+                </>
+            )}
         </g>
     );
 }
@@ -63,7 +69,7 @@ export default function HitRateVsAverageCard({rounds}: { rounds: Round[] }): Rea
                  aria-label="Your hit rate vs global average">
                 <Row y={22} label={`You (last ${DAYS_WINDOW} days)`} pct={myHitRate}
                      color={'var(--color-primary, #6366f1)'}/>
-                <Row y={52} label={'All players (all‑time)'} pct={globalAvg ?? myHitRate} color={'var(--color-success, #16a34a)'}/>
+                <Row y={52} label={'All players (all‑time)'} pct={globalAvg} color={'var(--color-success, #16a34a)'}/>
             </svg>
         </div>
     );

--- a/frontend/src/lib/achievements.test.ts
+++ b/frontend/src/lib/achievements.test.ts
@@ -53,6 +53,16 @@ describe('formatTimeOfDay (TZ pinned to UTC)', () => {
         // Server reports 60 minutes past midnight with a +60min offset → UTC midnight.
         expect(formatTimeOfDay(60, 60)).toBe('12:00 AM');
     });
+
+    it('normalizes negative totals from positive-offset timezones', () => {
+        // Server 00:30 with a +120min offset → UTC 22:30 the previous day.
+        expect(formatTimeOfDay(30, 120)).toBe('10:30 PM');
+    });
+
+    it('carries fractional minutes that round to 60 into the next hour', () => {
+        // 3:59.6 rounds to 4:00 instead of rendering "3:60".
+        expect(formatTimeOfDay(3 * 60 + 59.6)).toBe('4:00 AM');
+    });
 });
 
 describe('getAchievementTitle', () => {

--- a/frontend/src/lib/achievements.ts
+++ b/frontend/src/lib/achievements.ts
@@ -62,8 +62,14 @@ export function formatDuration(seconds: number): string {
 
 export function formatTimeOfDay(minutesSinceMidnightServer: number, serverOffsetMinutes = 0): string {
     const utcMinutesSinceMidnight = minutesSinceMidnightServer - serverOffsetMinutes;
-    const hours = (Math.floor(utcMinutesSinceMidnight / 60) % 24 + 24) % 24;
-    const minutes = Math.round(utcMinutesSinceMidnight % 60);
+    // Round the total first, then normalize into [0, 1440) — early-morning times in
+    // positive-offset timezones produce negative totals, and fractional averages can
+    // round to 60 minutes; both must carry into the hour instead of rendering
+    // "10:-30 PM" / "4:60 PM".
+    const total = Math.round(utcMinutesSinceMidnight);
+    const normalized = ((total % 1440) + 1440) % 1440;
+    const hours = Math.floor(normalized / 60);
+    const minutes = normalized % 60;
     const period = hours >= 12 ? 'PM' : 'AM';
     const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
     return `${displayHours}:${minutes.toString().padStart(2, '0')} ${period}`;

--- a/frontend/src/lib/hooks/useRoundPresence.ts
+++ b/frontend/src/lib/hooks/useRoundPresence.ts
@@ -159,11 +159,14 @@ export function useRoundPresence(scopeKey: string | null): PresenceSnapshot & {
             closeSocket();
 
             const wsOrigin = toWsOrigin(BACKEND_ORIGIN);
-            const url = `${wsOrigin}/ws/presence?scopeKey=${encodeURIComponent(scopeKey)}&ticket=${encodeURIComponent(ticket ?? "")}`;
+            const url = `${wsOrigin}/ws/presence?scopeKey=${encodeURIComponent(scopeKey)}`;
+            // Pass the ticket as a WebSocket subprotocol instead of a URL query
+            // parameter so it does not land in access logs or proxy log pipelines.
+            const subprotocols = ticket ? [`s5ticket.${ticket}`] : undefined;
 
             let ws: WebSocket;
             try {
-                ws = new WebSocket(url);
+                ws = new WebSocket(url, subprotocols);
             } catch (e) {
                 console.warn("[useRoundPresence] failed to open socket", e);
                 scheduleReconnect();


### PR DESCRIPTION
Closes #132
Closes #133
Closes #134
Closes #135
Closes #136
Closes #137
Closes #138
Closes #139
Closes #140
Closes #141
Closes #142

## Problem & Fix

**#132 my/today proxy returned 200 `[]` when the backend was down (reliability)**
Backend failures were indistinguishable from an empty game state, silently resetting the UI for signed-in players. Fix: the catch path now returns 502 with an error body; `useServerGuesses` already ignores non-ok responses.

**#133 WS ticket route fails closed for internal HTTP backends (reliability)**
The production HTTPS guard returned `{ticket: null}` for docker/k8s backend origins like `http://backend:8080`, silently killing presence. Fix: an `ALLOWED_BACKEND_ORIGINS` env var lists explicitly trusted internal origins that are exempt from the HTTPS requirement.

**#134 Logout was a state-changing GET (security)**
Any third-party page could force-logout visitors via `<img src="/api/auth/logout">`. Fix: the route now only accepts POST and `AuthLogoutLink` renders a small form; SameSite=Lax cookies are not sent on cross-site POSTs, closing the CSRF vector. (The X-Forwarded-Host redirect issue in this route is fixed by PR #173.)

**#135 Login-CSRF state check silently skipped (security)**
The callback only compared the state when the `s5_state` cookie was present, so expired/cleared cookies bypassed the check entirely. Fix: a missing cookie or URL param is now treated as a mismatch and redirects to `auth=csrf_error`.

**#136 502/504 comment posts invited duplicates (correctness)**
A gateway timeout after the backend committed a comment surfaced as a definitive "Upstream error 504", inviting a retry. Fix: 502/503/504 now return `outcomeUnknown: true` with the check-the-list message.

**#137 Raw fetch errors leaked to the client (security)**
`submitGuessAction` returned `e.message` (hosts, ports, connection errors) to the UI. Fix: logs server-side and returns a fixed generic message.

**#138 formatTimeOfDay rendered "10:-30 PM" / "4:60 PM" (correctness)**
Negative totals in positive-offset timezones and fractional averages rounding to 60 minutes produced malformed times in achievement tooltips. Fix: round the total first and normalize into [0, 1440) before deriving hours/minutes.

**#139 WS ticket in URL query string (security hardening)**
The presence ticket landed in access/proxy logs via `&ticket=...`. Fix: the client now offers the ticket as the WebSocket subprotocol `s5ticket.<ticket>`; the backend handshake interceptor accepts it (query param still supported for backward compatibility) and echoes the selected subprotocol so the handshake completes. Added unit tests for the subprotocol parsing.

**#140 "All players" bar showed the player's own hit rate (data integrity)**
`globalAvg ?? myHitRate` presented the user's own stat as the global benchmark when leaderboard data was missing. Fix: `Row` now renders a "No data" placeholder when the percentage is null.

**#141 Unguarded metadataBase crashed pages on bad NEXT_PUBLIC_DOMAIN (misconfig resilience)**
`metadataBase: new URL(...)` was evaluated without a guard while the same value is safely derived elsewhere. Fix: metadataBase is built via try/catch from the already-guarded `origin` and omitted on failure.

**#142 Redirecting URLs in the sitemap + double redirect hop (SEO)**
The sitemap listed `/`, `/review-guesser`, and `/review-guesser/random` (all 307/308), and `/` cost two hops to reach `/review-guesser/1`. Fix: redirecting routes are excluded from the sitemap, today's archive copy is excluded from the date loop, `/` and `/rg` redirect straight to `/review-guesser/1`, and the dead metadata export was removed from `app/page.tsx`.

## Tests
- Frontend `pnpm test`: 20 files / 166 tests passed (incl. new cases for comment gateway errors, fetch-error leak, formatTimeOfDay normalization)
- Frontend `pnpm build` (vitest + next build + type check): passed
- Backend `./gradlew test` (full suite): passed
- Backend `./gradlew test --tests PresenceHandshakeInterceptorTest`: passed

Note: this branch is based on `main`; `[round]/actions.ts`, `actions.test.ts`, and `sitemap.ts` are also touched by PR #173 (MEDIUM), so a trivial rebase may be needed once that merges.

## Ready-for-review checklist
- [x] Branch created fresh off the latest default branch
- [x] Fix is minimal and matches repository conventions
- [x] Fix plan re-verified against the actual code
- [x] Local lint/typecheck/tests pass
- [x] PR body has `Closes #N`, Problem & Fix, tests run
- [x] No unrelated changes, debug code, or secrets