### PR TITLE
Fix audit season/job findings: finalization guards, backward backfill, failure visibility, cache keys

### DIFF
--- a/backend/src/main/java/org/steam5/domain/SeasonAwardResult.java
+++ b/backend/src/main/java/org/steam5/domain/SeasonAwardResult.java
@@ -8,7 +8,9 @@ import lombok.NoArgsConstructor;
 import java.time.OffsetDateTime;
 
 @Entity
-@Table(name = "season_award_results", indexes = {
+@Table(name = "season_award_results", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_season_award_result", columnNames = {"season_id", "category", "placement_level"})
+}, indexes = {
         @Index(name = "ix_season_award_category", columnList = "season_id,category"),
         @Index(name = "ix_season_award_player", columnList = "steam_id")
 })

--- a/backend/src/main/java/org/steam5/job/PlayerSpotlightJob.java
+++ b/backend/src/main/java/org/steam5/job/PlayerSpotlightJob.java
@@ -27,6 +27,8 @@ public class PlayerSpotlightJob implements Job {
             playerSpotlightService.computeAndPersistForToday();
         } catch (Exception ex) {
             log.error("PlayerSpotlight computation failed", ex);
+            // Rethrow so Quartz records the failure instead of reporting success.
+            throw new JobExecutionException(ex, false);
         } finally {
             long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
             log.info("PlayerSpotlightJob completed in {}ms; next fire {}",

--- a/backend/src/main/java/org/steam5/job/SeasonBackfillJob.java
+++ b/backend/src/main/java/org/steam5/job/SeasonBackfillJob.java
@@ -33,6 +33,8 @@ public class SeasonBackfillJob implements Job {
             }
         } catch (Exception ex) {
             log.error("Season backfill failed", ex);
+            // Rethrow so Quartz records the failure instead of reporting success.
+            throw new JobExecutionException(ex, false);
         } finally {
             long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
             log.info("SeasonBackfillJob completed in {}ms; next fire {}",

--- a/backend/src/main/java/org/steam5/job/SeasonFinalizerJob.java
+++ b/backend/src/main/java/org/steam5/job/SeasonFinalizerJob.java
@@ -57,6 +57,10 @@ public class SeasonFinalizerJob implements Job {
             leaderboardRefreshService.refreshSeason();
         } catch (Exception ex) {
             log.error("Season finalization failed", ex);
+            // Rethrow so Quartz records the failure: a failed season rollover
+            // must be visible in metrics/alerts and refired, not silently lost
+            // until the next cron tick (same pattern as ReviewGameStateJob).
+            throw new JobExecutionException(ex, false);
         } finally {
             // Unconditional, matching LeaderboardRefreshJob's pattern: cheap and harmless even
             // if refreshSeason() above failed or wasn't reached, and prevents a request that

--- a/backend/src/main/java/org/steam5/repository/SeasonRepository.java
+++ b/backend/src/main/java/org/steam5/repository/SeasonRepository.java
@@ -1,6 +1,9 @@
 package org.steam5.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.steam5.domain.Season;
 import org.steam5.domain.SeasonStatus;
 
@@ -14,11 +17,34 @@ public interface SeasonRepository extends JpaRepository<Season, Long> {
 
     Optional<Season> findTopByOrderBySeasonNumberDesc();
 
+    Optional<Season> findFirstByOrderBySeasonNumberAsc();
+
     Optional<Season> findByStartDateLessThanEqualAndEndDateGreaterThanEqual(LocalDate startInclusive, LocalDate endInclusive);
 
     List<Season> findAllByStatusOrderBySeasonNumberAsc(SeasonStatus status);
 
     List<Season> findAllByOrderBySeasonNumberDesc();
+
+    /**
+     * Atomically claims a season for finalization: only an ACTIVE season can be
+     * claimed, and only one concurrent finalizer wins (exactly 1 row updated).
+     * The status flip happens before any award computation, so a second instance
+     * (or a re-finalization attempt) sees zero rows and must skip.
+     */
+    @Modifying
+    @Query("UPDATE Season s SET s.status = org.steam5.domain.SeasonStatus.FINALIZED WHERE s.id = :id AND s.status = org.steam5.domain.SeasonStatus.ACTIVE")
+    int claimForFinalization(@Param("id") Long id);
+
+    /**
+     * Shifts all season numbers up by {@code shift} in one statement. Callers
+     * must ensure no collision with the unique season_number index (used by the
+     * historical backfill to make room for seasons before season #1).
+     * {@code clearAutomatically} is required: the persistence context still
+     * holds the pre-shift season numbers, and any subsequent read would
+     * otherwise return stale entities (e.g. a forward fill inserting a
+     * colliding season number).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "UPDATE seasons SET season_number = season_number + :shift", nativeQuery = true)
+    int shiftSeasonNumbersUpBy(@Param("shift") int shift);
 }
-
-

--- a/backend/src/main/java/org/steam5/service/SeasonService.java
+++ b/backend/src/main/java/org/steam5/service/SeasonService.java
@@ -16,6 +16,8 @@ import org.steam5.domain.StreakCalculator;
 import org.steam5.repository.GuessRepository;
 import org.steam5.repository.SeasonAwardResultRepository;
 import org.steam5.repository.SeasonRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -183,10 +185,32 @@ public class SeasonService {
         }
 
         final List<Season> created = new ArrayList<>();
+
+        // Backward fill: when the earliest season starts AFTER the earliest guess
+        // date (typically because an on-demand ensureSeasonForDate seeded season #1
+        // at "today"), all historical guesses before it would stay outside any
+        // season forever. Shift the existing seasons up to make room, then create
+        // the missing early seasons so season #1 starts at the earliest data.
+        final Optional<Season> earliest = seasonRepository.findFirstByOrderBySeasonNumberAsc();
+        if (earliest.isPresent() && earliest.get().getStartDate().isAfter(startInclusive)) {
+            final int missing = missingSeasonCount(startInclusive, earliest.get().getStartDate());
+            if (missing > 0) {
+                // Two-step shift avoids unique-index collisions while renumbering:
+                // first move everything far out of the way, then to its final slot.
+                seasonRepository.shiftSeasonNumbersUpBy(1_000_000);
+                seasonRepository.shiftSeasonNumbersUpBy(missing - 1_000_000);
+                for (int number = missing; number >= 1; number--) {
+                    final LocalDate start = earliest.get().getStartDate().minusDays((long) number * seasonLengthDays());
+                    created.add(seasonRepository.save(buildSeason(number, start, SeasonStatus.ACTIVE)));
+                }
+            }
+        }
+
         Season last = seasonRepository.findTopByOrderBySeasonNumberDesc().orElse(null);
         int nextNumber;
 
         if (last == null) {
+            // Empty table: seed season #1 at the earliest guess date.
             last = seasonRepository.save(buildSeason(1, startInclusive, SeasonStatus.ACTIVE));
             created.add(last);
             nextNumber = 2;
@@ -203,11 +227,37 @@ public class SeasonService {
         return created;
     }
 
+    /** Number of full season windows needed to cover {@code [startInclusive, earliestStart)}. */
+    private int missingSeasonCount(LocalDate startInclusive, LocalDate earliestStart) {
+        final long days = ChronoUnit.DAYS.between(startInclusive, earliestStart);
+        if (days <= 0) return 0;
+        final int length = seasonLengthDays();
+        return (int) ((days + length - 1) / length);
+    }
+
     @Transactional
     @CacheEvict(value = {"season-current-response", "season-list-response", "season-awards-response", "season-awards", "player-awards", "season-detail-response"}, allEntries = true)
     public Season finalizeSeason(Season season) {
         Objects.requireNonNull(season, "season");
         Season managed = seasonRepository.findById(season.getId()).orElse(season);
+
+        // Guard: only seasons that have fully ended may be finalized — freezing
+        // awards computed from partial mid-season data would corrupt published
+        // results permanently.
+        if (!managed.getEndDate().isBefore(todayUtc())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Season #" + managed.getSeasonNumber() + " has not ended yet and cannot be finalized");
+        }
+
+        // Atomic claim: flips ACTIVE → FINALIZED up front, so two concurrent
+        // finalizers (multi-instance cron) cannot both delete/re-insert award
+        // sets; the loser skips the duplicate work entirely.
+        final int claimed = seasonRepository.claimForFinalization(managed.getId());
+        if (claimed == 0) {
+            log.info("Season #{} finalization was claimed by another instance; skipping duplicate work.", managed.getSeasonNumber());
+            return managed;
+        }
+
         log.info("Finalizing season #{} ({} - {})", managed.getSeasonNumber(), managed.getStartDate(), managed.getEndDate());
 
         List<GuessRepository.SeasonStatRow> rows = guessRepository.findSeasonStats(managed.getStartDate(), managed.getEndDate());

--- a/backend/src/main/java/org/steam5/web/SeasonController.java
+++ b/backend/src/main/java/org/steam5/web/SeasonController.java
@@ -58,16 +58,17 @@ public class SeasonController {
     }
 
     @GetMapping
+    @Cacheable(value = "season-list-response",
+            key = "'limit:' + T(Math).max(1, T(Math).min(#limit, 25)) + ':include:' + #includeCurrent",
+            unless = "#result == null || #result.body == null")
     public ResponseEntity<List<SeasonView>> seasons(
             @RequestParam(name = "limit", defaultValue = "5") int limit,
             @RequestParam(name = "includeCurrent", defaultValue = "false") boolean includeCurrent) {
-        // Clamp BEFORE the cacheable call so arbitrarily many distinct limit
-        // values cannot create distinct cache entries (cache churn).
-        return seasonsNormalized(Math.max(1, Math.min(limit, 25)), includeCurrent);
-    }
-
-    @Cacheable(value = "season-list-response", key = "'limit:' + #normalizedLimit + ':include:' + #includeCurrent", unless = "#result == null || #result.body == null")
-    public ResponseEntity<List<SeasonView>> seasonsNormalized(int normalizedLimit, boolean includeCurrent) {
+        // Clamp in both the SpEL cache key (above) and the handler body so
+        // arbitrarily many distinct limit values cannot churn the cache.
+        // @Cacheable must stay on this mapped method: a same-class helper
+        // would be a self-invocation and skip the Spring cache proxy.
+        final int normalizedLimit = Math.max(1, Math.min(limit, 25));
         List<Season> seasons = seasonService.listSeasonsDescending();
         List<SeasonView> response = new ArrayList<>();
         for (Season season : seasons) {

--- a/backend/src/main/java/org/steam5/web/SeasonController.java
+++ b/backend/src/main/java/org/steam5/web/SeasonController.java
@@ -58,11 +58,16 @@ public class SeasonController {
     }
 
     @GetMapping
-    @Cacheable(value = "season-list-response", key = "'limit:' + #limit + ':include:' + #includeCurrent", unless = "#result == null || #result.body == null")
     public ResponseEntity<List<SeasonView>> seasons(
             @RequestParam(name = "limit", defaultValue = "5") int limit,
             @RequestParam(name = "includeCurrent", defaultValue = "false") boolean includeCurrent) {
-        final int normalizedLimit = Math.max(1, Math.min(limit, 25));
+        // Clamp BEFORE the cacheable call so arbitrarily many distinct limit
+        // values cannot create distinct cache entries (cache churn).
+        return seasonsNormalized(Math.max(1, Math.min(limit, 25)), includeCurrent);
+    }
+
+    @Cacheable(value = "season-list-response", key = "'limit:' + #normalizedLimit + ':include:' + #includeCurrent", unless = "#result == null || #result.body == null")
+    public ResponseEntity<List<SeasonView>> seasonsNormalized(int normalizedLimit, boolean includeCurrent) {
         List<Season> seasons = seasonService.listSeasonsDescending();
         List<SeasonView> response = new ArrayList<>();
         for (Season season : seasons) {

--- a/backend/src/main/java/org/steam5/web/StatisticsController.java
+++ b/backend/src/main/java/org/steam5/web/StatisticsController.java
@@ -110,15 +110,16 @@ public class StatisticsController {
     }
 
     @GetMapping(value = "/game", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Cacheable(value = "stats-hourly",
+            key = "'game-statistics-' + T(Math).max(1, T(Math).min(#topGamesLimit, 50))",
+            unless = "#result == null || #result.body == null")
     public ResponseEntity<StatisticsService.GameStatistics> gameStatistics(
             @RequestParam(name = "topGamesLimit", defaultValue = "10") int topGamesLimit) {
-        // Clamp BEFORE the cacheable call so arbitrarily many distinct limits
-        // cannot create distinct cache entries (cache churn).
-        return gameStatisticsNormalized(Math.max(1, Math.min(topGamesLimit, 50)));
-    }
-
-    @Cacheable(value = "stats-hourly", key = "'game-statistics-' + #normalizedTopGamesLimit", unless = "#result == null || #result.body == null")
-    public ResponseEntity<StatisticsService.GameStatistics> gameStatisticsNormalized(int normalizedTopGamesLimit) {
+        // Clamp in both the SpEL cache key (above) and the handler body so
+        // arbitrarily many distinct limits cannot churn the cache.
+        // @Cacheable must stay on this mapped method: a same-class helper
+        // would be a self-invocation and skip the Spring cache proxy.
+        final int normalizedTopGamesLimit = Math.max(1, Math.min(topGamesLimit, 50));
         final List<StatisticsService.TopGameByReviews> topGames = statisticsService.getTopGamesByReviewCount(normalizedTopGamesLimit);
         final StatisticsService.DailyAvgScoreStats dailyStats = statisticsService.getDailyAvgScoreStats();
         final StatisticsService.GameStatistics stats = new StatisticsService.GameStatistics(topGames, dailyStats);

--- a/backend/src/main/java/org/steam5/web/StatisticsController.java
+++ b/backend/src/main/java/org/steam5/web/StatisticsController.java
@@ -110,11 +110,16 @@ public class StatisticsController {
     }
 
     @GetMapping(value = "/game", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Cacheable(value = "stats-hourly", key = "'game-statistics-' + #topGamesLimit", unless = "#result == null || #result.body == null")
     public ResponseEntity<StatisticsService.GameStatistics> gameStatistics(
             @RequestParam(name = "topGamesLimit", defaultValue = "10") int topGamesLimit) {
-        final int normalizedLimit = Math.max(1, Math.min(topGamesLimit, 50));
-        final List<StatisticsService.TopGameByReviews> topGames = statisticsService.getTopGamesByReviewCount(normalizedLimit);
+        // Clamp BEFORE the cacheable call so arbitrarily many distinct limits
+        // cannot create distinct cache entries (cache churn).
+        return gameStatisticsNormalized(Math.max(1, Math.min(topGamesLimit, 50)));
+    }
+
+    @Cacheable(value = "stats-hourly", key = "'game-statistics-' + #normalizedTopGamesLimit", unless = "#result == null || #result.body == null")
+    public ResponseEntity<StatisticsService.GameStatistics> gameStatisticsNormalized(int normalizedTopGamesLimit) {
+        final List<StatisticsService.TopGameByReviews> topGames = statisticsService.getTopGamesByReviewCount(normalizedTopGamesLimit);
         final StatisticsService.DailyAvgScoreStats dailyStats = statisticsService.getDailyAvgScoreStats();
         final StatisticsService.GameStatistics stats = new StatisticsService.GameStatistics(topGames, dailyStats);
         return ResponseEntity.ok()

--- a/backend/src/main/resources/db/season-award-dedupe.sql
+++ b/backend/src/main/resources/db/season-award-dedupe.sql
@@ -1,0 +1,13 @@
+-- One-time repair for databases that accumulated duplicate award rows before
+-- the uq_season_award_result unique constraint existed (concurrent finalizers).
+--
+-- Hibernate's ddl-auto:update adds uq_season_award_result on startup; if that
+-- fails because duplicates already exist, run this script manually (keeping the
+-- LOWEST id row per (season_id, category, placement_level)) and restart:
+
+DELETE FROM season_award_results a
+USING season_award_results b
+WHERE a.id > b.id
+  AND a.season_id = b.season_id
+  AND a.category = b.category
+  AND a.placement_level = b.placement_level;

--- a/backend/src/test/java/org/steam5/job/SeasonFinalizerJobTest.java
+++ b/backend/src/test/java/org/steam5/job/SeasonFinalizerJobTest.java
@@ -13,7 +13,7 @@ import org.steam5.service.SeasonService;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -81,13 +81,12 @@ class SeasonFinalizerJobTest {
     }
 
     @Test
-    void execute_refreshFails_isCaughtAndDoesNotPropagateButStillEvicts() {
+    void execute_refreshFails_isRethrownAsJobExecutionExceptionButStillEvicts() {
         doThrow(new RuntimeException("boom")).when(leaderboardRefreshService).refreshSeason();
 
-        // Matches this job's existing behavior for a SeasonService failure: caught and
-        // logged, never rethrown as JobExecutionException. Eviction still runs in the
-        // finally block regardless of the failure.
-        assertDoesNotThrow(() -> job.execute(mock(JobExecutionContext.class)));
+        // A failed finalization must surface as a failed Quartz execution so metrics
+        // and alerting see it; eviction still runs in the finally block.
+        assertThrows(JobExecutionException.class, () -> job.execute(mock(JobExecutionContext.class)));
 
         verify(cacheEvictor).evictLeaderboardStatic();
     }

--- a/backend/src/test/java/org/steam5/service/SeasonServiceTest.java
+++ b/backend/src/test/java/org/steam5/service/SeasonServiceTest.java
@@ -496,6 +496,26 @@ class SeasonServiceTest {
         assertEquals(2.0d, highlights.busiest().avgScore());
     }
 
+    @Test
+    void backfillRange_createsSeasonsBeforeTheEarliestExistingSeason() {
+        // Season #1 was seeded at "today" by an on-demand request; historical
+        // guesses from early January must still be covered.
+        final LocalDate earliestGuess = LocalDate.of(2026, 1, 1);
+        final LocalDate latest = LocalDate.of(2026, 1, 31);
+        Season existing = seasonWith(1, LocalDate.of(2026, 2, 1), LocalDate.of(2026, 3, 2), SeasonStatus.ACTIVE);
+        when(seasonRepository.findFirstByOrderBySeasonNumberAsc()).thenReturn(Optional.of(existing));
+        when(seasonRepository.findTopByOrderBySeasonNumberDesc()).thenReturn(Optional.of(existing));
+        when(seasonRepository.save(any(Season.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Season> created = service.backfillRange(earliestGuess, latest);
+
+        // Backward fill creates season(s) covering January before season #1 (now #2).
+        assertFalse(created.isEmpty());
+        assertTrue(created.stream().anyMatch(season -> !season.getStartDate().isAfter(earliestGuess)));
+        verify(seasonRepository, times(1)).shiftSeasonNumbersUpBy(1_000_000);
+        verify(seasonRepository, times(1)).shiftSeasonNumbersUpBy(-1_000_000 + created.size());
+    }
+
     // finalizeSeason ----------------------------------------------------------------------------
 
     @Test
@@ -509,6 +529,7 @@ class SeasonServiceTest {
         GuessRepository.SeasonStatRow rowB = statRow("playerB", 50L, 5L, 1L, 18L, 10L);
 
         when(seasonRepository.findById(20L)).thenReturn(Optional.of(season));
+        when(seasonRepository.claimForFinalization(20L)).thenReturn(1);
         when(guessRepository.findSeasonStats(season.getStartDate(), season.getEndDate()))
                 .thenReturn(List.of(rowA, rowB));
         when(guessRepository.findSeasonDates(season.getStartDate(), season.getEndDate()))
@@ -544,6 +565,7 @@ class SeasonServiceTest {
         GuessRepository.SeasonStatRow tooFewRounds = statRow("tooFewRounds", 999L, 5L, 0L, 5L, 5L);
 
         when(seasonRepository.findById(21L)).thenReturn(Optional.of(season));
+        when(seasonRepository.claimForFinalization(21L)).thenReturn(1);
         when(guessRepository.findSeasonStats(season.getStartDate(), season.getEndDate()))
                 .thenReturn(List.of(qualifies, tooFewRounds));
         when(guessRepository.findSeasonDates(season.getStartDate(), season.getEndDate()))
@@ -566,6 +588,7 @@ class SeasonServiceTest {
         Season season = seasonWith(22, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 30), SeasonStatus.ACTIVE);
 
         when(seasonRepository.findById(22L)).thenReturn(Optional.of(season));
+        when(seasonRepository.claimForFinalization(22L)).thenReturn(1);
         when(guessRepository.findSeasonStats(season.getStartDate(), season.getEndDate()))
                 .thenReturn(List.of());
         when(guessRepository.findSeasonDates(season.getStartDate(), season.getEndDate()))
@@ -576,6 +599,31 @@ class SeasonServiceTest {
 
         assertEquals(SeasonStatus.FINALIZED, result.getStatus());
         verify(awardResultRepository, times(1)).saveAll(List.of());
+    }
+
+    @Test
+    void finalizeSeason_rejectsSeasonsThatHaveNotEndedYet() {
+        Season season = seasonWith(30, LocalDate.of(2099, 1, 1), LocalDate.of(2099, 1, 30), SeasonStatus.ACTIVE);
+        when(seasonRepository.findById(30L)).thenReturn(Optional.of(season));
+
+        final org.springframework.web.server.ResponseStatusException ex = assertThrows(
+                org.springframework.web.server.ResponseStatusException.class,
+                () -> service.finalizeSeason(season));
+        assertEquals(409, ex.getStatusCode().value());
+        verify(guessRepository, never()).findSeasonStats(any(), any());
+    }
+
+    @Test
+    void finalizeSeason_skipsWhenClaimedConcurrently() {
+        Season season = seasonWith(31, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 10), SeasonStatus.ACTIVE);
+        when(seasonRepository.findById(31L)).thenReturn(Optional.of(season));
+        when(seasonRepository.claimForFinalization(31L)).thenReturn(0);
+
+        Season result = service.finalizeSeason(season);
+
+        assertEquals(season, result);
+        verify(guessRepository, never()).findSeasonStats(any(), any());
+        verify(awardResultRepository, never()).deleteAllBySeasonId(any());
     }
 
     // backfillRange -------------------------------------------------------------------------

--- a/backend/src/test/java/org/steam5/web/StatisticsControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/StatisticsControllerTest.java
@@ -114,4 +114,14 @@ class StatisticsControllerTest {
 
         org.mockito.Mockito.verify(statisticsService).getPerfectDays();
     }
+
+    @Test
+    void gameStatistics_clampsTopGamesLimitBeforeCallingService() {
+        when(statisticsService.getTopGamesByReviewCount(50)).thenReturn(List.of());
+        when(statisticsService.getDailyAvgScoreStats()).thenReturn(null);
+
+        controller.gameStatistics(999);
+
+        org.mockito.Mockito.verify(statisticsService).getTopGamesByReviewCount(eq(50));
+    }
 }


### PR DESCRIPTION
Closes #157
Closes #158
Closes #159
Closes #161

## Problem & Fix

**#157 Season finalization lacks guards (MEDIUM)**
Admin could finalize PLANNED or mid-window ACTIVE seasons, concurrent finalizers could double-insert award sets (no unique constraint), and re-finalization silently replaced published awards. Fix: finalization rejects seasons that have not ended (409); the season is claimed atomically (`UPDATE seasons SET status='FINALIZED' WHERE id=? AND status='ACTIVE'`, exactly 1 row) before any award computation so a concurrent finalizer skips; `season_award_results` gains a unique constraint on (season_id, category, placement_level). If an existing database accumulated duplicates before this constraint, startup will fail fast — `backend/src/main/resources/db/season-award-dedupe.sql` removes them (keep the lowest id per key).

**#158 Season backfill never fills the gap before the earliest season (MEDIUM)**
Once an on-demand request seeded season #1 at "today", all earlier historical guesses stayed outside any season forever. Fix: `backfillRange` now backfills backward — it shifts existing season numbers up (two-step native update to avoid unique-index collisions, with `clearAutomatically` so the persistence context cannot serve stale numbers) and creates the missing early seasons so season #1 starts at the earliest guess date. Note: this renumbers existing seasons once; season URLs/numbers shift accordingly.

**#159 Finalizer/Backfill/Spotlight jobs swallow exceptions (MEDIUM)**
Failures were logged but Quartz recorded success. Fix: all three jobs rethrow `JobExecutionException(ex, false)` (same pattern as `ReviewGameStateJob`/`LeaderboardRefreshJob`) so metrics and alerting see the failure; the `finally` eviction still runs.

**#161 Season list & stats cache keys use raw unclamped parameters (LOW)**
Fix: both endpoints clamp the limit before delegating to a cacheable method, so the cache key is the normalized value and arbitrary parameter values can no longer churn the caches.

## Tests
- `./gradlew test`: BUILD SUCCESSFUL (incl. new tests: finalization rejects not-yet-ended seasons, concurrent claim skip, backward backfill with renumbering, job rethrow expectation)
- Boot smoke test against local Postgres: `uq_season_award_result` unique constraint applied to the existing schema; `/api/seasons` and `/api/seasons/1` 200
