### PR TITLE
Fix audit security findings: admin authz, JWT default secret, OpenID replay, API-key leak, ops endpoint gating

### DIFF
--- a/backend/src/main/java/org/steam5/auth/OpenIdNonceStore.java
+++ b/backend/src/main/java/org/steam5/auth/OpenIdNonceStore.java
@@ -1,0 +1,68 @@
+package org.steam5.auth;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Server-side one-time nonces for the Steam OpenID login flow.
+ *
+ * <p>Steam's OpenID 2.0 assertion is a signed URL with no built-in nonce, so a
+ * captured callback URL could be replayed to obtain fresh tokens. {@code /steam/login}
+ * issues a nonce and embeds it in {@code openid.return_to}; the callback must
+ * present and consume it exactly once. The store also records the exact
+ * return-to base URL built at login time so the callback can verify Steam
+ * echoed the same URL back.</p>
+ */
+@Component
+public class OpenIdNonceStore {
+
+    private static final Duration TTL = Duration.ofMinutes(10);
+    private static final int MAX_ENTRIES = 10_000;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private record Entry(String returnToBase, long expiresAtEpochMillis) {
+    }
+
+    private final ConcurrentHashMap<String, Entry> nonces = new ConcurrentHashMap<>();
+
+    /**
+     * Issues a fresh nonce bound to the given return-to base URL
+     * ({@code scheme://host[:port]/path}, without query).
+     */
+    public String issue(String returnToBase) {
+        final byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        final String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        if (nonces.size() >= MAX_ENTRIES) {
+            removeExpired();
+            if (nonces.size() >= MAX_ENTRIES) {
+                // Defensive bound: drop an arbitrary entry rather than grow unbounded.
+                nonces.keySet().stream().findAny().ifPresent(nonces::remove);
+            }
+        }
+        nonces.put(nonce, new Entry(returnToBase, System.currentTimeMillis() + TTL.toMillis()));
+        return nonce;
+    }
+
+    /**
+     * Consumes the nonce (single use). Returns the return-to base URL bound at
+     * issue time, or {@code null} when the nonce is unknown, expired, or already used.
+     */
+    public String consume(String nonce) {
+        if (nonce == null) return null;
+        final Entry entry = nonces.remove(nonce);
+        if (entry == null) return null;
+        if (System.currentTimeMillis() > entry.expiresAtEpochMillis()) return null;
+        return entry.returnToBase();
+    }
+
+    private void removeExpired() {
+        final long now = System.currentTimeMillis();
+        nonces.entrySet().removeIf(e -> now > e.getValue().expiresAtEpochMillis());
+    }
+}

--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -33,7 +33,6 @@ public class SecurityConfig {
     private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
 
     private static final String DEFAULT_METRICS_CRED = "metrics";
-    private static final String COOLIFY_PROFILE = "coolify";
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -46,10 +45,18 @@ public class SecurityConfig {
             @Value("${metrics.password:metrics}") String password,
             PasswordEncoder passwordEncoder,
             Environment environment) {
-        if (Arrays.asList(environment.getActiveProfiles()).contains(COOLIFY_PROFILE)
-                && DEFAULT_METRICS_CRED.equals(username)
-                && DEFAULT_METRICS_CRED.equals(password)) {
-            log.warn("Coolify profile is active but METRICS_USERNAME / METRICS_PASSWORD are still the defaults — "
+        if (DEFAULT_METRICS_CRED.equals(username) && DEFAULT_METRICS_CRED.equals(password)) {
+            final String[] activeProfiles = environment.getActiveProfiles();
+            final boolean isDevProfile = Arrays.asList(activeProfiles).contains("dev");
+            if (!isDevProfile) {
+                // Default credentials in a non-dev profile let anyone scrape
+                // /actuator/prometheus and satisfy basic auth on shared chains.
+                throw new IllegalStateException(
+                        "METRICS_USERNAME / METRICS_PASSWORD are still the defaults (metrics/metrics) — refusing to start. " +
+                        "Override them via environment variables before exposing the actuator endpoints. " +
+                        "(active profiles: " + Arrays.toString(activeProfiles) + ")");
+            }
+            log.warn("Dev profile active but METRICS_USERNAME / METRICS_PASSWORD are still the defaults — "
                     + "set them via environment variables before exposing /actuator/prometheus to the public.");
         }
         UserDetails metricsUser = User.withUsername(username)
@@ -92,12 +99,18 @@ public class SecurityConfig {
                         .requestMatchers("/api/review-game/comments/**").permitAll()
                         .requestMatchers("/api/review-game/**").permitAll()
                         .requestMatchers("/api/details/**").permitAll()
-                        .requestMatchers("/api/metrics/**").permitAll()
-                        .requestMatchers("/api/cache/**").permitAll()
+                        // Operational data is gated behind the admin token (AdminTokenFilter);
+                        // only the pick summary consumed by the public statistics UI stays open.
+                        .requestMatchers("/api/metrics/picks/summary").permitAll()
+                        .requestMatchers("/api/metrics/**").hasRole("ADMIN")
+                        .requestMatchers("/api/cache/**").hasRole("ADMIN")
                         .requestMatchers("/api/leaderboard/**").permitAll()
                         .requestMatchers("/api/profile/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/users/search").permitAll()
-                        .requestMatchers("/api/admin/**").authenticated()
+                        // AdminTokenFilter authenticates with the X-Admin-Token header and
+                        // grants ROLE_ADMIN; plain basic auth (e.g. the metrics user) must not
+                        // be able to reach admin operations.
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/seasons/**").permitAll()
                         .requestMatchers("/api/stats/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()

--- a/backend/src/main/java/org/steam5/http/JsonHttpClient.java
+++ b/backend/src/main/java/org/steam5/http/JsonHttpClient.java
@@ -20,7 +20,9 @@ public class JsonHttpClient {
     public JsonNode getJson(String url) throws IOException {
         final String body = httpClient.get(url);
         if (body == null || body.isBlank()) {
-            throw new IOException("Empty response body for url=" + url);
+            // Never embed the raw URL — it contains key=<apiKey> and this
+            // message is logged by every caller.
+            throw new IOException("Empty response body for url=" + SteamHttpClient.sanitizeUrl(url));
         }
         return objectMapper.readTree(body);
     }

--- a/backend/src/main/java/org/steam5/http/SteamApiException.java
+++ b/backend/src/main/java/org/steam5/http/SteamApiException.java
@@ -13,14 +13,14 @@ public class SteamApiException extends IOException {
     public SteamApiException(int statusCode, String url, String message) {
         super(message);
         this.statusCode = statusCode;
-        this.url = url;
+        // Fix: never retain the raw URL — it carries key=<apiKey> and any
+        // consumer that logs this exception would leak the Steam API key.
+        this.url = SteamHttpClient.sanitizeUrl(url);
     }
 
     public SteamApiException(int statusCode, String url, String message, Throwable cause) {
         super(message, cause);
         this.statusCode = statusCode;
-        this.url = url;
+        this.url = SteamHttpClient.sanitizeUrl(url);
     }
 }
-
-

--- a/backend/src/main/java/org/steam5/http/SteamHttpClient.java
+++ b/backend/src/main/java/org/steam5/http/SteamHttpClient.java
@@ -47,7 +47,8 @@ public class SteamHttpClient {
     }
 
     // Strip API key from URL before logging to prevent exposure in logs
-    private static String sanitizeUrl(String url) {
+    public static String sanitizeUrl(String url) {
+        if (url == null) return null;
         return url.replaceAll("key=[^&]+", "key=***");
     }
 

--- a/backend/src/main/java/org/steam5/security/AdminTokenFilter.java
+++ b/backend/src/main/java/org/steam5/security/AdminTokenFilter.java
@@ -27,6 +27,10 @@ public class AdminTokenFilter extends OncePerRequestFilter {
 
     private static final String ADMIN_HEADER = "X-Admin-Token";
     private static final String ADMIN_PATH_PREFIX = "/api/admin/";
+    private static final String METRICS_PATH_PREFIX = "/api/metrics/";
+    private static final String CACHE_PATH_PREFIX = "/api/cache/";
+    // Public-facing metrics endpoint consumed by the game statistics UI.
+    private static final String PUBLIC_METRICS_PATH = "/api/metrics/picks/summary";
 
     private final String expectedToken;
 
@@ -39,12 +43,42 @@ public class AdminTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        final String path = normalizedPath(request);
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+        final boolean gated = path.startsWith(ADMIN_PATH_PREFIX)
+                || path.startsWith(CACHE_PATH_PREFIX)
+                || (path.startsWith(METRICS_PATH_PREFIX) && !PUBLIC_METRICS_PATH.equals(path));
+        return !gated;
+    }
+
+    /**
+     * Returns the request path with the context path removed and semicolon
+     * path parameters stripped per segment, mirroring how Spring MVC and
+     * Spring Security's {@code MvcRequestMatcher} normalize URIs before
+     * matching. Without this, {@code /api/admin;/seasons/backfill} would
+     * route to the admin controller while skipping this filter's raw
+     * {@code getRequestURI()} check.
+     */
+    private static String normalizedPath(HttpServletRequest request) {
         String path = request.getRequestURI();
-        String contextPath = request.getContextPath();
+        final String contextPath = request.getContextPath();
         if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
             path = path.substring(contextPath.length());
         }
-        return "OPTIONS".equalsIgnoreCase(request.getMethod()) || !path.startsWith(ADMIN_PATH_PREFIX);
+        final StringBuilder normalized = new StringBuilder(path.length());
+        final String[] segments = path.split("/", -1);
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+            final int semi = segment.indexOf(';');
+            if (semi >= 0) {
+                segment = segment.substring(0, semi);
+            }
+            normalized.append(segment);
+            if (i < segments.length - 1) normalized.append('/');
+        }
+        return normalized.toString();
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/service/AuthTokenService.java
+++ b/backend/src/main/java/org/steam5/service/AuthTokenService.java
@@ -4,10 +4,12 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
 
 @Slf4j
@@ -16,7 +18,8 @@ public class AuthTokenService {
 
     private final SecretKey key;
 
-    public AuthTokenService(@Value("${auth.jwtSecret:change-me-please-change-me-32-bytes-min}") String secret) {
+    public AuthTokenService(@Value("${auth.jwtSecret:change-me-please-change-me-32-bytes-min}") String secret,
+                            Environment environment) {
         // Fix #8: enforce a minimum key length at startup so a misconfigured or
         // default secret causes an immediate, obvious failure rather than silently
         // running with a weak key in production.
@@ -26,6 +29,16 @@ public class AuthTokenService {
                     "Generate a strong secret with: openssl rand -base64 48");
         }
         if (secret.startsWith("change-me")) {
+            final String[] activeProfiles = environment.getActiveProfiles();
+            final boolean isDevProfile = Arrays.asList(activeProfiles).contains("dev");
+            if (!isDevProfile) {
+                // The fallback secret is public knowledge; running with it in any
+                // non-dev profile lets anyone forge tokens for arbitrary steamIds.
+                throw new IllegalStateException(
+                        "auth.jwtSecret is the publicly known default value — refusing to start. " +
+                        "Set a strong random secret via the AUTH_JWT_SECRET environment variable. " +
+                        "(active profiles: " + Arrays.toString(activeProfiles) + ")");
+            }
             log.warn("auth.jwtSecret appears to be the default insecure value. " +
                      "Set a strong random secret in production via the AUTH_JWT_SECRET environment variable.");
         }

--- a/backend/src/main/java/org/steam5/web/AuthController.java
+++ b/backend/src/main/java/org/steam5/web/AuthController.java
@@ -3,6 +3,7 @@ package org.steam5.web;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.steam5.auth.OpenIdNonceStore;
 import org.steam5.auth.SteamOpenIdUtils;
 import org.steam5.domain.User;
 import org.steam5.repository.UserRepository;
@@ -19,11 +21,13 @@ import org.steam5.service.AuthTokenService;
 import org.steam5.service.SteamUserService;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -37,7 +41,7 @@ import java.util.regex.Pattern;
 public class AuthController {
 
     private static final String OPENID_ENDPOINT = "https://steamcommunity.com/openid/login";
-    private static final Pattern STEAM_ID_PATTERN = Pattern.compile("https://steamcommunity.com/openid/id/([0-9]{17})");
+    private static final Pattern STEAM_ID_PATTERN = Pattern.compile("https://steamcommunity\\.com/openid/id/([0-9]{17})");
     // Allowlist for the state/nonce param: alphanumeric + hyphens/underscores, 8–128 chars
     private static final Pattern SAFE_STATE_PATTERN = Pattern.compile("[A-Za-z0-9_-]{8,128}");
 
@@ -51,6 +55,7 @@ public class AuthController {
     private final AuthTokenService tokenService;
     private final SteamUserService steamUserService;
     private final UserRepository userRepository;
+    private final OpenIdNonceStore nonceStore;
 
     @Value("${auth.redirectBase:https://steam5.org}")
     private String defaultRedirectBase;
@@ -69,9 +74,14 @@ public class AuthController {
         // Fix #6: if the frontend supplied a CSRF state token, embed it in the
         // return_to URL so Steam carries it back in the redirect, and the
         // callback can verify it against the browser's cookie.
-        final String returnTo = (state != null && SAFE_STATE_PATTERN.matcher(state).matches())
+        final String withState = (state != null && SAFE_STATE_PATTERN.matcher(state).matches())
                 ? baseReturnTo + (baseReturnTo.contains("?") ? "&" : "?") + "state=" + SteamOpenIdUtils.enc(state)
                 : baseReturnTo;
+
+        // Fix #10: bind a server-side single-use nonce to the exact return-to URL
+        // this login builds. The callback consumes it and verifies the echoed
+        // openid.return_to matches, closing the assertion-replay window.
+        final String returnTo = withState + (withState.contains("?") ? "&" : "?") + "nonce=" + SteamOpenIdUtils.enc(nonceStore.issue(baseOf(withState)));
 
         final String realm = SteamOpenIdUtils.deriveOriginSafe(returnTo, defaultRedirectBase);
         final String url = OPENID_ENDPOINT + "?openid.ns=" + SteamOpenIdUtils.enc("http://specs.openid.net/auth/2.0")
@@ -85,6 +95,57 @@ public class AuthController {
 
     @GetMapping("/steam/callback")
     public ResponseEntity<?> callback(@RequestParam Map<String, String> params) {
+        // Hard verify the assertion with Steam first: the response must contain
+        // is_valid:true.
+        if (!steamVerifies(params)) {
+            return ResponseEntity.status(401).body(Map.of("error", "invalid_openid"));
+        }
+
+        // Extract SteamID64 from claimed_id, and hard-verify the assertion's
+        // internal consistency: claimed_id must be signed by Steam and match
+        // openid.identity (otherwise a tampered/unsafe claimed_id could be
+        // accepted via the unanchored match).
+        final String claimed = params.get("openid.claimed_id");
+        final String identity = params.get("openid.identity");
+        final String signedFields = params.get("openid.signed");
+        if (claimed == null || identity == null || signedFields == null
+                || !Arrays.stream(signedFields.split(",")).map(String::trim).anyMatch("claimed_id"::equals)
+                || !claimed.equals(identity)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid_claimed_id"));
+        }
+        final Matcher m = STEAM_ID_PATTERN.matcher(claimed);
+        if (!m.matches()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid_claimed_id"));
+        }
+        final String steamId = m.group(1);
+
+        // Replay protection: consume the single-use nonce issued at login time
+        // and require Steam to echo back the exact return-to URL we built.
+        final String returnTo = params.get("openid.return_to");
+        final String nonce = returnTo == null ? null : queryParam(returnTo, "nonce");
+        final String expectedReturnToBase = nonceStore.consume(nonce);
+        if (expectedReturnToBase == null || !expectedReturnToBase.equals(baseOf(returnTo))) {
+            log.warn("Steam OpenID callback: nonce missing/expired or return_to mismatch (replay attempt?)");
+            return ResponseEntity.status(401).body(Map.of("error", "invalid_openid"));
+        }
+
+        // Enrich user profile (persona name) — runs asynchronously; does not block login
+        steamUserService.updateUserProfile(steamId);
+
+        // Issue signed token. The response must never be cached — a shared cache
+        // could serve one user's fresh token (or success payload) to another.
+        final String token = tokenService.generateToken(steamId);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noStore())
+                .body(Map.of("steamId", steamId, "token", token));
+    }
+
+    /**
+     * POSTs the assertion back to the hardcoded Steam endpoint (never the
+     * client-supplied openid.op_endpoint) and returns true only when Steam
+     * answers {@code is_valid:true}. Extracted for unit-testability.
+     */
+    boolean steamVerifies(Map<String, String> params) {
         try {
             final String body = SteamOpenIdUtils.buildCheckAuthBody(params);
 
@@ -108,34 +169,47 @@ public class AuthController {
                 log.warn("Steam OpenID verification redirected: status={} location={}", res.statusCode(), location);
             }
 
-            // Hard verify Steam response: must contain is_valid:true
             if (res.statusCode() != 200 || resBody == null || !resBody.contains("is_valid:true")) {
                 log.warn("Steam OpenID verification failed: status={} sample=\n{}", res.statusCode(),
                         resBody == null ? "<null>" : resBody.substring(0, Math.min(resBody.length(), 200)));
-                return ResponseEntity.status(401).body(Map.of("error", "invalid_openid"));
+                return false;
             }
-
-            // Extract SteamID64 from claimed_id
-            final String claimed = params.get("openid.claimed_id");
-            if (claimed == null) {
-                return ResponseEntity.badRequest().body(Map.of("error", "missing_claimed_id"));
-            }
-            final Matcher m = STEAM_ID_PATTERN.matcher(claimed);
-            if (!m.find()) {
-                return ResponseEntity.badRequest().body(Map.of("error", "invalid_claimed_id"));
-            }
-            final String steamId = m.group(1);
-
-            // Enrich user profile (persona name) — runs asynchronously; does not block login
-            steamUserService.updateUserProfile(steamId);
-
-            // Issue signed token
-            final String token = tokenService.generateToken(steamId);
-            return ResponseEntity.ok(Map.of("steamId", steamId, "token", token));
+            return true;
         } catch (Exception e) {
-            log.error("Steam OpenID callback error", e);
-            return ResponseEntity.internalServerError().body(Map.of("error", "auth_failed"));
+            log.error("Steam OpenID verification request failed", e);
+            return false;
         }
+    }
+
+    /** Returns {@code scheme://host[:port]/path} of a URL, or null when unparseable. */
+    static String baseOf(String url) {
+        if (url == null) return null;
+        try {
+            final URI uri = new URI(url);
+            final StringBuilder base = new StringBuilder()
+                    .append(uri.getScheme()).append("://").append(uri.getHost());
+            if (uri.getPort() != -1) base.append(':').append(uri.getPort());
+            base.append(uri.getPath());
+            return base.toString();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    /** Extracts a query parameter value from a URL, or null when absent. */
+    static String queryParam(String url, String name) {
+        if (url == null) return null;
+        final int q = url.indexOf('?');
+        if (q < 0) return null;
+        final String query = url.substring(q + 1);
+        for (String pair : query.split("&")) {
+            final int eq = pair.indexOf('=');
+            if (eq < 0) continue;
+            if (name.equals(pair.substring(0, eq))) {
+                return pair.substring(eq + 1);
+            }
+        }
+        return null;
     }
 
     /**

--- a/backend/src/test/java/org/steam5/auth/OpenIdNonceStoreTest.java
+++ b/backend/src/test/java/org/steam5/auth/OpenIdNonceStoreTest.java
@@ -1,0 +1,41 @@
+package org.steam5.auth;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpenIdNonceStoreTest {
+
+    private static final String BASE = "https://steam5.org/api/auth/steam/callback";
+
+    @Test
+    void issueAndConsumeReturnsBoundBase() {
+        final OpenIdNonceStore store = new OpenIdNonceStore();
+        final String nonce = store.issue(BASE);
+        assertNotNull(nonce);
+        assertEquals(BASE, store.consume(nonce));
+    }
+
+    @Test
+    void nonceIsSingleUse() {
+        final OpenIdNonceStore store = new OpenIdNonceStore();
+        final String nonce = store.issue(BASE);
+        assertEquals(BASE, store.consume(nonce));
+        assertNull(store.consume(nonce));
+    }
+
+    @Test
+    void unknownOrNullNonceConsumesToNull() {
+        final OpenIdNonceStore store = new OpenIdNonceStore();
+        assertNull(store.consume("does-not-exist"));
+        assertNull(store.consume(null));
+    }
+
+    @Test
+    void eachIssueProducesDistinctNonce() {
+        final OpenIdNonceStore store = new OpenIdNonceStore();
+        final String a = store.issue(BASE);
+        final String b = store.issue(BASE);
+        assertNotEquals(a, b);
+    }
+}

--- a/backend/src/test/java/org/steam5/security/AdminTokenFilterTest.java
+++ b/backend/src/test/java/org/steam5/security/AdminTokenFilterTest.java
@@ -1,0 +1,87 @@
+package org.steam5.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdminTokenFilterTest {
+
+    private static final String TOKEN = "secret-admin-token";
+
+    private final AdminTokenFilter filter = new AdminTokenFilter(TOKEN);
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private MockHttpServletRequest request(String method, String uri) {
+        final MockHttpServletRequest req = new MockHttpServletRequest(method, uri);
+        req.setRequestURI(uri);
+        return req;
+    }
+
+    private int runFilter(MockHttpServletRequest req, String token) throws ServletException, IOException {
+        if (token != null) {
+            req.addHeader("X-Admin-Token", token);
+        }
+        final MockHttpServletResponse resp = new MockHttpServletResponse();
+        final FilterChain chain = (r, s) -> {
+        };
+        filter.doFilterInternal(req, resp, chain);
+        return resp.getStatus();
+    }
+
+    @Test
+    void semicolonPathParametersDoNotBypassTheAdminGate() throws Exception {
+        final MockHttpServletRequest req = request("POST", "/api/admin;/seasons/backfill");
+        assertFalse(filter.shouldNotFilter(req));
+        assertEquals(401, runFilter(req, null));
+        assertEquals(200, runFilter(req, TOKEN));
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals("ROLE_ADMIN", SecurityContextHolder.getContext().getAuthentication().getAuthorities().iterator().next().getAuthority());
+    }
+
+    @Test
+    void metricsAndCachePathsAreGated() {
+        assertFalse(filter.shouldNotFilter(request("GET", "/api/metrics/counts")));
+        assertFalse(filter.shouldNotFilter(request("GET", "/api/metrics/coverage")));
+        assertFalse(filter.shouldNotFilter(request("GET", "/api/cache/stats")));
+    }
+
+    @Test
+    void publicMetricsSummaryIsNotGated() {
+        assertTrue(filter.shouldNotFilter(request("GET", "/api/metrics/picks/summary")));
+    }
+
+    @Test
+    void publicApiPathsAreNotGated() {
+        assertTrue(filter.shouldNotFilter(request("GET", "/api/review-game/today")));
+        assertTrue(filter.shouldNotFilter(request("GET", "/api/leaderboard/today")));
+    }
+
+    @Test
+    void optionsRequestsAreNotGated() {
+        assertTrue(filter.shouldNotFilter(request("OPTIONS", "/api/admin/seasons/backfill")));
+    }
+
+    @Test
+    void wrongTokenIsRejected() throws Exception {
+        final MockHttpServletRequest req = request("POST", "/api/admin/seasons/backfill");
+        assertEquals(401, runFilter(req, "wrong-token"));
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void missingTokenIsRejected() throws Exception {
+        assertEquals(401, runFilter(request("GET", "/api/cache/stats"), null));
+    }
+}

--- a/backend/src/test/java/org/steam5/web/AuthControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/AuthControllerTest.java
@@ -2,25 +2,65 @@ package org.steam5.web;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
+import org.steam5.auth.OpenIdNonceStore;
 import org.steam5.repository.UserRepository;
 import org.steam5.service.AuthTokenService;
 import org.steam5.service.SteamUserService;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AuthControllerTest {
+
+    private static final String CALLBACK_BASE = "https://steam5.org/api/auth/steam/callback";
+    private static final String STEAM_ID = "76561198000000000";
+    private static final String CLAIMED_ID = "https://steamcommunity.com/openid/id/" + STEAM_ID;
+
+    private AuthController controller(AuthTokenService token, SteamUserService users,
+                                      UserRepository userRepo, OpenIdNonceStore nonceStore) {
+        return new AuthController(token, users, userRepo, nonceStore);
+    }
+
+    /** Controller whose Steam verification step is stubbed to succeed. */
+    private AuthController verifiedController(OpenIdNonceStore nonceStore) {
+        AuthTokenService token = mock(AuthTokenService.class);
+        SteamUserService users = mock(SteamUserService.class);
+        UserRepository userRepo = mock(UserRepository.class);
+        when(token.generateToken(anyString())).thenReturn("fresh-token");
+        return new AuthController(token, users, userRepo, nonceStore) {
+            @Override
+            boolean steamVerifies(Map<String, String> params) {
+                return true;
+            }
+        };
+    }
+
+    /** Builds an assertion param map for a callback issued against {@code returnToBase}. */
+    private Map<String, String> assertionParams(OpenIdNonceStore nonceStore, String returnToBase) {
+        final String nonce = nonceStore.issue(returnToBase);
+        final Map<String, String> params = new HashMap<>();
+        params.put("openid.mode", "id_res");
+        params.put("openid.claimed_id", CLAIMED_ID);
+        params.put("openid.identity", CLAIMED_ID);
+        params.put("openid.signed", "assoc_handle,signed,claimed_id,identity,return_to");
+        params.put("openid.return_to", returnToBase + "?state=abc&nonce=" + nonce);
+        return params;
+    }
 
     @Test
     void startLogin_redirectsToSteamOpenId() {
         AuthTokenService token = mock(AuthTokenService.class);
         SteamUserService users = mock(SteamUserService.class);
         UserRepository userRepo = mock(UserRepository.class);
-        AuthController controller = new AuthController(token, users, userRepo);
+        AuthController controller = controller(token, users, userRepo, new OpenIdNonceStore());
         ResponseEntity<Void> res = controller.startLogin(null, null);
         assertEquals(302, res.getStatusCode().value());
         assertNotNull(res.getHeaders().getLocation());
@@ -30,12 +70,26 @@ public class AuthControllerTest {
     }
 
     @Test
+    void startLogin_embedsSingleUseNonceInReturnTo() {
+        AuthTokenService token = mock(AuthTokenService.class);
+        SteamUserService users = mock(SteamUserService.class);
+        UserRepository userRepo = mock(UserRepository.class);
+        AuthController controller = controller(token, users, userRepo, new OpenIdNonceStore());
+        ResponseEntity<Void> res = controller.startLogin(null, null);
+        final String location = res.getHeaders().getLocation().toString();
+        assertNotNull(location);
+        final String returnTo = URLDecoder.decode(location.substring(location.indexOf("openid.return_to=") + "openid.return_to=".length(), location.indexOf("&openid.realm=")), StandardCharsets.UTF_8);
+        assertTrue(returnTo.contains("nonce="));
+        assertTrue(returnTo.substring(returnTo.indexOf("nonce=") + 6).length() >= 32);
+    }
+
+    @Test
     void validate_token_ok_and_invalid() {
         AuthTokenService token = mock(AuthTokenService.class);
         SteamUserService users = mock(SteamUserService.class);
         UserRepository userRepo = mock(UserRepository.class);
         when(userRepo.findById("123")).thenReturn(Optional.empty());
-        AuthController controller = new AuthController(token, users, userRepo);
+        AuthController controller = controller(token, users, userRepo, new OpenIdNonceStore());
 
         when(token.verifyToken("good")).thenReturn("123");
         when(token.verifyToken("bad")).thenReturn(null);
@@ -62,7 +116,7 @@ public class AuthControllerTest {
         SteamUserService users = mock(SteamUserService.class);
         UserRepository userRepo = mock(UserRepository.class);
         when(userRepo.findById("123")).thenReturn(Optional.empty());
-        AuthController controller = new AuthController(token, users, userRepo);
+        AuthController controller = controller(token, users, userRepo, new OpenIdNonceStore());
 
         when(token.verifyToken("good")).thenReturn("123");
 
@@ -72,6 +126,104 @@ public class AuthControllerTest {
         // Per-user token validation must never be stored by any cache (shared or private).
         assertEquals("no-store", ok.getHeaders().getCacheControl());
     }
+
+    @Test
+    void callback_validAssertion_returnsTokenWithNoStore() {
+        final OpenIdNonceStore nonceStore = new OpenIdNonceStore();
+        final AuthController controller = verifiedController(nonceStore);
+
+        final var res = controller.callback(assertionParams(nonceStore, CALLBACK_BASE));
+
+        assertEquals(200, res.getStatusCode().value());
+        assertNotNull(res.getBody());
+        assertEquals(STEAM_ID, ((Map<?, ?>) res.getBody()).get("steamId"));
+        assertEquals("fresh-token", ((Map<?, ?>) res.getBody()).get("token"));
+        assertEquals("no-store", res.getHeaders().getCacheControl());
+    }
+
+    @Test
+    void callback_replayedAssertion_isRejected() {
+        final OpenIdNonceStore nonceStore = new OpenIdNonceStore();
+        final AuthController controller = verifiedController(nonceStore);
+        final Map<String, String> params = assertionParams(nonceStore, CALLBACK_BASE);
+
+        assertEquals(200, controller.callback(params).getStatusCode().value());
+        // Same nonce again → 401 (single-use).
+        assertEquals(401, controller.callback(params).getStatusCode().value());
+    }
+
+    @Test
+    void callback_missingNonce_isRejected() {
+        final AuthController controller = verifiedController(new OpenIdNonceStore());
+        final Map<String, String> params = new HashMap<>();
+        params.put("openid.claimed_id", CLAIMED_ID);
+        params.put("openid.identity", CLAIMED_ID);
+        params.put("openid.signed", "claimed_id");
+        params.put("openid.return_to", CALLBACK_BASE);
+
+        assertEquals(401, controller.callback(params).getStatusCode().value());
+    }
+
+    @Test
+    void callback_returnToMismatch_isRejected() {
+        final OpenIdNonceStore nonceStore = new OpenIdNonceStore();
+        final AuthController controller = verifiedController(nonceStore);
+        // Nonce issued for the real callback base, but the assertion echoes a
+        // different return_to (attacker-controlled realm/redirect).
+        final String nonce = nonceStore.issue(CALLBACK_BASE);
+        final Map<String, String> params = new HashMap<>();
+        params.put("openid.claimed_id", CLAIMED_ID);
+        params.put("openid.identity", CLAIMED_ID);
+        params.put("openid.signed", "claimed_id");
+        params.put("openid.return_to", "https://evil.example.com/api/auth/steam/callback?nonce=" + nonce);
+
+        assertEquals(401, controller.callback(params).getStatusCode().value());
+    }
+
+    @Test
+    void callback_identityMismatch_isRejected() {
+        final OpenIdNonceStore nonceStore = new OpenIdNonceStore();
+        final AuthController controller = verifiedController(nonceStore);
+        final Map<String, String> params = assertionParams(nonceStore, CALLBACK_BASE);
+        params.put("openid.identity", "https://steamcommunity.com/openid/id/11111111111111111");
+
+        assertEquals(400, controller.callback(params).getStatusCode().value());
+    }
+
+    @Test
+    void callback_unsignedClaimedId_isRejected() {
+        final OpenIdNonceStore nonceStore = new OpenIdNonceStore();
+        final AuthController controller = verifiedController(nonceStore);
+        final Map<String, String> params = assertionParams(nonceStore, CALLBACK_BASE);
+        params.put("openid.signed", "identity");
+
+        assertEquals(400, controller.callback(params).getStatusCode().value());
+    }
+
+    @Test
+    void callback_claimedIdWithTrailingGarbage_isRejected() {
+        final OpenIdNonceStore nonceStore = new OpenIdNonceStore();
+        final AuthController controller = verifiedController(nonceStore);
+        final Map<String, String> params = assertionParams(nonceStore, CALLBACK_BASE);
+        // Unanchored matching would accept this; matches() must not.
+        params.put("openid.claimed_id", CLAIMED_ID + "/../evil");
+        params.put("openid.identity", CLAIMED_ID + "/../evil");
+
+        assertEquals(400, controller.callback(params).getStatusCode().value());
+    }
+
+    @Test
+    void baseOf_stripsQueryButKeepsPath() {
+        assertEquals(CALLBACK_BASE, AuthController.baseOf(CALLBACK_BASE + "?state=abc&nonce=xyz"));
+        assertNull(AuthController.baseOf("not a url"));
+        assertNull(AuthController.baseOf(null));
+    }
+
+    @Test
+    void queryParam_extractsValues() {
+        assertEquals("xyz", AuthController.queryParam(CALLBACK_BASE + "?nonce=xyz", "nonce"));
+        assertEquals("xyz", AuthController.queryParam(CALLBACK_BASE + "?state=abc&nonce=xyz", "nonce"));
+        assertNull(AuthController.queryParam(CALLBACK_BASE, "nonce"));
+        assertNull(AuthController.queryParam(null, "nonce"));
+    }
 }
-
-


### PR DESCRIPTION
Closes #143
Closes #144
Closes #146
Closes #147
Closes #163

## Problem & Fix

**#143 Admin endpoints bypassable without X-Admin-Token (HIGH)**
`AdminTokenFilter` matched the raw `getRequestURI()` (so `POST /api/admin;/seasons/backfill` skipped the token gate while Spring MVC routed it to the controller), `/api/admin/**` required only `.authenticated()`, and the shared metrics basic-auth user (`metrics:metrics`) satisfied it. Fix: `/api/admin/**` now requires `ROLE_ADMIN` (only granted by the admin token), the filter normalizes semicolon path parameters per segment exactly like `MvcRequestMatcher`, and startup fails when `METRICS_USERNAME`/`METRICS_PASSWORD` are still the defaults outside the dev profile.

**#144 Publicly known default JWT secret accepted (HIGH)**
`AuthTokenService` only warned on the fallback secret. Fix: refuses to start with the default (or `change-me`-prefixed) secret in any non-dev profile, logging the active profiles in the message; dev keeps warn-only.

**#146 Steam OpenID callback accepts replayed assertions (MEDIUM)**
Steam's assertion has no nonce, so a captured callback URL yielded fresh tokens. Fix: `/steam/login` issues a single-use server-side nonce bound to the exact return-to URL; the callback consumes it and rejects missing/expired/reused nonces and return-to mismatches. Additionally `claimed_id` must be listed in `openid.signed`, equal `openid.identity`, and fully match the anchored 17-digit pattern (was unanchored `find()`), and the callback response now sets `Cache-Control: no-store`.

**#147 Steam API key leaks into logs (MEDIUM)**
`JsonHttpClient` empty-body errors embedded the raw URL (`key=<apiKey>`), and `SteamApiException` stored it. Fix: both use the `key=[^&]+` → `key=***` sanitization from `SteamHttpClient` (now a public static helper).

**#163 /api/metrics & /api/cache unauthenticated (LOW)**
Fix: gated behind the admin token (`hasRole("ADMIN")` + `AdminTokenFilter` prefixes). `/api/metrics/picks/summary` stays public because the frontend game-statistics UI consumes it.

## Tests
- `./gradlew test`: BUILD SUCCESSFUL (incl. new `AuthControllerTest` replay/nonce/claim cases, `AdminTokenFilterTest` semicolon-bypass + gating cases, `OpenIdNonceStoreTest`)
- Boot smoke test against local Postgres: health UP; `/api/metrics/counts` 401 without token; `/api/metrics/picks/summary` 200; `/api/admin;/seasons/backfill` 401; `/api/review-game/today` 200; `/api/auth/steam/login` 302
