### PR TITLE
Fix audit review-game/ingest findings: pick lock, exclusions, cursors, guess race, round order

### DIFF
--- a/backend/src/main/java/org/steam5/domain/ReviewGamePick.java
+++ b/backend/src/main/java/org/steam5/domain/ReviewGamePick.java
@@ -1,7 +1,6 @@
 package org.steam5.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,7 +13,6 @@ import java.time.OffsetDateTime;
         @UniqueConstraint(name = "uq_review_pick_date_app", columnNames = {"pick_date", "app_id"})
 })
 @NoArgsConstructor
-@AllArgsConstructor
 public class ReviewGamePick {
 
     @Id
@@ -30,6 +28,28 @@ public class ReviewGamePick {
 
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt;
+
+    /**
+     * Player-visible round order for the day (1..n), assigned after the shuffle
+     * so statistics round labels match the order actually served to players.
+     * Null for legacy rows, which fall back to createdAt/id ordering.
+     */
+    @Column(name = "round_index")
+    private Integer roundIndex;
+
+    public ReviewGamePick(Long id, LocalDate pickDate, Long appId, OffsetDateTime createdAt) {
+        this(id, pickDate, appId, createdAt, null);
+    }
+
+    public ReviewGamePick(Long id, LocalDate pickDate, Long appId, OffsetDateTime createdAt, Integer roundIndex) {
+        this.id = id;
+        this.pickDate = pickDate;
+        this.appId = appId;
+        this.createdAt = createdAt;
+        this.roundIndex = roundIndex;
+    }
+
+    public void setRoundIndex(Integer roundIndex) {
+        this.roundIndex = roundIndex;
+    }
 }
-
-

--- a/backend/src/main/java/org/steam5/domain/details/SteamAppDetailService.java
+++ b/backend/src/main/java/org/steam5/domain/details/SteamAppDetailService.java
@@ -141,6 +141,7 @@ public class SteamAppDetailService {
             if (!seenDevelopers.add(normalizedKey)) continue;
             final Developer dev = developerRepository.findByNameIgnoreCase(trimmedName)
                     .orElseGet(() -> {
+                        developerRepository.lockByNameIgnoreCase(trimmedName);
                         developerRepository.insertIfAbsent(trimmedName);
                         return developerRepository.findByNameIgnoreCase(trimmedName).orElseThrow();
                     });
@@ -157,6 +158,7 @@ public class SteamAppDetailService {
             if (!seenPublishers.add(normalizedKey)) continue;
             final Publisher pub = publisherRepository.findByNameIgnoreCase(trimmedName)
                     .orElseGet(() -> {
+                        publisherRepository.lockByNameIgnoreCase(trimmedName);
                         publisherRepository.insertIfAbsent(trimmedName);
                         return publisherRepository.findByNameIgnoreCase(trimmedName).orElseThrow();
                     });
@@ -173,6 +175,7 @@ public class SteamAppDetailService {
             if (!seenCategories.add(normalizedKey)) continue;
             final Category g = categoryRepository.findByDescriptionIgnoreCase(trimmedDesc)
                     .orElseGet(() -> {
+                        categoryRepository.lockByDescriptionIgnoreCase(trimmedDesc);
                         categoryRepository.insertIfAbsent(trimmedDesc);
                         return categoryRepository.findByDescriptionIgnoreCase(trimmedDesc).orElseThrow();
                     });
@@ -189,6 +192,7 @@ public class SteamAppDetailService {
             if (!seenGenres.add(normalizedKey)) continue;
             final Genre g = genreRepository.findByDescriptionIgnoreCase(trimmedDesc)
                     .orElseGet(() -> {
+                        genreRepository.lockByDescriptionIgnoreCase(trimmedDesc);
                         genreRepository.insertIfAbsent(trimmedDesc);
                         return genreRepository.findByDescriptionIgnoreCase(trimmedDesc).orElseThrow();
                     });

--- a/backend/src/main/java/org/steam5/domain/details/SteamAppDetailService.java
+++ b/backend/src/main/java/org/steam5/domain/details/SteamAppDetailService.java
@@ -55,7 +55,10 @@ public class SteamAppDetailService {
         if (trimmed.isEmpty()) return null;
         if (trimmed.startsWith("//")) return "https:" + trimmed;
         if (trimmed.startsWith("http://")) return "https://" + trimmed.substring(7);
-        return trimmed;
+        if (trimmed.startsWith("https://")) return trimmed;
+        // Only http(s) sources are allowed; drop anything else (file:, ftp:, …)
+        // so a non-HTTP URL can never reach the blurhash fetch pipeline.
+        return null;
     }
 
     private static String joinDlcIds(JsonNode dlcArray) {
@@ -121,10 +124,14 @@ public class SteamAppDetailService {
         detail.getDevelopers().clear();
         detail.getPublisher().clear();
         detail.getGenres().clear();
+        detail.getCategories().clear();
         detail.getScreenshots().clear();
         detail.getMovies().clear();
 
-        // Developers (lookup-or-create by name)
+        // Developers (atomic lookup-or-create by name: INSERT ... ON CONFLICT
+        // DO NOTHING + select — a plain check-then-insert would race concurrent
+        // upserts, the loser would violate the unique constraint and roll back
+        // the whole upsert, permanently excluding an otherwise-fine app)
         Set<String> seenDevelopers = new HashSet<>();
         for (JsonNode devNode : safeArray(data.path("developers"))) {
             final String rawName = devNode.asText(null);
@@ -132,13 +139,15 @@ public class SteamAppDetailService {
             if (StringUtils.isBlank(trimmedName)) continue;
             final String normalizedKey = trimmedName.toLowerCase();
             if (!seenDevelopers.add(normalizedKey)) continue;
-            final Developer dev = developerRepository
-                    .findByNameIgnoreCase(trimmedName)
-                    .orElseGet(() -> developerRepository.save(new Developer(null, trimmedName)));
+            final Developer dev = developerRepository.findByNameIgnoreCase(trimmedName)
+                    .orElseGet(() -> {
+                        developerRepository.insertIfAbsent(trimmedName);
+                        return developerRepository.findByNameIgnoreCase(trimmedName).orElseThrow();
+                    });
             detail.getDevelopers().add(dev);
         }
 
-        // Publishers (lookup-or-create by name)
+        // Publishers (atomic lookup-or-create by name)
         Set<String> seenPublishers = new HashSet<>();
         for (JsonNode pubNode : safeArray(data.path("publishers"))) {
             final String rawName = pubNode.asText(null);
@@ -146,13 +155,15 @@ public class SteamAppDetailService {
             if (StringUtils.isBlank(trimmedName)) continue;
             final String normalizedKey = trimmedName.toLowerCase();
             if (!seenPublishers.add(normalizedKey)) continue;
-            final Publisher pub = publisherRepository
-                    .findByNameIgnoreCase(trimmedName)
-                    .orElseGet(() -> publisherRepository.save(new Publisher(null, trimmedName)));
+            final Publisher pub = publisherRepository.findByNameIgnoreCase(trimmedName)
+                    .orElseGet(() -> {
+                        publisherRepository.insertIfAbsent(trimmedName);
+                        return publisherRepository.findByNameIgnoreCase(trimmedName).orElseThrow();
+                    });
             detail.getPublisher().add(pub);
         }
 
-        // Categories (lookup-or-create by description)
+        // Categories (atomic lookup-or-create by description)
         Set<String> seenCategories = new HashSet<>();
         for (JsonNode genreNode : safeArray(data.path("categories"))) {
             final String rawDesc = genreNode.path("description").asText(null);
@@ -160,13 +171,15 @@ public class SteamAppDetailService {
             if (StringUtils.isBlank(trimmedDesc)) continue;
             final String normalizedKey = trimmedDesc.toLowerCase();
             if (!seenCategories.add(normalizedKey)) continue;
-            final Category g = categoryRepository
-                    .findByDescriptionIgnoreCase(trimmedDesc)
-                    .orElseGet(() -> categoryRepository.save(new Category(null, trimmedDesc)));
+            final Category g = categoryRepository.findByDescriptionIgnoreCase(trimmedDesc)
+                    .orElseGet(() -> {
+                        categoryRepository.insertIfAbsent(trimmedDesc);
+                        return categoryRepository.findByDescriptionIgnoreCase(trimmedDesc).orElseThrow();
+                    });
             detail.getCategories().add(g);
         }
 
-        // Genres (lookup-or-create by description)
+        // Genres (atomic lookup-or-create by description)
         Set<String> seenGenres = new HashSet<>();
         for (JsonNode genreNode : safeArray(data.path("genres"))) {
             final String rawDesc = genreNode.path("description").asText(null);
@@ -174,9 +187,11 @@ public class SteamAppDetailService {
             if (StringUtils.isBlank(trimmedDesc)) continue;
             final String normalizedKey = trimmedDesc.toLowerCase();
             if (!seenGenres.add(normalizedKey)) continue;
-            final Genre g = genreRepository
-                    .findByDescriptionIgnoreCase(trimmedDesc)
-                    .orElseGet(() -> genreRepository.save(new Genre(null, trimmedDesc)));
+            final Genre g = genreRepository.findByDescriptionIgnoreCase(trimmedDesc)
+                    .orElseGet(() -> {
+                        genreRepository.insertIfAbsent(trimmedDesc);
+                        return genreRepository.findByDescriptionIgnoreCase(trimmedDesc).orElseThrow();
+                    });
             detail.getGenres().add(g);
         }
 

--- a/backend/src/main/java/org/steam5/http/PublicHttpUrl.java
+++ b/backend/src/main/java/org/steam5/http/PublicHttpUrl.java
@@ -1,0 +1,96 @@
+package org.steam5.http;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * SSRF guard for outbound fetches of untrusted (DB/Steam-sourced) URLs.
+ *
+ * <p>Only http(s) on ports 80/443 is allowed, http is upgraded to https, and
+ * every resolved address must be a public unicast address (no loopback,
+ * link-local, RFC1918, CGNAT, IPv6 ULA, or multicast).</p>
+ */
+public final class PublicHttpUrl {
+
+    private PublicHttpUrl() {
+    }
+
+    /**
+     * Returns an https URI that is safe to open, or empty when the URL must not
+     * be fetched.
+     */
+    public static Optional<URI> httpsTarget(String url) {
+        if (url == null || url.isBlank()) {
+            return Optional.empty();
+        }
+        final URI uri;
+        try {
+            uri = URI.create(url.trim());
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+        final String scheme = uri.getScheme() == null ? null : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            return Optional.empty();
+        }
+        if (uri.getHost() == null || uri.getHost().isBlank() || uri.getUserInfo() != null) {
+            return Optional.empty();
+        }
+        final int port = uri.getPort();
+        if (port != -1 && port != 80 && port != 443) {
+            return Optional.empty();
+        }
+        final URI https;
+        try {
+            final int httpsPort = (port == -1 || port == 80) ? -1 : port;
+            https = new URI("https", null, uri.getHost(), httpsPort, uri.getPath(), uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException ex) {
+            return Optional.empty();
+        }
+        try {
+            for (InetAddress address : InetAddress.getAllByName(https.getHost())) {
+                if (isDisallowedAddress(address)) {
+                    return Optional.empty();
+                }
+            }
+        } catch (UnknownHostException ex) {
+            return Optional.empty();
+        }
+        return Optional.of(https);
+    }
+
+    static boolean isDisallowedAddress(InetAddress address) {
+        if (address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()) {
+            return true;
+        }
+        return isCarrierGradeNat(address) || isUniqueLocalIpv6(address);
+    }
+
+    /** 100.64.0.0/10 — not classified as site-local by {@link InetAddress}. */
+    private static boolean isCarrierGradeNat(InetAddress address) {
+        if (!(address instanceof Inet4Address v4)) {
+            return false;
+        }
+        final byte[] octets = v4.getAddress();
+        final int second = octets[1] & 0xFF;
+        return (octets[0] & 0xFF) == 100 && second >= 64 && second <= 127;
+    }
+
+    /** fc00::/7 unique-local — not classified as site-local by {@link InetAddress}. */
+    private static boolean isUniqueLocalIpv6(InetAddress address) {
+        if (!(address instanceof Inet6Address v6)) {
+            return false;
+        }
+        return (v6.getAddress()[0] & 0xFE) == 0xFC;
+    }
+}

--- a/backend/src/main/java/org/steam5/http/PublicHttpUrl.java
+++ b/backend/src/main/java/org/steam5/http/PublicHttpUrl.java
@@ -1,8 +1,18 @@
 package org.steam5.http;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
@@ -14,7 +24,9 @@ import java.util.Optional;
  *
  * <p>Only http(s) on ports 80/443 is allowed, http is upgraded to https, and
  * every resolved address must be a public unicast address (no loopback,
- * link-local, RFC1918, CGNAT, IPv6 ULA, or multicast).</p>
+ * link-local, RFC1918, CGNAT, IPv6 ULA, multicast, or IPv4-mapped private
+ * literals). Resolved addresses are re-checked immediately before connect to
+ * mitigate DNS rebinding.</p>
  */
 public final class PublicHttpUrl {
 
@@ -54,10 +66,8 @@ public final class PublicHttpUrl {
             return Optional.empty();
         }
         try {
-            for (InetAddress address : InetAddress.getAllByName(https.getHost())) {
-                if (isDisallowedAddress(address)) {
-                    return Optional.empty();
-                }
+            if (!hasOnlyAllowedAddresses(https.getHost())) {
+                return Optional.empty();
             }
         } catch (UnknownHostException ex) {
             return Optional.empty();
@@ -65,15 +75,92 @@ public final class PublicHttpUrl {
         return Optional.of(https);
     }
 
+    /**
+     * Opens an {@link HttpsURLConnection} after validating the URL and pinning
+     * the TCP connection to a freshly resolved public address (DNS rebinding
+     * mitigation).
+     */
+    public static Optional<HttpURLConnection> openHttpsConnection(String url) throws IOException {
+        final Optional<URI> target = httpsTarget(url);
+        if (target.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(openHttpsConnection(target.get()));
+    }
+
+    static HttpURLConnection openHttpsConnection(URI httpsUri) throws IOException {
+        final String host = httpsUri.getHost();
+        final int port = httpsUri.getPort() == -1 ? 443 : httpsUri.getPort();
+        final InetAddress connectAddress = selectConnectAddress(host);
+
+        final HttpsURLConnection conn = (HttpsURLConnection) httpsUri.toURL().openConnection(Proxy.NO_PROXY);
+        conn.setSSLSocketFactory(new PinnedAddressSocketFactory(host, port, connectAddress));
+        conn.setHostnameVerifier((hostname, session) -> hostname.equalsIgnoreCase(host));
+        conn.setInstanceFollowRedirects(false);
+        return conn;
+    }
+
+    private static InetAddress selectConnectAddress(String host) throws IOException {
+        final InetAddress[] resolved;
+        try {
+            resolved = InetAddress.getAllByName(host);
+        } catch (UnknownHostException ex) {
+            throw new IOException("Unable to resolve host", ex);
+        }
+        for (InetAddress address : resolved) {
+            if (!isDisallowedAddress(address)) {
+                return address;
+            }
+        }
+        throw new IOException("Host resolves only to disallowed addresses");
+    }
+
+    private static boolean hasOnlyAllowedAddresses(String host) throws UnknownHostException {
+        for (InetAddress address : InetAddress.getAllByName(host)) {
+            if (isDisallowedAddress(address)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     static boolean isDisallowedAddress(InetAddress address) {
-        if (address.isAnyLocalAddress()
-                || address.isLoopbackAddress()
-                || address.isLinkLocalAddress()
-                || address.isSiteLocalAddress()
-                || address.isMulticastAddress()) {
+        final InetAddress normalized = normalizeAddress(address);
+        if (normalized.isAnyLocalAddress()
+                || normalized.isLoopbackAddress()
+                || normalized.isLinkLocalAddress()
+                || normalized.isSiteLocalAddress()
+                || normalized.isMulticastAddress()) {
             return true;
         }
-        return isCarrierGradeNat(address) || isUniqueLocalIpv6(address);
+        return isCarrierGradeNat(normalized) || isUniqueLocalIpv6(normalized);
+    }
+
+    /** Treat IPv4-compatible/mapped IPv6 literals as their embedded IPv4 address. */
+    private static InetAddress normalizeAddress(InetAddress address) {
+        if (address instanceof Inet6Address v6 && isIpv4MappedAddress(v6)) {
+            try {
+                return extractIpv4FromMapped(v6);
+            } catch (UnknownHostException ex) {
+                return address;
+            }
+        }
+        return address;
+    }
+
+    static boolean isIpv4MappedAddress(Inet6Address v6) {
+        final byte[] octets = v6.getAddress();
+        for (int i = 0; i < 10; i++) {
+            if (octets[i] != 0) {
+                return false;
+            }
+        }
+        return octets[10] == (byte) 0xff && octets[11] == (byte) 0xff;
+    }
+
+    private static InetAddress extractIpv4FromMapped(Inet6Address v6) throws UnknownHostException {
+        final byte[] octets = v6.getAddress();
+        return InetAddress.getByAddress(new byte[]{octets[12], octets[13], octets[14], octets[15]});
     }
 
     /** 100.64.0.0/10 — not classified as site-local by {@link InetAddress}. */
@@ -92,5 +179,77 @@ public final class PublicHttpUrl {
             return false;
         }
         return (v6.getAddress()[0] & 0xFE) == 0xFC;
+    }
+
+    /**
+     * Connects to a pre-validated IP while preserving SNI/certificate checks for
+     * the original hostname.
+     */
+    private static final class PinnedAddressSocketFactory extends SSLSocketFactory {
+        private final SSLSocketFactory delegate = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        private final String hostname;
+        private final int port;
+        private final InetAddress address;
+
+        private PinnedAddressSocketFactory(String hostname, int port, InetAddress address) {
+            this.hostname = hostname;
+            this.port = port;
+            this.address = address;
+        }
+
+        @Override
+        public Socket createSocket() throws IOException {
+            return configure(createPlainSocket());
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            return configure(createPlainSocket());
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+            return configure(createPlainSocket());
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            return configure(createPlainSocket());
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+                throws IOException {
+            return configure(createPlainSocket());
+        }
+
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return delegate.getDefaultCipherSuites();
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return delegate.getSupportedCipherSuites();
+        }
+
+        @Override
+        public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+            return configure(delegate.createSocket(socket, this.hostname, this.port, autoClose));
+        }
+
+        private Socket createPlainSocket() throws IOException {
+            final Socket socket = new Socket(Proxy.NO_PROXY);
+            socket.connect(new InetSocketAddress(address, this.port), 15_000);
+            return socket;
+        }
+
+        private SSLSocket configure(Socket socket) throws IOException {
+            final SSLSocket ssl = (SSLSocket) delegate.createSocket(socket, hostname, port, true);
+            final SSLParameters params = ssl.getSSLParameters();
+            params.setServerNames(java.util.List.of(new SNIHostName(hostname)));
+            ssl.setSSLParameters(params);
+            return ssl;
+        }
     }
 }

--- a/backend/src/main/java/org/steam5/job/ReviewGameStateJob.java
+++ b/backend/src/main/java/org/steam5/job/ReviewGameStateJob.java
@@ -50,13 +50,25 @@ public class ReviewGameStateJob implements Job {
                 context.getJobDetail().getKey(), context.getFireTime(), context.getScheduledFireTime(), context.getRefireCount());
         try {
             final var picks = service.generateDailyPicks();
-            lastSuccessEpochSeconds.set(System.currentTimeMillis() / 1000L);
-            lastSuccessSize.set(picks == null ? 0L : picks.size());
-            Counter.builder("steam5.daily.picks.generated")
-                    .description("Daily-picks generation runs by outcome")
-                    .tag("outcome", "success")
-                    .register(meterRegistry)
-                    .increment();
+            if (picks != null && !picks.isEmpty()) {
+                lastSuccessEpochSeconds.set(System.currentTimeMillis() / 1000L);
+                lastSuccessSize.set(picks.size());
+                Counter.builder("steam5.daily.picks.generated")
+                        .description("Daily-picks generation runs by outcome")
+                        .tag("outcome", "success")
+                        .register(meterRegistry)
+                        .increment();
+            } else {
+                // An empty result means generation produced no picks (e.g. Steam
+                // outage). Recording it as success would silence the
+                // Steam5DailyPicksMissing alert for a day without a game.
+                log.warn("ReviewGameState generation produced no picks; recording failure outcome");
+                Counter.builder("steam5.daily.picks.generated")
+                        .description("Daily-picks generation runs by outcome")
+                        .tag("outcome", "failure")
+                        .register(meterRegistry)
+                        .increment();
+            }
         } catch (Exception e) {
             log.error("ReviewGameState generation failed", e);
             Counter.builder("steam5.daily.picks.generated")

--- a/backend/src/main/java/org/steam5/repository/DailyPickLockRepository.java
+++ b/backend/src/main/java/org/steam5/repository/DailyPickLockRepository.java
@@ -1,7 +1,6 @@
 package org.steam5.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,10 +10,15 @@ import java.time.LocalDate;
 
 public interface DailyPickLockRepository extends JpaRepository<DailyPickLock, LocalDate> {
 
+    /**
+     * Non-blocking per-day generation lock. The previous {@code INSERT ... ON
+     * CONFLICT DO NOTHING} blocked on the unique index for the whole duration of
+     * the winner's transaction (which used to span slow Steam enrichment); with
+     * the production {@code statement_timeout} that turned concurrent day-rollover
+     * requests into 500s. {@code pg_try_advisory_xact_lock} returns immediately
+     * and is released automatically when the transaction ends.
+     */
     @Transactional
-    @Modifying(clearAutomatically = false, flushAutomatically = false)
-    @Query(value = "INSERT INTO daily_pick_lock(pick_date, created_at) VALUES (:date, now()) ON CONFLICT DO NOTHING", nativeQuery = true)
-    int tryAcquire(@Param("date") LocalDate date);
+    @Query(value = "SELECT pg_try_advisory_xact_lock(hashtext(:date))", nativeQuery = true)
+    boolean tryAcquire(@Param("date") String date);
 }
-
-

--- a/backend/src/main/java/org/steam5/repository/DailyPickLockRepository.java
+++ b/backend/src/main/java/org/steam5/repository/DailyPickLockRepository.java
@@ -17,8 +17,13 @@ public interface DailyPickLockRepository extends JpaRepository<DailyPickLock, Lo
      * the production {@code statement_timeout} that turned concurrent day-rollover
      * requests into 500s. {@code pg_try_advisory_xact_lock} returns immediately
      * and is released automatically when the transaction ends.
+     *
+     * <p>Two-key form namespaces this lock class ({@code daily-pick-lock}) so a
+     * 32-bit {@code hashtext(date)} collision cannot block an unrelated advisory
+     * lock, and two dates hashing to the same int still contend only within
+     * this namespace.</p>
      */
     @Transactional
-    @Query(value = "SELECT pg_try_advisory_xact_lock(hashtext(:date))", nativeQuery = true)
+    @Query(value = "SELECT pg_try_advisory_xact_lock(hashtext('daily-pick-lock'), hashtext(:date))", nativeQuery = true)
     boolean tryAcquire(@Param("date") String date);
 }

--- a/backend/src/main/java/org/steam5/repository/ReviewGamePickRepository.java
+++ b/backend/src/main/java/org/steam5/repository/ReviewGamePickRepository.java
@@ -16,10 +16,12 @@ import java.util.Optional;
 public interface ReviewGamePickRepository extends JpaRepository<ReviewGamePick, Long> {
 
     /**
-     * Returns all picks for one challenge day.
+     * Returns all picks for one challenge day, ordered by the player-visible
+     * round index (legacy rows without a round index fall back to id order).
      * Uses the index on review_game_pick.pick_date (idx_pick_date / equivalent).
      */
-    List<ReviewGamePick> findByPickDate(LocalDate pickDate);
+    @Query("SELECT p FROM ReviewGamePick p WHERE p.pickDate = :pickDate ORDER BY p.roundIndex ASC NULLS LAST, p.id ASC")
+    List<ReviewGamePick> findByPickDate(@Param("pickDate") LocalDate pickDate);
 
     /**
      * Batch day lookup used to avoid N+1 fetches when multiple dates are processed together.

--- a/backend/src/main/java/org/steam5/repository/details/CategoryRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/CategoryRepository.java
@@ -13,9 +13,17 @@ import java.util.Optional;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByDescriptionIgnoreCase(String description);
 
+    /** Serializes lookup-or-create for the same description across case variants. */
+    @Query(value = "SELECT pg_advisory_xact_lock(hashtext('category-desc'), hashtext(lower(:description)))", nativeQuery = true)
+    void lockByDescriptionIgnoreCase(@Param("description") String description);
+
     /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
     @Modifying(clearAutomatically = false, flushAutomatically = false)
-    @Query(value = "INSERT INTO category(description) VALUES (:description) ON CONFLICT DO NOTHING", nativeQuery = true)
+    @Query(value = """
+            INSERT INTO category(description)
+            SELECT :description
+            WHERE NOT EXISTS (SELECT 1 FROM category c WHERE lower(c.description) = lower(:description))
+            """, nativeQuery = true)
     int insertIfAbsent(@Param("description") String description);
 }
 

--- a/backend/src/main/java/org/steam5/repository/details/CategoryRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/CategoryRepository.java
@@ -1,6 +1,9 @@
 package org.steam5.repository.details;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.steam5.domain.details.Category;
 
@@ -9,6 +12,11 @@ import java.util.Optional;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByDescriptionIgnoreCase(String description);
+
+    /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
+    @Modifying(clearAutomatically = false, flushAutomatically = false)
+    @Query(value = "INSERT INTO category(description) VALUES (:description) ON CONFLICT DO NOTHING", nativeQuery = true)
+    int insertIfAbsent(@Param("description") String description);
 }
 
 

--- a/backend/src/main/java/org/steam5/repository/details/DeveloperRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/DeveloperRepository.java
@@ -1,6 +1,9 @@
 package org.steam5.repository.details;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.steam5.domain.details.Developer;
 
@@ -9,6 +12,11 @@ import java.util.Optional;
 @Repository
 public interface DeveloperRepository extends JpaRepository<Developer, Long> {
     Optional<Developer> findByNameIgnoreCase(String name);
+
+    /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
+    @Modifying(clearAutomatically = false, flushAutomatically = false)
+    @Query(value = "INSERT INTO developer(name) VALUES (:name) ON CONFLICT DO NOTHING", nativeQuery = true)
+    int insertIfAbsent(@Param("name") String name);
 }
 
 

--- a/backend/src/main/java/org/steam5/repository/details/DeveloperRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/DeveloperRepository.java
@@ -13,9 +13,17 @@ import java.util.Optional;
 public interface DeveloperRepository extends JpaRepository<Developer, Long> {
     Optional<Developer> findByNameIgnoreCase(String name);
 
+    /** Serializes lookup-or-create for the same name across case variants. */
+    @Query(value = "SELECT pg_advisory_xact_lock(hashtext('developer-name'), hashtext(lower(:name)))", nativeQuery = true)
+    void lockByNameIgnoreCase(@Param("name") String name);
+
     /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
     @Modifying(clearAutomatically = false, flushAutomatically = false)
-    @Query(value = "INSERT INTO developer(name) VALUES (:name) ON CONFLICT DO NOTHING", nativeQuery = true)
+    @Query(value = """
+            INSERT INTO developer(name)
+            SELECT :name
+            WHERE NOT EXISTS (SELECT 1 FROM developer d WHERE lower(d.name) = lower(:name))
+            """, nativeQuery = true)
     int insertIfAbsent(@Param("name") String name);
 }
 

--- a/backend/src/main/java/org/steam5/repository/details/GenreRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/GenreRepository.java
@@ -13,9 +13,17 @@ import java.util.Optional;
 public interface GenreRepository extends JpaRepository<Genre, Long> {
     Optional<Genre> findByDescriptionIgnoreCase(String description);
 
+    /** Serializes lookup-or-create for the same description across case variants. */
+    @Query(value = "SELECT pg_advisory_xact_lock(hashtext('genre-desc'), hashtext(lower(:description)))", nativeQuery = true)
+    void lockByDescriptionIgnoreCase(@Param("description") String description);
+
     /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
     @Modifying(clearAutomatically = false, flushAutomatically = false)
-    @Query(value = "INSERT INTO genre(description) VALUES (:description) ON CONFLICT DO NOTHING", nativeQuery = true)
+    @Query(value = """
+            INSERT INTO genre(description)
+            SELECT :description
+            WHERE NOT EXISTS (SELECT 1 FROM genre g WHERE lower(g.description) = lower(:description))
+            """, nativeQuery = true)
     int insertIfAbsent(@Param("description") String description);
 }
 

--- a/backend/src/main/java/org/steam5/repository/details/GenreRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/GenreRepository.java
@@ -1,6 +1,9 @@
 package org.steam5.repository.details;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.steam5.domain.details.Genre;
 
@@ -9,6 +12,11 @@ import java.util.Optional;
 @Repository
 public interface GenreRepository extends JpaRepository<Genre, Long> {
     Optional<Genre> findByDescriptionIgnoreCase(String description);
+
+    /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
+    @Modifying(clearAutomatically = false, flushAutomatically = false)
+    @Query(value = "INSERT INTO genre(description) VALUES (:description) ON CONFLICT DO NOTHING", nativeQuery = true)
+    int insertIfAbsent(@Param("description") String description);
 }
 
 

--- a/backend/src/main/java/org/steam5/repository/details/PublisherRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/PublisherRepository.java
@@ -13,9 +13,17 @@ import java.util.Optional;
 public interface PublisherRepository extends JpaRepository<Publisher, Long> {
     Optional<Publisher> findByNameIgnoreCase(String name);
 
+    /** Serializes lookup-or-create for the same name across case variants. */
+    @Query(value = "SELECT pg_advisory_xact_lock(hashtext('publisher-name'), hashtext(lower(:name)))", nativeQuery = true)
+    void lockByNameIgnoreCase(@Param("name") String name);
+
     /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
     @Modifying(clearAutomatically = false, flushAutomatically = false)
-    @Query(value = "INSERT INTO publisher(name) VALUES (:name) ON CONFLICT DO NOTHING", nativeQuery = true)
+    @Query(value = """
+            INSERT INTO publisher(name)
+            SELECT :name
+            WHERE NOT EXISTS (SELECT 1 FROM publisher p WHERE lower(p.name) = lower(:name))
+            """, nativeQuery = true)
     int insertIfAbsent(@Param("name") String name);
 }
 

--- a/backend/src/main/java/org/steam5/repository/details/PublisherRepository.java
+++ b/backend/src/main/java/org/steam5/repository/details/PublisherRepository.java
@@ -1,6 +1,9 @@
 package org.steam5.repository.details;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.steam5.domain.details.Publisher;
 
@@ -9,6 +12,11 @@ import java.util.Optional;
 @Repository
 public interface PublisherRepository extends JpaRepository<Publisher, Long> {
     Optional<Publisher> findByNameIgnoreCase(String name);
+
+    /** Atomic insert-or-ignore used by the lookup-or-create path to avoid check-then-insert races. */
+    @Modifying(clearAutomatically = false, flushAutomatically = false)
+    @Query(value = "INSERT INTO publisher(name) VALUES (:name) ON CONFLICT DO NOTHING", nativeQuery = true)
+    int insertIfAbsent(@Param("name") String name);
 }
 
 

--- a/backend/src/main/java/org/steam5/service/BlurhashService.java
+++ b/backend/src/main/java/org/steam5/service/BlurhashService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.steam5.job.blurhash.BlurHash;
 
+import org.steam5.http.PublicHttpUrl;
+
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -13,6 +15,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -86,25 +89,25 @@ public class BlurhashService {
             return null;
         }
 
-        try {
-            final URI uri = URI.create(url);
-            final String scheme = uri.getScheme();
-            if (scheme == null || !("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
-                // Never fetch non-HTTP sources (file:, ftp:, …) from DB-driven URLs.
-                log.warn("Refusing to fetch blurhash source with unsupported scheme '{}'", scheme);
-                return null;
-            }
+        final Optional<URI> safeTarget = PublicHttpUrl.httpsTarget(url);
+        if (safeTarget.isEmpty()) {
+            log.warn("Refusing to fetch blurhash source: scheme, port, or resolved address is not a public https URL");
+            return null;
+        }
 
-            // Prefer HTTPS for plain-http Steam CDN URLs.
-            final URI target = "http".equalsIgnoreCase(scheme)
-                    ? URI.create("https://" + uri.toString().substring("http://".length()))
-                    : uri;
-            final java.net.HttpURLConnection conn = (java.net.HttpURLConnection) target.toURL().openConnection();
+        try {
+            final java.net.HttpURLConnection conn = (java.net.HttpURLConnection) safeTarget.get().toURL().openConnection();
             try {
                 // Explicit timeouts: a stalled Steam CDN connection must not hang a
                 // Quartz worker indefinitely (the scheduler only has 5 threads).
                 conn.setConnectTimeout(15_000);
                 conn.setReadTimeout(30_000);
+                // Do not follow redirects: a 302 to loopback/link-local would bypass
+                // the pre-connect PublicHttpUrl host check.
+                conn.setInstanceFollowRedirects(false);
+                if (conn.getResponseCode() / 100 != 2) {
+                    return null;
+                }
                 try (InputStream in = conn.getInputStream()) {
                     final BufferedImage img = ImageIO.read(in);
                     if (img == null) return null;

--- a/backend/src/main/java/org/steam5/service/BlurhashService.java
+++ b/backend/src/main/java/org/steam5/service/BlurhashService.java
@@ -82,13 +82,39 @@ public class BlurhashService {
         if (IMAGE_SIZES.get(type) == null) {
             throw new IllegalArgumentException("Invalid type=" + type);
         }
+        if (url == null || url.isBlank()) {
+            return null;
+        }
 
-        try (InputStream in = URI.create(url).toURL().openStream()) {
-            final BufferedImage img = ImageIO.read(in);
-            if (img == null) return null;
-            final String hash = BlurHash.encode(img, 4, 4);
-            final String data = toPngDataUrl(img, IMAGE_SIZES.get(type).width, IMAGE_SIZES.get(type).height);
-            return new Encoded(hash, data);
+        try {
+            final URI uri = URI.create(url);
+            final String scheme = uri.getScheme();
+            if (scheme == null || !("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
+                // Never fetch non-HTTP sources (file:, ftp:, …) from DB-driven URLs.
+                log.warn("Refusing to fetch blurhash source with unsupported scheme '{}'", scheme);
+                return null;
+            }
+
+            // Prefer HTTPS for plain-http Steam CDN URLs.
+            final URI target = "http".equalsIgnoreCase(scheme)
+                    ? URI.create("https://" + uri.toString().substring("http://".length()))
+                    : uri;
+            final java.net.HttpURLConnection conn = (java.net.HttpURLConnection) target.toURL().openConnection();
+            try {
+                // Explicit timeouts: a stalled Steam CDN connection must not hang a
+                // Quartz worker indefinitely (the scheduler only has 5 threads).
+                conn.setConnectTimeout(15_000);
+                conn.setReadTimeout(30_000);
+                try (InputStream in = conn.getInputStream()) {
+                    final BufferedImage img = ImageIO.read(in);
+                    if (img == null) return null;
+                    final String hash = BlurHash.encode(img, 4, 4);
+                    final String data = toPngDataUrl(img, IMAGE_SIZES.get(type).width, IMAGE_SIZES.get(type).height);
+                    return new Encoded(hash, data);
+                }
+            } finally {
+                conn.disconnect();
+            }
         } catch (Exception e) {
             log.error("Error encoding image from url={}", url, e);
             return null;

--- a/backend/src/main/java/org/steam5/service/BlurhashService.java
+++ b/backend/src/main/java/org/steam5/service/BlurhashService.java
@@ -12,7 +12,6 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.net.URI;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
@@ -89,14 +88,13 @@ public class BlurhashService {
             return null;
         }
 
-        final Optional<URI> safeTarget = PublicHttpUrl.httpsTarget(url);
-        if (safeTarget.isEmpty()) {
-            log.warn("Refusing to fetch blurhash source: scheme, port, or resolved address is not a public https URL");
-            return null;
-        }
-
         try {
-            final java.net.HttpURLConnection conn = (java.net.HttpURLConnection) safeTarget.get().toURL().openConnection();
+            final Optional<java.net.HttpURLConnection> connection = PublicHttpUrl.openHttpsConnection(url);
+            if (connection.isEmpty()) {
+                log.warn("Refusing to fetch blurhash source: scheme, port, or resolved address is not a public https URL");
+                return null;
+            }
+            final java.net.HttpURLConnection conn = connection.get();
             try {
                 // Explicit timeouts: a stalled Steam CDN connection must not hang a
                 // Quartz worker indefinitely (the scheduler only has 5 threads).

--- a/backend/src/main/java/org/steam5/service/ReviewGameStateService.java
+++ b/backend/src/main/java/org/steam5/service/ReviewGameStateService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.steam5.config.ReviewGameConfig;
 import org.steam5.domain.GameDate;
+import org.steam5.domain.DailyPickLock;
 import org.steam5.domain.ReviewGamePick;
 import org.steam5.domain.SteamAppReviews;
 import org.steam5.http.SteamApiException;
@@ -41,9 +42,12 @@ public class ReviewGameStateService {
             return existing;
         }
 
-        // Try to acquire a per-day lock to prevent concurrent generation (job vs endpoint)
-        final int acquired = pickLockRepository.tryAcquire(today);
-        if (acquired == 0) {
+        // Try to acquire a per-day lock to prevent concurrent generation (job vs
+        // endpoint). This is a NON-BLOCKING advisory lock — concurrent callers
+        // return immediately instead of blocking on the daily_pick_lock unique
+        // index for the winner's whole (potentially slow) transaction.
+        final boolean acquired = pickLockRepository.tryAcquire(today.toString());
+        if (!acquired) {
             // Another generator is running/just ran; wait briefly for it to finish then return existing
             for (int i = 0; i < 20; i++) { // ~2s total
                 final List<ReviewGamePick> concurrent = pickRepository.findByPickDate(today);
@@ -113,19 +117,57 @@ public class ReviewGameStateService {
             round++;
         }
 
-        // Shuffle picks to avoid deterministic bucket order per round
+        if (picks.isEmpty()) {
+            // A full generation pass produced no picks (e.g. Steam API outage). Do
+            // NOT record the daily lock row — the advisory lock is released at
+            // commit, so later requests can retry generation for the same day.
+            log.warn("Pick generation produced no picks for {}; day remains unlocked for later retry", today);
+            return List.of();
+        }
+
+        // Shuffle picks to avoid deterministic bucket order per round, then assign
+        // the player-visible round index (1..n) AFTER the shuffle so statistics
+        // round labels match the order actually served to players.
         Collections.shuffle(picks);
+        for (int i = 0; i < picks.size(); i++) {
+            picks.get(i).setRoundIndex(i + 1);
+        }
         final List<ReviewGamePick> saved = pickRepository.saveAll(picks);
+        pickLockRepository.save(new DailyPickLock(today, OffsetDateTime.now()));
         log.info("Generated {} review-game picks for {}", saved.size(), today);
 
-        // Enrich picked apps and invalidate caches only when new picks were created
-        if (!saved.isEmpty()) {
-            for (ReviewGamePick p : saved) {
-                enrichPickedApp(p);
-            }
-            evictReviewGameStateAfterCommit();
+        // Blurhash events are @TransactionalEventListener(AFTER_COMMIT): they
+        // MUST be published inside this transaction or they are dropped.
+        for (ReviewGamePick p : saved) {
+            eventPublisher.publishEvent(new BlurhashEncodeRequested(p.getAppId(), null, BlurhashEnqueueListener.Type.SCREENSHOT));
         }
+
+        // Slow Steam enrichment runs AFTER the transaction commits so the lock
+        // and picks are durably visible before the API calls start.
+        enrichPickedAppsAfterCommit(saved);
+        evictReviewGameStateAfterCommit();
         return saved;
+    }
+
+    /**
+     * Runs {@link #enrichPickedApp} for each pick after the generation
+     * transaction commits. Enriching inline (this method is
+     * {@code @Transactional}) would hold the advisory lock and the picks'
+     * transaction open across slow Steam API calls, keeping concurrent
+     * day-rollover requests waiting. With no active transaction (plain unit
+     * test) enrichment runs immediately.
+     */
+    private void enrichPickedAppsAfterCommit(final List<ReviewGamePick> saved) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    saved.forEach(ReviewGameStateService.this::enrichPickedApp);
+                }
+            });
+        } else {
+            saved.forEach(this::enrichPickedApp);
+        }
     }
 
     /**
@@ -182,9 +224,12 @@ public class ReviewGameStateService {
 
     /**
      * Validates an appId by fetching its details. Returns {@code true} if usable.
-     * On a non-usable or errored app, records an exclusion and returns {@code false}.
      * A Steam API 429 (rate limit) is never treated as an exclusion — it aborts
-     * generation by propagating, so we respect the API rather than poisoning the pool.
+     * generation by propagating, so we respect the API rather than poisoning the
+     * pool. Transient failures (5xx, network 599, or any non-Steam exception)
+     * skip the app WITHOUT exclusion so an API outage window cannot permanently
+     * shrink the candidate pool. Only definitive rejections are excluded: Steam
+     * answering {@code success=false} (app gone/unavailable) or a 4xx response.
      */
     private boolean validateAppOrExclude(final Long appId) {
         try {
@@ -198,18 +243,27 @@ public class ReviewGameStateService {
                 log.warn("Steam API rate limited (429) while validating appId {}. Aborting pick generation without exclusion.", appId);
                 throw new RuntimeException(sae); // propagate to stop execution per policy
             }
+            if (sae.getStatusCode() >= 500 || sae.getStatusCode() == 599) {
+                // Transient upstream/network failure — never permanently exclude.
+                log.warn("Transient Steam API failure (HTTP {}) while validating appId {}; skipping without exclusion", sae.getStatusCode(), appId);
+                return false;
+            }
             excludedAppRepository.save(new org.steam5.domain.ExcludedApp(appId, "details fetch error: HTTP " + sae.getStatusCode(), OffsetDateTime.now()));
             return false;
         } catch (Exception e) {
-            excludedAppRepository.save(new org.steam5.domain.ExcludedApp(appId, "details fetch error: " + e.getMessage(), OffsetDateTime.now()));
+            // Unknown failures (parsing, persistence) are treated as transient: a
+            // permanent exclusion here could poison the pool and, during an
+            // outage, lock a day to zero picks.
+            log.warn("Non-Steam failure while validating appId {}; skipping without exclusion", appId, e);
             return false;
         }
     }
 
     /**
      * Refreshes a freshly picked app's data: conditionally re-fetches reviews when
-     * they are stale beyond the configured freshness window, re-fetches details, and
-     * publishes a blurhash-encode request for its screenshots. Failures are logged
+     * they are stale beyond the configured freshness window and re-fetches details.
+     * (Blurhash events are published separately inside the generation transaction.)
+     * Failures are logged
      * and swallowed so one bad app cannot abort the rest of the day's enrichment.
      */
     private void enrichPickedApp(final ReviewGamePick p) {
@@ -236,9 +290,6 @@ public class ReviewGameStateService {
         } catch (Exception e) {
             log.warn("Failed to refresh details for picked appId {}", p.getAppId(), e);
         }
-
-        // Publish an event to enqueue BlurhashScreenshotsJob asynchronously for this appId
-        eventPublisher.publishEvent(new BlurhashEncodeRequested(p.getAppId(), null, BlurhashEnqueueListener.Type.SCREENSHOT));
     }
 
     private final SteamAppReviewsRepository reviewsRepository;

--- a/backend/src/main/java/org/steam5/service/StatisticsService.java
+++ b/backend/src/main/java/org/steam5/service/StatisticsService.java
@@ -268,7 +268,11 @@ public class StatisticsService {
                 : reviewGamePickRepository.findByPickDateIn(pickDates).stream()
                 .collect(Collectors.groupingBy(ReviewGamePick::getPickDate));
         picksByDate.values().forEach(picks -> picks.sort(
-                Comparator.comparing(ReviewGamePick::getCreatedAt).thenComparing(ReviewGamePick::getId)
+                // Player-visible round order: the explicit round index persisted at
+                // generation time; legacy rows (null) fall back to createdAt/id.
+                Comparator.comparing(ReviewGamePick::getRoundIndex, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(ReviewGamePick::getCreatedAt)
+                        .thenComparing(ReviewGamePick::getId)
         ));
 
         return rows.stream()

--- a/backend/src/main/java/org/steam5/service/SteamAppDetailsFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppDetailsFetcher.java
@@ -47,10 +47,25 @@ public class SteamAppDetailsFetcher implements Fetcher {
 
         final long lastAppId = ingestStateRepository.findById("steam_app_details").map(IngestState::getLastAppId).orElse(0L);
         final int batchLimit = Math.max(1, jobsConfig.getSteamAppDetails().getBatchLimit());
-        log.info("Starting details ingestion from appId > {} (batchLimit={})", lastAppId, batchLimit);
+
+        // The cursor is monotonic per pass; once it points past the last app in
+        // the index every run would be a permanent no-op, leaving prices,
+        // screenshots, and descriptions stale forever. Reset it to 0 so the next
+        // run re-walks the index as a refresh pass.
+        long effectiveLastAppId = lastAppId;
+        if (effectiveLastAppId > 0) {
+            final Page<SteamAppIndex> ahead = appIndexRepository.findByAppIdGreaterThan(effectiveLastAppId, PageRequest.of(0, 1, Sort.by("appId").ascending()));
+            if (ahead.isEmpty()) {
+                log.info("Details ingest cursor {} is at/after the last indexed appId; resetting to 0 for the next refresh pass", effectiveLastAppId);
+                ingestStateRepository.upsert("steam_app_details", 0L, OffsetDateTime.now());
+                effectiveLastAppId = 0L;
+            }
+        }
+
+        log.info("Starting details ingestion from appId > {} (batchLimit={})", effectiveLastAppId, batchLimit);
 
         long processed = 0L;
-        Long cursor = lastAppId;
+        Long cursor = effectiveLastAppId;
         final int pageSize = 500; // single HTTP call per app, moderate batch size
         boolean more = true;
         while (more && processed < batchLimit) {
@@ -67,19 +82,20 @@ public class SteamAppDetailsFetcher implements Fetcher {
                 try {
                     fetchForAppId(appId);
                 } catch (Exception e) {
-                    // bail immediately on any HTTP error such as 429
+                    // bail immediately on any HTTP error such as 429. The cursor is
+                    // deliberately NOT advanced: the failed app must be retried on
+                    // the next run instead of being skipped forever.
                     throw e;
-                } finally {
-                    // advance cursor regardless of outcome to avoid getting stuck
-                    ingestStateRepository.upsert("steam_app_details", appId, OffsetDateTime.now());
                 }
+                // advance cursor only on success so transient failures are retried
+                ingestStateRepository.upsert("steam_app_details", appId, OffsetDateTime.now());
                 processed++;
                 cursor = appId;
             }
             more = page.hasNext() && processed < batchLimit;
         }
 
-        log.info("Details ingestion finished. processed={} batchLimit={} starting_after={}", processed, batchLimit, lastAppId);
+        log.info("Details ingestion finished. processed={} batchLimit={} starting_after={}", processed, batchLimit, effectiveLastAppId);
     }
 
     public boolean fetchForAppId(final Long appId) throws IOException {

--- a/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
@@ -74,12 +74,23 @@ public class SteamAppReviewsFetcher implements Fetcher {
                 }
                 final Long appId = idx.getAppId();
                 if (appId == null) continue;
-                fetchForAppId(appId);
+                // Bulk path: skip the aggregate cache clear per app (it would
+                // thrash the whole review-game cache up to batchLimit times per
+                // run); the cache is cleared once at the end of the job below.
+                fetchForAppId(appId, false);
                 ingestStateRepository.upsert("steam_app_reviews", appId, OffsetDateTime.now());
                 processed++;
                 cursor = appId;
             }
             more = page.hasNext() && processed < batchLimit;
+        }
+
+        if (processed > 0) {
+            final var reviewGame = cacheManager.getCache("review-game");
+            if (reviewGame != null) {
+                reviewGame.clear();
+                log.info("Cleared review-game cache after bulk reviews ingestion of {} apps", processed);
+            }
         }
 
         log.info("Reviews ingestion finished. processed={} batchLimit={} starting_after={}", processed, batchLimit, lastAppId);

--- a/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
+++ b/backend/src/main/java/org/steam5/service/SteamAppReviewsFetcher.java
@@ -57,10 +57,24 @@ public class SteamAppReviewsFetcher implements Fetcher {
 
         final long lastAppId = ingestStateRepository.findById("steam_app_reviews").map(IngestState::getLastAppId).orElse(0L);
         final int batchLimit = Math.max(1, jobsConfig.getSteamAppReviews().getBatchLimit());
-        log.info("Starting reviews ingestion from appId > {} (batchLimit={})", lastAppId, batchLimit);
+
+        // Same cursor reset as details ingest: once the pointer is past the last
+        // indexed app every run would be a permanent no-op, leaving review counts
+        // stale forever. Reset to 0 so the next run re-walks as a refresh pass.
+        long effectiveLastAppId = lastAppId;
+        if (effectiveLastAppId > 0) {
+            final Page<SteamAppIndex> ahead = appIndexRepository.findByAppIdGreaterThan(effectiveLastAppId, PageRequest.of(0, 1, Sort.by("appId").ascending()));
+            if (ahead.isEmpty()) {
+                log.info("Reviews ingest cursor {} is at/after the last indexed appId; resetting to 0 for the next refresh pass", effectiveLastAppId);
+                ingestStateRepository.upsert("steam_app_reviews", 0L, OffsetDateTime.now());
+                effectiveLastAppId = 0L;
+            }
+        }
+
+        log.info("Starting reviews ingestion from appId > {} (batchLimit={})", effectiveLastAppId, batchLimit);
 
         long processed = 0L;
-        Long cursor = lastAppId;
+        Long cursor = effectiveLastAppId;
         final int pageSize = 1000; // large batches; single HTTP call per app
         boolean more = true;
         while (more && processed < batchLimit) {
@@ -93,7 +107,7 @@ public class SteamAppReviewsFetcher implements Fetcher {
             }
         }
 
-        log.info("Reviews ingestion finished. processed={} batchLimit={} starting_after={}", processed, batchLimit, lastAppId);
+        log.info("Reviews ingestion finished. processed={} batchLimit={} starting_after={}", processed, batchLimit, effectiveLastAppId);
     }
 
     public boolean fetchForAppId(Long appId) throws IOException {

--- a/backend/src/main/java/org/steam5/web/ReviewGameStateController.java
+++ b/backend/src/main/java/org/steam5/web/ReviewGameStateController.java
@@ -27,6 +27,9 @@ import org.steam5.service.ReviewGameStateService;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.TriggerKey;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -61,6 +64,7 @@ public class ReviewGameStateController {
     private final org.steam5.repository.ReviewGamePickRepository pickRepository;
     private final Scheduler scheduler;
     private final MeterRegistry meterRegistry;
+    private final PlatformTransactionManager transactionManager;
 
     // Live daily data — rounds regenerate at ~00:01 UTC; 30 min CDN window absorbs
     // traffic spikes while keeping staleness bounded. must-revalidate forbids any
@@ -499,13 +503,25 @@ public class ReviewGameStateController {
                     .register(meterRegistry)
                     .increment();
         } catch (DataIntegrityViolationException ignored) {
-            // another request saved the same guess concurrently; return the persisted one
-            final var existing = guessRepository.findBySteamIdAndGameDateAndRoundIndex(steamId, date, roundIndex);
-            if (existing.isPresent()) {
+            // Another request saved the same guess concurrently. The current
+            // transaction is aborted (Postgres 25P02), so any re-read here would
+            // fail too — re-read OUTSIDE it in a fresh read-only transaction and
+            // return the persisted guess to keep concurrent double-submits
+            // idempotent.
+            final TransactionTemplate readOnly = new TransactionTemplate(transactionManager);
+            readOnly.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+            readOnly.setReadOnly(true);
+            final var existing = readOnly.execute(status ->
+                    guessRepository.findBySteamIdAndGameDateAndRoundIndex(steamId, date, roundIndex));
+            if (existing != null && existing.isPresent()) {
                 final var g = existing.get();
                 final boolean alreadyOk = g.getActualBucket() != null && g.getActualBucket().equals(g.getSelectedBucket());
                 return ResponseEntity.ok(new GuessResponse(g.getAppId(), total, g.getActualBucket(), alreadyOk));
             }
+            // Conflict with no persisted row: never fall through to a success
+            // response for a guess that was not saved.
+            log.error("Duplicate-guess conflict resolved without a persisted row: steamId={} date={} roundIndex={}", steamId, date, roundIndex);
+            return ResponseEntity.status(409).body(new GuessResponse(req.appId, total, computedActual, false));
         }
         final boolean ok = isCorrectForLabel(req.bucketGuess, total);
         return ResponseEntity.ok(new GuessResponse(req.appId, total, computedActual, ok));
@@ -655,8 +671,17 @@ public class ReviewGameStateController {
     public ResponseEntity<HistoricalAlwaysPickResponse> alwaysPickHistory(
             @RequestParam(value = "from", required = false) String from,
             @RequestParam(value = "to", required = false) String to) {
-        final java.time.LocalDate start = from == null || from.isBlank() ? java.time.LocalDate.of(1970, 1, 1) : java.time.LocalDate.parse(from);
-        final java.time.LocalDate end = to == null || to.isBlank() ? GameDate.todayUtc() : java.time.LocalDate.parse(to);
+        // Malformed dates must 400, not 500. (Unbounded ranges are safe: the
+        // computation iterates only pick dates that actually exist in range,
+        // not every calendar day between from and to.)
+        final java.time.LocalDate start;
+        final java.time.LocalDate end;
+        try {
+            start = from == null || from.isBlank() ? java.time.LocalDate.of(1970, 1, 1) : java.time.LocalDate.parse(from);
+            end = to == null || to.isBlank() ? GameDate.todayUtc() : java.time.LocalDate.parse(to);
+        } catch (java.time.format.DateTimeParseException e) {
+            return ResponseEntity.badRequest().build();
+        }
         if (end.isBefore(start)) return ResponseEntity.badRequest().build();
         final var result = computeAlwaysPickForRange(start, end);
         return ResponseEntity.ok()
@@ -687,16 +712,20 @@ public class ReviewGameStateController {
             picksByDate.computeIfAbsent(pick.getPickDate(), ignored -> new ArrayList<>()).add(pick);
         }
         picksByDate.values().forEach(picks -> picks.sort(
-                Comparator.comparing(ReviewGamePick::getCreatedAt).thenComparing(ReviewGamePick::getId)
+                // Match the player-visible round order (explicit round index,
+                // legacy rows fall back to createdAt/id).
+                Comparator.comparing(org.steam5.domain.ReviewGamePick::getRoundIndex, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(org.steam5.domain.ReviewGamePick::getCreatedAt)
+                        .thenComparing(org.steam5.domain.ReviewGamePick::getId)
         ));
 
-        java.time.LocalDate d = start;
-        while (!d.isAfter(end)) {
-            final List<org.steam5.domain.ReviewGamePick> picks = picksByDate.getOrDefault(d, List.of());
-            if (!picks.isEmpty()) {
-                for (org.steam5.domain.ReviewGamePick p : picks) appIds.add(p.getAppId());
-            }
-            d = d.plusDays(1);
+        // Iterate only the pick dates that actually exist in range, in
+        // chronological order. Iterating every calendar day between start and
+        // end (potentially millions of empty days for to=9999-12-31) was an
+        // anonymous CPU DoS; days without picks contribute nothing.
+        for (LocalDate d : picksByDate.keySet().stream().sorted().toList()) {
+            final List<org.steam5.domain.ReviewGamePick> picks = picksByDate.get(d);
+            for (org.steam5.domain.ReviewGamePick p : picks) appIds.add(p.getAppId());
         }
         final List<String> actualBuckets = appIds.stream()
                 .map(id -> service.inferBucket(service.getTotalReviewCountForApp(id)))

--- a/backend/src/main/java/org/steam5/web/ReviewGameStateController.java
+++ b/backend/src/main/java/org/steam5/web/ReviewGameStateController.java
@@ -521,7 +521,9 @@ public class ReviewGameStateController {
             // Conflict with no persisted row: never fall through to a success
             // response for a guess that was not saved.
             log.error("Duplicate-guess conflict resolved without a persisted row: steamId={} date={} roundIndex={}", steamId, date, roundIndex);
-            return ResponseEntity.status(409).body(new GuessResponse(req.appId, total, computedActual, false));
+            // Empty 409: do not return totalReviews/actualBucket for a guess that
+            // was not saved (that would leak today's answer for a retry).
+            return ResponseEntity.status(409).build();
         }
         final boolean ok = isCorrectForLabel(req.bucketGuess, total);
         return ResponseEntity.ok(new GuessResponse(req.appId, total, computedActual, ok));

--- a/backend/src/test/java/org/steam5/ReviewGameStateServiceTest.java
+++ b/backend/src/test/java/org/steam5/ReviewGameStateServiceTest.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.steam5.config.ReviewGameConfig;
 import org.steam5.domain.GameDate;
 import org.steam5.domain.ReviewGamePick;
+import org.steam5.http.SteamApiException;
 import org.steam5.job.events.BlurhashEncodeRequested;
 import org.steam5.repository.DailyPickLockRepository;
 import org.steam5.repository.ExcludedAppRepository;
@@ -70,7 +71,7 @@ public class ReviewGameStateServiceTest {
         config.setMinReviewsFreshDays(0);
 
         // Lock acquired
-        when(pickLockRepository.tryAcquire(any())).thenReturn(1);
+        when(pickLockRepository.tryAcquire(any())).thenReturn(true);
 
         // No existing picks
         when(pickRepository.findByPickDate(any(LocalDate.class))).thenReturn(List.of());
@@ -136,6 +137,31 @@ public class ReviewGameStateServiceTest {
         }
         // Ensure event published for each
         verify(eventPublisher, atLeast(5)).publishEvent(any(BlurhashEncodeRequested.class));
+    }
+
+    @Test
+    void generateDailyPicks_assignsPlayerVisibleRoundIndexes() {
+        // Round numbers must match the order players actually see (post-shuffle
+        // order), so statistics round labels can rely on them.
+        final List<ReviewGamePick> picks = service.generateDailyPicks();
+        assertEquals(5, picks.size());
+        final List<Integer> indexes = picks.stream().map(ReviewGamePick::getRoundIndex).toList();
+        assertEquals(List.of(1, 2, 3, 4, 5), indexes);
+    }
+
+    @Test
+    void generateDailyPicks_transientSteamFailure_producesNoPicksNoLockNoExclusions() throws Exception {
+        // A Steam API outage during generation must not permanently exclude
+        // candidates nor lock the day to zero picks.
+        doThrow(new SteamApiException(599, "https://store.steampowered.com/api/appdetails?appids=1&key=abc", "Network error"))
+                .when(detailsFetcher).fetchForAppId(anyLong());
+
+        final List<ReviewGamePick> picks = service.generateDailyPicks();
+
+        assertTrue(picks.isEmpty());
+        verify(pickLockRepository, never()).save(any());
+        verify(excludedAppRepository, never()).save(any());
+        verify(pickRepository, never()).saveAll(anyList());
     }
 
     private ReviewGameStateService stubbedServiceFor(ReviewGameStateService.BUCKET_STRATEGY strategy) {

--- a/backend/src/test/java/org/steam5/http/PublicHttpUrlTest.java
+++ b/backend/src/test/java/org/steam5/http/PublicHttpUrlTest.java
@@ -2,6 +2,7 @@ package org.steam5.http;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -29,6 +30,9 @@ class PublicHttpUrlTest {
         assertTrue(PublicHttpUrl.httpsTarget("https://100.64.0.1/img.png").isEmpty());
         assertTrue(PublicHttpUrl.httpsTarget("https://[::1]/img.png").isEmpty());
         assertTrue(PublicHttpUrl.httpsTarget("https://[fc00::1]/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://[::ffff:127.0.0.1]/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://[::ffff:7f00:1]/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://[::ffff:10.0.0.1]/img.png").isEmpty());
     }
 
     @Test
@@ -47,6 +51,12 @@ class PublicHttpUrlTest {
         assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("100.64.1.1")));
         assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("::1")));
         assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("fc00::1")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("::ffff:127.0.0.1")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("::ffff:10.0.0.1")));
+        final InetAddress mappedPublic = InetAddress.getByName("::ffff:8.8.8.8");
+        if (mappedPublic instanceof Inet6Address inet6Address) {
+            assertTrue(PublicHttpUrl.isIpv4MappedAddress(inet6Address));
+        }
         assertFalse(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("8.8.8.8")));
         assertFalse(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("1.1.1.1")));
     }

--- a/backend/src/test/java/org/steam5/http/PublicHttpUrlTest.java
+++ b/backend/src/test/java/org/steam5/http/PublicHttpUrlTest.java
@@ -1,0 +1,53 @@
+package org.steam5.http;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PublicHttpUrlTest {
+
+    @Test
+    void rejectsNonHttpSchemes() {
+        assertTrue(PublicHttpUrl.httpsTarget("file:///etc/passwd").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("ftp://example.com/a.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("javascript:alert(1)").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget(null).isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("").isEmpty());
+    }
+
+    @Test
+    void rejectsPrivateAndMetadataIpLiterals() {
+        assertTrue(PublicHttpUrl.httpsTarget("https://127.0.0.1/x").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("http://10.0.0.5/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://192.168.1.10/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://172.16.0.1/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("http://169.254.169.254/latest/meta-data").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://100.64.0.1/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://[::1]/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://[fc00::1]/img.png").isEmpty());
+    }
+
+    @Test
+    void rejectsNonStandardPortsAndUserInfo() {
+        assertTrue(PublicHttpUrl.httpsTarget("https://example.com:8080/img.png").isEmpty());
+        assertTrue(PublicHttpUrl.httpsTarget("https://user:pass@example.com/img.png").isEmpty());
+    }
+
+    @Test
+    void classifiesReservedAddressesWithoutDns() throws UnknownHostException {
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("127.0.0.1")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("10.1.2.3")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("192.168.0.1")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("172.31.255.255")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("169.254.169.254")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("100.64.1.1")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("::1")));
+        assertTrue(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("fc00::1")));
+        assertFalse(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("8.8.8.8")));
+        assertFalse(PublicHttpUrl.isDisallowedAddress(InetAddress.getByName("1.1.1.1")));
+    }
+}

--- a/backend/src/test/java/org/steam5/service/BlurhashServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/BlurhashServiceTest.java
@@ -1,0 +1,19 @@
+package org.steam5.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BlurhashServiceTest {
+
+    private final BlurhashService service = new BlurhashService();
+
+    @Test
+    void readAndEncode_rejectsNonPublicUrlsWithoutOpeningAConnection() {
+        assertNull(service.readAndEncode("file:///etc/passwd", BlurhashService.Type.THUMBNAIL));
+        assertNull(service.readAndEncode("ftp://example.com/a.png", BlurhashService.Type.THUMBNAIL));
+        assertNull(service.readAndEncode("https://127.0.0.1/img.png", BlurhashService.Type.THUMBNAIL));
+        assertNull(service.readAndEncode("http://169.254.169.254/latest/meta-data", BlurhashService.Type.THUMBNAIL));
+        assertNull(service.readAndEncode("https://example.com:8443/img.png", BlurhashService.Type.THUMBNAIL));
+    }
+}

--- a/backend/src/test/java/org/steam5/service/BlurhashServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/BlurhashServiceTest.java
@@ -13,6 +13,7 @@ class BlurhashServiceTest {
         assertNull(service.readAndEncode("file:///etc/passwd", BlurhashService.Type.THUMBNAIL));
         assertNull(service.readAndEncode("ftp://example.com/a.png", BlurhashService.Type.THUMBNAIL));
         assertNull(service.readAndEncode("https://127.0.0.1/img.png", BlurhashService.Type.THUMBNAIL));
+        assertNull(service.readAndEncode("https://[::ffff:127.0.0.1]/img.png", BlurhashService.Type.THUMBNAIL));
         assertNull(service.readAndEncode("http://169.254.169.254/latest/meta-data", BlurhashService.Type.THUMBNAIL));
         assertNull(service.readAndEncode("https://example.com:8443/img.png", BlurhashService.Type.THUMBNAIL));
     }

--- a/backend/src/test/java/org/steam5/web/ReviewGameStateControllerCacheTest.java
+++ b/backend/src/test/java/org/steam5/web/ReviewGameStateControllerCacheTest.java
@@ -10,6 +10,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.steam5.domain.GameDate;
 import org.steam5.domain.Guess;
 import org.steam5.domain.ReviewGamePick;
@@ -69,7 +70,8 @@ public class ReviewGameStateControllerCacheTest {
         scheduler = mock(Scheduler.class);
         meterRegistry = mock(MeterRegistry.class);
         controller = new ReviewGameStateController(service, detailRepository, guessRepository,
-                reviewsRepository, userRepository, pickRepository, scheduler, meterRegistry);
+                reviewsRepository, userRepository, pickRepository, scheduler, meterRegistry,
+                mock(PlatformTransactionManager.class));
     }
 
     // --- Finding 2: per-user data must never be publicly cacheable ---

--- a/backend/src/test/java/org/steam5/web/ReviewGameStateControllerRandomArchiveTest.java
+++ b/backend/src/test/java/org/steam5/web/ReviewGameStateControllerRandomArchiveTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.quartz.Scheduler;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.steam5.domain.GameDate;
 import org.steam5.repository.GuessRepository;
 import org.steam5.repository.ReviewGamePickRepository;
@@ -14,11 +15,13 @@ import org.steam5.repository.details.SteamAppDetailRepository;
 import org.steam5.service.ReviewGameStateService;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +42,8 @@ public class ReviewGameStateControllerRandomArchiveTest {
         final Scheduler scheduler = mock(Scheduler.class);
         final MeterRegistry meterRegistry = mock(MeterRegistry.class);
         controller = new ReviewGameStateController(service, detailRepository, guessRepository,
-                reviewsRepository, userRepository, pickRepository, scheduler, meterRegistry);
+                reviewsRepository, userRepository, pickRepository, scheduler, meterRegistry,
+                mock(PlatformTransactionManager.class));
     }
 
     @Test
@@ -62,5 +66,20 @@ public class ReviewGameStateControllerRandomArchiveTest {
 
         assertEquals(404, res.getStatusCode().value());
         assertNull(res.getBody());
+    }
+
+    @Test
+    void alwaysPickHistory_malformedDatesReturn400() {
+        when(pickRepository.findByPickDateBetween(any(), any())).thenReturn(List.of());
+        assertEquals(400, controller.alwaysPickHistory("2024-13-99", null).getStatusCode().value());
+        assertEquals(400, controller.alwaysPickHistory("2024-01-01", "garbage").getStatusCode().value());
+        assertEquals(400, controller.alwaysPickHistory("2024-12-31", "2024-01-01").getStatusCode().value());
+    }
+
+    @Test
+    void alwaysPickHistory_validRangeReturns200() {
+        when(pickRepository.findByPickDateBetween(any(), any())).thenReturn(List.of());
+        final var res = controller.alwaysPickHistory("2024-01-01", "2024-01-31");
+        assertEquals(200, res.getStatusCode().value());
     }
 }


### PR DESCRIPTION
Closes #145
Closes #149
Closes #150
Closes #151
Closes #152
Closes #154
Closes #155
Closes #156
Closes #170

## Problem & Fix

**#145 Transient Steam failures permanently exclude candidates (HIGH)**
Every non-429 failure wrote a permanent `excluded_app` row; a zero-pick generation still committed the daily lock, locking the day to zero picks. Fix: 5xx/599/unknown errors skip the app without exclusion (only `success=false` and 4xx exclude); zero-pick generations no longer record the lock row so the day can regenerate; `ReviewGameStateJob` only records success when picks are non-empty.

**#149 Details ingest cursor advances past failures and never resets (MEDIUM)**
Fix: cursor advances only on success (failed apps retried next run) and resets to 0 when it reaches the end of the app index, making subsequent runs refresh passes.

**#150 Bulk reviews ingest clears the review-game cache per app (MEDIUM)**
Fix: the ingest loop passes `clearReviewGameAggregates=false` and clears the cache once at the end of the run (matching the documented design and the refresh job).

**#151 Duplicate-guess race returns 500 or silent success (MEDIUM)**
The re-read after `DataIntegrityViolationException` ran on the aborted transaction (25P02 → 500), and a missing row fell through to a success response. Fix: re-read in a `REQUIRES_NEW` read-only transaction via `TransactionTemplate`; if still absent, return 409 instead of a fake success.

**#152 always-pick unbounded range DoS + 500 on malformed dates (MEDIUM)**
Fix: malformed dates return 400. Deviation from the plan's "reject spans > 3660 days": the frontend's no-parameter "all time" view would have started 400ing, so instead the computation now iterates only the pick dates that actually exist in range (days without picks contributed nothing) — the unbounded day-by-day loop is gone entirely and the DB query stays index-bounded.

**#154 Pick-lock INSERT blocks concurrent requests (MEDIUM)**
Fix: the lock is now `pg_try_advisory_xact_lock` (returns immediately, released at commit), the lock row is only recorded after successful generation, and Steam enrichment runs after commit (`afterCommit` synchronization) so the transaction commits quickly. Blurhash events are still published inside the transaction — their listener is `@TransactionalEventListener(AFTER_COMMIT)` and would silently drop post-commit events.

**#155 Detail upsert never clears categories; lookup-or-create races (MEDIUM)**
Fix: categories are cleared alongside the other children on full refresh; developer/publisher/category/genre lookups use `INSERT ... ON CONFLICT DO NOTHING` + re-select instead of check-then-insert (which rolled back the whole upsert and permanently excluded the app). The case-insensitive unique index was skipped — the DB unique constraints are case-sensitive and adding a `LOWER(name)` index could fail on pre-existing case-variant rows; the Java-side fix closes the race.

**#156 Blurhash fetch: no timeouts, no scheme validation (MEDIUM)**
Fix: `HttpURLConnection` with 15s connect / 30s read timeouts; scheme must be http/https (http upgraded to https); `normalizeToHttps` drops other schemes (`file:`, `ftp:`, …) instead of passing them through.

**#170 Top-games round labels don't match player-visible order (LOW)**
Fix: `ReviewGamePick` persists an explicit `round_index` assigned after the shuffle; the day query (`findByPickDate`) and the statistics ordering use it (legacy null rows fall back to createdAt/id).

## Tests
- `./gradlew test`: BUILD SUCCESSFUL (incl. new round-index, transient-failure/no-lock, and always-pick 400 tests)
- Boot smoke test against local Postgres: `round_index` column added by ddl-auto; `/api/review-game/today` 200 with unchanged pick order; anonymous guess 200; always-pick malformed date 400, no-params 200, `from=1970-01-01&to=9999-12-31` 200 (fast); advisory-lock query returns `t`; `/api/stats/game` 200 with roundIndex labels
