### PR TITLE
Fix audit LOW findings: tiebreaks, search escaping, UTC windows, cache eviction

### DIFF
--- a/backend/src/main/java/org/steam5/job/BlurhashScreenshotsJob.java
+++ b/backend/src/main/java/org/steam5/job/BlurhashScreenshotsJob.java
@@ -13,7 +13,9 @@ import org.steam5.repository.details.ScreenshotRepository;
 import org.steam5.service.BlurhashService;
 import org.steam5.service.DomainCacheEvictor;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 @Slf4j
@@ -92,6 +94,7 @@ public class BlurhashScreenshotsJob implements Job {
         // Fallback 'full-run' job, which encodes screenshots up to the configured batch limit.
         long start = System.nanoTime();
         int scanned = 0, encoded = 0, failed = 0;
+        final Set<Long> processedAppIds = new HashSet<>();
         final int batchLimit = Math.max(1, jobsConfig.getBlurhash().getBatchLimit());
         try {
             final int pageSize = 10; // small batch to limit memory
@@ -106,6 +109,9 @@ public class BlurhashScreenshotsJob implements Job {
                     }
                     scanned++;
                     cursorId = screenshot.getId(); // advance cursor to last scanned screenshot
+                    if (screenshot.getAppId() != null) {
+                        processedAppIds.add(screenshot.getAppId().getAppId());
+                    }
                     final Counters c = handleScreenshot(screenshot);
                     encoded += c.encoded;
                     failed += c.failed;
@@ -128,6 +134,12 @@ public class BlurhashScreenshotsJob implements Job {
                 final Cache cache = cacheManager.getCache("review-game");
                 if (cache != null) {
                     cache.clear();
+                }
+                // Also evict each processed app's one-day detail cache entry so the freshly
+                // encoded screenshot blur data appears in cached app detail responses
+                // immediately instead of up to the 24h TTL (mirrors the targeted path).
+                for (final Long appId : processedAppIds) {
+                    cacheEvictor.evictAppDetailEntry(appId);
                 }
             }
         }

--- a/backend/src/main/java/org/steam5/repository/GuessRepository.java
+++ b/backend/src/main/java/org/steam5/repository/GuessRepository.java
@@ -171,13 +171,13 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
     }
 
     @Query(value = "SELECT steam_id AS steamId, COUNT(*) AS rounds, " +
-            "AVG(EXTRACT(HOUR FROM created_at) * 60 + EXTRACT(MINUTE FROM created_at)) AS avgMinutes " +
+            "AVG(EXTRACT(HOUR FROM (created_at AT TIME ZONE 'UTC')) * 60 + EXTRACT(MINUTE FROM (created_at AT TIME ZONE 'UTC'))) AS avgMinutes " +
             "FROM guesses GROUP BY steam_id HAVING COUNT(*) >= :minRounds " +
             "ORDER BY avgMinutes ASC", nativeQuery = true)
     List<AvgTimeRow> findUsersByAvgSubmissionTimeAsc(@Param("minRounds") int minRounds);
 
     @Query(value = "SELECT steam_id AS steamId, COUNT(*) AS rounds, " +
-            "AVG(EXTRACT(HOUR FROM created_at) * 60 + EXTRACT(MINUTE FROM created_at)) AS avgMinutes " +
+            "AVG(EXTRACT(HOUR FROM (created_at AT TIME ZONE 'UTC')) * 60 + EXTRACT(MINUTE FROM (created_at AT TIME ZONE 'UTC'))) AS avgMinutes " +
             "FROM guesses WHERE game_date BETWEEN :startDate AND :endDate " +
             "GROUP BY steam_id HAVING COUNT(*) >= :minRounds " +
             "ORDER BY avgMinutes ASC", nativeQuery = true)
@@ -186,13 +186,13 @@ public interface GuessRepository extends JpaRepository<Guess, Long> {
                                                              @Param("minRounds") int minRounds);
 
     @Query(value = "SELECT steam_id AS steamId, COUNT(*) AS rounds, " +
-            "AVG(EXTRACT(HOUR FROM created_at) * 60 + EXTRACT(MINUTE FROM created_at)) AS avgMinutes " +
+            "AVG(EXTRACT(HOUR FROM (created_at AT TIME ZONE 'UTC')) * 60 + EXTRACT(MINUTE FROM (created_at AT TIME ZONE 'UTC'))) AS avgMinutes " +
             "FROM guesses GROUP BY steam_id HAVING COUNT(*) >= :minRounds " +
             "ORDER BY avgMinutes DESC", nativeQuery = true)
     List<AvgTimeRow> findUsersByAvgSubmissionTimeDesc(@Param("minRounds") int minRounds);
 
     @Query(value = "SELECT steam_id AS steamId, COUNT(*) AS rounds, " +
-            "AVG(EXTRACT(HOUR FROM created_at) * 60 + EXTRACT(MINUTE FROM created_at)) AS avgMinutes " +
+            "AVG(EXTRACT(HOUR FROM (created_at AT TIME ZONE 'UTC')) * 60 + EXTRACT(MINUTE FROM (created_at AT TIME ZONE 'UTC'))) AS avgMinutes " +
             "FROM guesses WHERE game_date BETWEEN :startDate AND :endDate " +
             "GROUP BY steam_id HAVING COUNT(*) >= :minRounds " +
             "ORDER BY avgMinutes DESC", nativeQuery = true)

--- a/backend/src/main/java/org/steam5/repository/LeaderboardMvRepository.java
+++ b/backend/src/main/java/org/steam5/repository/LeaderboardMvRepository.java
@@ -36,25 +36,25 @@ public interface LeaderboardMvRepository extends Repository<Guess, Long> {
     @Query(value = "SELECT steam_id AS steamId, total_points AS totalPoints, rounds, hits, flops, " +
             "too_high AS tooHigh, too_low AS tooLow, avg_points AS avgPoints, persona_name AS personaName, " +
             "avatar_full AS avatarFull, blurdata_avatar_full AS blurdataAvatarFull, profile_url AS profileUrl " +
-            "FROM mv_leaderboard_all_time ORDER BY total_points DESC", nativeQuery = true)
+            "FROM mv_leaderboard_all_time ORDER BY total_points DESC, steam_id ASC", nativeQuery = true)
     List<LeaderboardMvRow> findAllTime();
 
     @Query(value = "SELECT steam_id AS steamId, total_points AS totalPoints, rounds, hits, flops, " +
             "too_high AS tooHigh, too_low AS tooLow, avg_points AS avgPoints, persona_name AS personaName, " +
             "avatar_full AS avatarFull, blurdata_avatar_full AS blurdataAvatarFull, profile_url AS profileUrl " +
-            "FROM mv_leaderboard_monthly ORDER BY total_points DESC", nativeQuery = true)
+            "FROM mv_leaderboard_monthly ORDER BY total_points DESC, steam_id ASC", nativeQuery = true)
     List<LeaderboardMvRow> findMonthly();
 
     @Query(value = "SELECT steam_id AS steamId, total_points AS totalPoints, rounds, hits, flops, " +
             "too_high AS tooHigh, too_low AS tooLow, avg_points AS avgPoints, persona_name AS personaName, " +
             "avatar_full AS avatarFull, blurdata_avatar_full AS blurdataAvatarFull, profile_url AS profileUrl " +
-            "FROM mv_leaderboard_weekly ORDER BY total_points DESC", nativeQuery = true)
+            "FROM mv_leaderboard_weekly ORDER BY total_points DESC, steam_id ASC", nativeQuery = true)
     List<LeaderboardMvRow> findWeekly();
 
     @Query(value = "SELECT steam_id AS steamId, total_points AS totalPoints, rounds, hits, flops, " +
             "too_high AS tooHigh, too_low AS tooLow, avg_points AS avgPoints, persona_name AS personaName, " +
             "avatar_full AS avatarFull, blurdata_avatar_full AS blurdataAvatarFull, profile_url AS profileUrl " +
-            "FROM mv_leaderboard_season ORDER BY total_points DESC", nativeQuery = true)
+            "FROM mv_leaderboard_season ORDER BY total_points DESC, steam_id ASC", nativeQuery = true)
     List<LeaderboardMvRow> findSeason();
 
     interface HardestGameMvRow {

--- a/backend/src/main/java/org/steam5/service/DomainCacheEvictor.java
+++ b/backend/src/main/java/org/steam5/service/DomainCacheEvictor.java
@@ -51,6 +51,20 @@ public class DomainCacheEvictor {
     }
 
     /**
+     * Drop only the per-app {@code one-day} cache entry for a single app, without clearing
+     * the shared {@code review-game} cache. Used by bulk loops (e.g. the full-run blurhash
+     * job) that clear {@code review-game} once up front but still need each processed app's
+     * cached detail response invalidated so freshly encoded screenshot blur data is served
+     * immediately rather than up to 24h later.
+     */
+    public void evictAppDetailEntry(final Long appId) {
+        final org.springframework.cache.Cache oneDay = cacheManager.getCache(ONE_DAY);
+        if (oneDay != null) {
+            oneDay.evict(appId);
+        }
+    }
+
+    /**
      * Drop cached leaderboard responses (all-time, monthly, weekly-floating, season). Call
      * after a leaderboard materialized view refresh, since the cached entries would otherwise
      * keep serving pre-refresh data for up to the cache's 10-minute TTL.

--- a/backend/src/main/java/org/steam5/service/LeaderboardService.java
+++ b/backend/src/main/java/org/steam5/service/LeaderboardService.java
@@ -11,6 +11,7 @@ import org.steam5.repository.LeaderboardMvRepository;
 import org.steam5.repository.UserRepository;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,7 +46,8 @@ public class LeaderboardService {
 
         return byUser.entrySet().stream()
                 .map(entry -> buildEntry(entry, usersById, streakDatesById, asOfDate))
-                .sorted((a, b) -> Long.compare(b.totalPoints(), a.totalPoints()))
+                .sorted(Comparator.comparingLong(LeaderEntry::totalPoints).reversed()
+                        .thenComparing(LeaderEntry::steamId))
                 .toList();
     }
 

--- a/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
+++ b/backend/src/main/java/org/steam5/service/PlayerSpotlightService.java
@@ -467,7 +467,7 @@ public class PlayerSpotlightService {
             if (yesterdayTotal == null) continue;
 
             final List<Integer> priorTotals = dailyTotals.entrySet().stream()
-                    .filter(e -> !e.getKey().equals(yesterday))
+                    .filter(e -> e.getKey().isBefore(yesterday))
                     .map(Map.Entry::getValue)
                     .toList();
             if (priorTotals.size() < MIN_PRIOR_DAYS_FOR_BEST_DAY_EVER) continue;

--- a/backend/src/main/java/org/steam5/service/StatisticsService.java
+++ b/backend/src/main/java/org/steam5/service/StatisticsService.java
@@ -5,6 +5,7 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.steam5.domain.GameDate;
 import org.steam5.domain.ReviewGamePick;
 import org.steam5.domain.Season;
 import org.steam5.repository.GuessRepository;
@@ -156,7 +157,7 @@ public class StatisticsService {
         final Set<String> alreadyAwarded = new HashSet<>();
 
         // Calculate date range for timeframe
-        final LocalDate today = LocalDate.now();
+        final LocalDate today = GameDate.todayUtc();
         final LocalDate startDate;
         final LocalDate endDate;
 

--- a/backend/src/main/java/org/steam5/web/UserSearchController.java
+++ b/backend/src/main/java/org/steam5/web/UserSearchController.java
@@ -42,11 +42,22 @@ public class UserSearchController {
             return Collections.emptyList();
         }
         final List<User> matches =
-                userRepository.findTop10ByPersonaNameContainingIgnoreCaseAndPersonaNameNotNullOrderByPersonaNameAsc(query);
+                userRepository.findTop10ByPersonaNameContainingIgnoreCaseAndPersonaNameNotNullOrderByPersonaNameAsc(
+                        escapeLikeWildcards(query));
         return matches.stream()
                 .filter(user -> steamId == null || !steamId.equals(user.getSteamId()))
                 .map(user -> new UserSearchDto(user.getSteamId(), user.getPersonaName(), user.getAvatar()))
                 .toList();
+    }
+
+    /**
+     * Escapes the LIKE wildcard characters ({@code %}, {@code _}) and the escape character
+     * ({@code \}) so a raw search term is matched literally. Without this, {@code q=%%}
+     * matches every user and {@code q=a_b} matches any three-character name, defeating the
+     * enumeration-guard intent of the endpoint. PostgreSQL's default LIKE escape is backslash.
+     */
+    private static String escapeLikeWildcards(final String value) {
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     public record UserSearchDto(String steamId, String personaName, String avatar) {

--- a/backend/src/main/java/org/steam5/web/admin/SeasonAdminController.java
+++ b/backend/src/main/java/org/steam5/web/admin/SeasonAdminController.java
@@ -29,9 +29,14 @@ public class SeasonAdminController {
         BackfillRequest effective = request == null ? new BackfillRequest(null, null, false) : request;
         List<Season> created;
         if (effective.startDate() != null && effective.endDate() != null) {
+            if (effective.startDate().isAfter(effective.endDate())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "startDate must be on or before endDate");
+            }
             created = seasonService.backfillRange(effective.startDate(), effective.endDate());
-        } else {
+        } else if (effective.startDate() == null && effective.endDate() == null) {
             created = seasonService.backfillHistoricalSeasons();
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "startDate and endDate must be provided together");
         }
 
         int finalized = 0;

--- a/backend/src/main/resources/db/mv-leaderboard-all-time.sql
+++ b/backend/src/main/resources/db/mv-leaderboard-all-time.sql
@@ -46,7 +46,7 @@ LEFT JOIN users u ON u.steam_id = g.steam_id
 -- CONSTRAINT users_pkey` — including the one pg_restore --clean issues when reloading a
 -- backup — unless the caller adds CASCADE.
 GROUP BY g.steam_id, u.steam_id, u.persona_name, u.avatar_full, u.blurdata_avatar_full, u.profile_url
-ORDER BY SUM(g.points) DESC
+ORDER BY SUM(g.points) DESC, g.steam_id ASC
 WITH NO DATA;
 
 -- Required for REFRESH MATERIALIZED VIEW CONCURRENTLY. CREATE INDEX CONCURRENTLY cannot run

--- a/backend/src/main/resources/db/mv-leaderboard-monthly.sql
+++ b/backend/src/main/resources/db/mv-leaderboard-monthly.sql
@@ -41,7 +41,7 @@ WHERE g.game_date BETWEEN (now() AT TIME ZONE 'UTC')::date - 29 AND (now() AT TI
 -- avoids a catalog dependency on users_pkey that would otherwise block DROP CONSTRAINT
 -- operations, e.g. from pg_restore --clean).
 GROUP BY g.steam_id, u.steam_id, u.persona_name, u.avatar_full, u.blurdata_avatar_full, u.profile_url
-ORDER BY SUM(g.points) DESC
+ORDER BY SUM(g.points) DESC, g.steam_id ASC
 WITH NO DATA;
 
 -- Required for REFRESH MATERIALIZED VIEW CONCURRENTLY. CREATE INDEX CONCURRENTLY cannot run

--- a/backend/src/main/resources/db/mv-leaderboard-season.sql
+++ b/backend/src/main/resources/db/mv-leaderboard-season.sql
@@ -50,7 +50,7 @@ LEFT JOIN users u ON u.steam_id = g.steam_id
 -- avoids a catalog dependency on users_pkey that would otherwise block DROP CONSTRAINT
 -- operations, e.g. from pg_restore --clean).
 GROUP BY g.steam_id, u.steam_id, u.persona_name, u.avatar_full, u.blurdata_avatar_full, u.profile_url
-ORDER BY SUM(g.points) DESC
+ORDER BY SUM(g.points) DESC, g.steam_id ASC
 WITH NO DATA;
 
 -- Required for REFRESH MATERIALIZED VIEW CONCURRENTLY. CREATE INDEX CONCURRENTLY cannot run

--- a/backend/src/main/resources/db/mv-leaderboard-weekly.sql
+++ b/backend/src/main/resources/db/mv-leaderboard-weekly.sql
@@ -40,7 +40,7 @@ WHERE g.game_date BETWEEN (now() AT TIME ZONE 'UTC')::date - 6 AND (now() AT TIM
 -- avoids a catalog dependency on users_pkey that would otherwise block DROP CONSTRAINT
 -- operations, e.g. from pg_restore --clean).
 GROUP BY g.steam_id, u.steam_id, u.persona_name, u.avatar_full, u.blurdata_avatar_full, u.profile_url
-ORDER BY SUM(g.points) DESC
+ORDER BY SUM(g.points) DESC, g.steam_id ASC
 WITH NO DATA;
 
 -- Required for REFRESH MATERIALIZED VIEW CONCURRENTLY. CREATE INDEX CONCURRENTLY cannot run

--- a/backend/src/test/java/org/steam5/web/UserSearchControllerWebTest.java
+++ b/backend/src/test/java/org/steam5/web/UserSearchControllerWebTest.java
@@ -64,4 +64,16 @@ class UserSearchControllerWebTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json("[]"));
     }
+
+    @Test
+    void search_escapesLikeWildcardsInQuery() throws Exception {
+        // q="100%_\" must reach the repository as "100\%\_\\" so %, _ and \ are
+        // matched literally rather than acting as LIKE wildcards.
+        when(userRepository.findTop10ByPersonaNameContainingIgnoreCaseAndPersonaNameNotNullOrderByPersonaNameAsc(
+                "100\\%\\_\\\\"))
+                .thenReturn(java.util.List.of());
+
+        mockMvc.perform(get("/api/users/search").param("q", "100%_\\"))
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
Closes #162
Closes #166
Closes #167
Closes #168
Closes #169
Closes #172

## Scope note

This PR fixes only the LOW findings whose fixes are minimal and very unlikely to
regress. The following LOW findings were intentionally left out of this PR
because a safe minimal fix isn't obvious — details in the "Deferred" section:

- #161 (cache-key churn) — needs a caching refactor/SpEL key change
- #163 (metrics/cache auth) — `/api/metrics/picks/summary` is fetched
  anonymously by the public `GameStatistics` frontend, so gating it would break
  the stats page
- #164 (profile endpoint) — safe fix requires rate limiting or a cap that
  changes behavior
- #170 (round labels) — needs a schema change (persist round index) or a
  round-ordering change
- #171 (perfect-days MV) — structural MV SQL rewrite, unverifiable without a DB

## Problem & Fix

**#162 User search does not escape LIKE wildcards (correctness)**
`q=%%` was passed straight to a `ContainingIgnoreCase` derived query, so `%`
and `_` acted as wildcards and `q=%%` matched every user, defeating the
endpoint's enumeration guard. Fix: escape `\`, `%`, and `_` before calling the
repository (PostgreSQL's default LIKE escape is backslash).

**#166 Admin backfill silently ignores partial date pairs (correctness)**
Providing only one of `startDate`/`endDate` silently ran a full historical
backfill, and `start > end` surfaced as a 500 via `IllegalArgumentException`.
Fix: the controller now rejects partial pairs and inverted ranges with a 400
`ResponseStatusException`. (Deviation from the issue's plan: I did not add a
global `IllegalArgumentException → 400` handler, since that would also mask
unrelated internal bugs as 400s.)

**#167 Statistics achievement windows use the JVM default timezone (correctness)**
DAILY/WEEKLY/MONTHLY windows used `LocalDate.now()` while the rest of the system
anchors to UTC, and the EARLY_BIRD/NIGHT_OWL SQL extracted hours in the DB
session timezone. Fix: use `GameDate.todayUtc()` and `AT TIME ZONE 'UTC'` in the
submission-time SQL.

**#168 BEST_DAY_EVER compares against a prior-best set including today (correctness)**
The prior-best set excluded only `yesterday`, so today's partial score (submitted
before the nightly job runs) could block a genuine personal best. Fix: only days
strictly before yesterday count as "prior".

**#169 Full-run blurhash job never evicts the per-app one-day cache (correctness)**
The full-run path only cleared the `review-game` cache, so freshly encoded
screenshots stayed hidden in cached app detail responses for up to the 24h TTL.
Fix: track processed app ids and evict each app's `one-day` entry (via a new
`DomainCacheEvictor.evictAppDetailEntry` that doesn't re-clear `review-game`).

**#172 Leaderboard ties have nondeterministic ordering (correctness)**
The live leaderboard sorted by total points only and used a `HashMap` grouping,
so tied players rotated positions between refreshes; the MV-backed read queries
also ordered by `total_points DESC` only. Fix: add a deterministic `steam_id`
tiebreak in the live sort, the MV read queries, and the MV definitions.

## Tests

- `./gradlew compileJava compileTestJava`: BUILD SUCCESSFUL
- `./gradlew test --tests org.steam5.web.UserSearchControllerWebTest`: passed
  (incl. new `search_escapesLikeWildcardsInQuery` case)
- `./gradlew test` (full suite): 247 tests, 0 failures / 0 errors / 0 skipped

Note: the MV `.sql` files and native-query changes could not be exercised
against a live PostgreSQL instance in this environment; the SQL changes are
mechanical (an added ORDER BY tiebreak and `AT TIME ZONE 'UTC'`).

## Deferred (not fixed here, see Scope note)

- #161, #163, #164, #170, #171

## Ready-for-review checklist

- [x] Branch created fresh off the latest default branch
- [x] Fix is minimal and matches repository conventions
- [x] Fix plan re-verified against the actual code (deviation on #166 noted)
- [x] Local compile + tests pass
- [x] PR body has `Closes #N`, Problem & Fix, tests run
- [x] No unrelated changes, debug code, or secrets
