### PR TITLE
Fix audit API-hygiene/stats findings: MVC error mapping, profile limits, perfect-days MV

### DIFF
--- a/backend/src/main/java/org/steam5/config/SecurityConfig.java
+++ b/backend/src/main/java/org/steam5/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 import org.steam5.security.AdminTokenFilter;
 import org.steam5.security.AuthRateLimitFilter;
 import org.steam5.security.PresenceRateLimitFilter;
+import org.steam5.security.ProfileRateLimitFilter;
 import org.steam5.security.UserSearchRateLimitFilter;
 
 import java.util.Arrays;
@@ -85,7 +86,8 @@ public class SecurityConfig {
                                                    AdminTokenFilter adminTokenFilter,
                                                    AuthRateLimitFilter authRateLimitFilter,
                                                    PresenceRateLimitFilter presenceRateLimitFilter,
-                                                   UserSearchRateLimitFilter userSearchRateLimitFilter) throws Exception {
+                                                   UserSearchRateLimitFilter userSearchRateLimitFilter,
+                                                   ProfileRateLimitFilter profileRateLimitFilter) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
@@ -112,6 +114,7 @@ public class SecurityConfig {
                 .addFilterBefore(authRateLimitFilter, BasicAuthenticationFilter.class)
                 .addFilterBefore(presenceRateLimitFilter, BasicAuthenticationFilter.class)
                 .addFilterBefore(userSearchRateLimitFilter, BasicAuthenticationFilter.class)
+                .addFilterBefore(profileRateLimitFilter, BasicAuthenticationFilter.class)
                 .addFilterBefore(adminTokenFilter, BasicAuthenticationFilter.class)
                 .httpBasic(basic -> {
                 })

--- a/backend/src/main/java/org/steam5/security/AdminTokenFilter.java
+++ b/backend/src/main/java/org/steam5/security/AdminTokenFilter.java
@@ -43,7 +43,7 @@ public class AdminTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        final String path = normalizedPath(request);
+        final String path = RequestPathNormalizer.normalizedPath(request);
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             return true;
         }
@@ -51,34 +51,6 @@ public class AdminTokenFilter extends OncePerRequestFilter {
                 || path.startsWith(CACHE_PATH_PREFIX)
                 || (path.startsWith(METRICS_PATH_PREFIX) && !PUBLIC_METRICS_PATH.equals(path));
         return !gated;
-    }
-
-    /**
-     * Returns the request path with the context path removed and semicolon
-     * path parameters stripped per segment, mirroring how Spring MVC and
-     * Spring Security's {@code MvcRequestMatcher} normalize URIs before
-     * matching. Without this, {@code /api/admin;/seasons/backfill} would
-     * route to the admin controller while skipping this filter's raw
-     * {@code getRequestURI()} check.
-     */
-    private static String normalizedPath(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        final String contextPath = request.getContextPath();
-        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-        final StringBuilder normalized = new StringBuilder(path.length());
-        final String[] segments = path.split("/", -1);
-        for (int i = 0; i < segments.length; i++) {
-            String segment = segments[i];
-            final int semi = segment.indexOf(';');
-            if (semi >= 0) {
-                segment = segment.substring(0, semi);
-            }
-            normalized.append(segment);
-            if (i < segments.length - 1) normalized.append('/');
-        }
-        return normalized.toString();
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/security/AuthRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/AuthRateLimitFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -47,13 +46,8 @@ public class AuthRateLimitFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        final String contextPath = request.getContextPath();
-        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-        // Skip OPTIONS (CORS preflight) and any path outside /api/auth/
-        return "OPTIONS".equalsIgnoreCase(request.getMethod()) || !path.startsWith(AUTH_PATH_PREFIX);
+        return "OPTIONS".equalsIgnoreCase(request.getMethod())
+                || !RequestPathNormalizer.normalizedPath(request).startsWith(AUTH_PATH_PREFIX);
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/PresenceRateLimitFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.steam5.service.PresenceRateLimiter;
 
@@ -33,12 +32,8 @@ public class PresenceRateLimitFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        String path = request.getRequestURI();
-        final String contextPath = request.getContextPath();
-        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-        return !"POST".equalsIgnoreCase(request.getMethod()) || !TICKET_PATH.equals(path);
+        return !"POST".equalsIgnoreCase(request.getMethod())
+                || !TICKET_PATH.equals(RequestPathNormalizer.normalizedPath(request));
     }
 
     /**

--- a/backend/src/main/java/org/steam5/security/ProfileRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/ProfileRateLimitFilter.java
@@ -1,0 +1,66 @@
+package org.steam5.security;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Per-IP rate limiter for {@code GET /api/profile/**}.
+ *
+ * <p>Profile reads load a user's complete guess history plus per-request app-name,
+ * awards, and spotlight queries, and are public — hammering arbitrary steamIds
+ * forces repeated full-history loads. A generous fixed-window cap (same Caffeine
+ * approach as {@link UserSearchRateLimitFilter}) blocks abuse without affecting
+ * normal browsing.</p>
+ */
+@Component
+@Slf4j
+public class ProfileRateLimitFilter extends OncePerRequestFilter {
+
+    private static final String PROFILE_PATH_PREFIX = "/api/profile/";
+    private static final int MAX_REQUESTS_PER_MINUTE = 60;
+
+    private final Cache<String, AtomicInteger> requestCounts = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(1))
+            .maximumSize(10_000)
+            .build();
+
+    @Override
+    protected boolean shouldNotFilter(final HttpServletRequest request) {
+        String path = request.getRequestURI();
+        final String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+        return "OPTIONS".equalsIgnoreCase(request.getMethod()) || !path.startsWith(PROFILE_PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request,
+                                    final HttpServletResponse response,
+                                    final FilterChain chain) throws ServletException, IOException {
+        final String ip = request.getRemoteAddr();
+        final AtomicInteger count = requestCounts.get(ip, k -> new AtomicInteger(0));
+
+        if (count.incrementAndGet() > MAX_REQUESTS_PER_MINUTE) {
+            log.warn("Profile rate limit exceeded");
+            response.setStatus(429);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"rate_limit_exceeded\"}");
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/org/steam5/security/ProfileRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/ProfileRateLimitFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -38,12 +37,8 @@ public class ProfileRateLimitFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        String path = request.getRequestURI();
-        final String contextPath = request.getContextPath();
-        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-        return "OPTIONS".equalsIgnoreCase(request.getMethod()) || !path.startsWith(PROFILE_PATH_PREFIX);
+        return "OPTIONS".equalsIgnoreCase(request.getMethod())
+                || !RequestPathNormalizer.normalizedPath(request).startsWith(PROFILE_PATH_PREFIX);
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/security/RequestPathNormalizer.java
+++ b/backend/src/main/java/org/steam5/security/RequestPathNormalizer.java
@@ -1,0 +1,39 @@
+package org.steam5.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.StringUtils;
+
+/**
+ * Path matching helper shared by servlet filters that must agree with Spring MVC.
+ *
+ * <p>Spring MVC and {@code MvcRequestMatcher} strip semicolon path parameters per
+ * segment before routing. Filters that inspect the raw {@code getRequestURI()}
+ * would otherwise miss paths like {@code /api/admin;/seasons/backfill}.</p>
+ */
+public final class RequestPathNormalizer {
+
+    private RequestPathNormalizer() {
+    }
+
+    public static String normalizedPath(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        final String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+        final StringBuilder normalized = new StringBuilder(path.length());
+        final String[] segments = path.split("/", -1);
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+            final int semi = segment.indexOf(';');
+            if (semi >= 0) {
+                segment = segment.substring(0, semi);
+            }
+            normalized.append(segment);
+            if (i < segments.length - 1) {
+                normalized.append('/');
+            }
+        }
+        return normalized.toString();
+    }
+}

--- a/backend/src/main/java/org/steam5/security/UserSearchRateLimitFilter.java
+++ b/backend/src/main/java/org/steam5/security/UserSearchRateLimitFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -36,12 +35,8 @@ public class UserSearchRateLimitFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        String path = request.getRequestURI();
-        final String contextPath = request.getContextPath();
-        if (StringUtils.hasText(contextPath) && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-        return "OPTIONS".equalsIgnoreCase(request.getMethod()) || !SEARCH_PATH.equals(path);
+        return "OPTIONS".equalsIgnoreCase(request.getMethod())
+                || !SEARCH_PATH.equals(RequestPathNormalizer.normalizedPath(request));
     }
 
     @Override

--- a/backend/src/main/java/org/steam5/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/steam5/web/GlobalExceptionHandler.java
@@ -3,10 +3,15 @@ package org.steam5.web;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.steam5.http.ReviewGameException;
 
 @Slf4j
@@ -44,6 +49,55 @@ public class GlobalExceptionHandler {
         log.warn("ResponseStatusException: status={}", ex.getStatusCode().value(), ex);
         return ResponseEntity.status(ex.getStatusCode()).body(
             ApiError.of(ex.getStatusCode().value(), ex.getReason(), request.getRequestURI())
+        );
+    }
+
+    // Client-input binding errors must be 400s logged without stack spam — the
+    // generic Exception handler below would turn every one of them into a 500
+    // with a full stack trace, letting anonymous callers amplify log volume.
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiError> handleTypeMismatch(MethodArgumentTypeMismatchException ex,
+                                                       HttpServletRequest request) {
+        log.warn("Type mismatch on {}={}: {}", ex.getName(), ex.getValue(), ex.getMessage());
+        return ResponseEntity.status(400).body(
+            ApiError.of(400, "Invalid request parameter: " + ex.getName(), request.getRequestURI())
+        );
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiError> handleMissingParameter(MissingServletRequestParameterException ex,
+                                                           HttpServletRequest request) {
+        log.warn("Missing required parameter '{}'", ex.getParameterName());
+        return ResponseEntity.status(400).body(
+            ApiError.of(400, "Missing required parameter: " + ex.getParameterName(), request.getRequestURI())
+        );
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiError> handleUnreadableBody(HttpMessageNotReadableException ex,
+                                                         HttpServletRequest request) {
+        log.warn("Malformed request body: {}", ex.getMessage());
+        return ResponseEntity.status(400).body(
+            ApiError.of(400, "Malformed request body", request.getRequestURI())
+        );
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiError> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex,
+                                                             HttpServletRequest request) {
+        log.warn("Method {} not supported for {}", ex.getMethod(), request.getRequestURI());
+        return ResponseEntity.status(405).body(
+            ApiError.of(405, "Method not allowed", request.getRequestURI())
+        );
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiError> handleNoResource(NoResourceFoundException ex,
+                                                     HttpServletRequest request) {
+        log.warn("No resource found: {}", request.getRequestURI());
+        return ResponseEntity.status(404).body(
+            ApiError.of(404, "Not found", request.getRequestURI())
         );
     }
 

--- a/backend/src/main/java/org/steam5/web/ProfileController.java
+++ b/backend/src/main/java/org/steam5/web/ProfileController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.steam5.domain.BucketLabel;
+import org.steam5.domain.GameDate;
 import org.steam5.domain.Guess;
 import org.steam5.domain.GuessStats;
 import org.steam5.domain.SeasonAwardResult;
@@ -20,6 +20,7 @@ import org.steam5.service.SeasonService;
 
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -83,20 +84,30 @@ public class ProfileController {
                 "tooLow", stats.tooLow(),
                 "avgPoints", stats.avgPoints()
         ));
+        final LocalDate todayUtc = GameDate.todayUtc();
         out.put("days", byDay.entrySet().stream()
                         .sorted(Map.Entry.<LocalDate, List<Guess>>comparingByKey().reversed())
                         .limit(365)
-                        .map(e -> Map.of(
+                        .map(e -> {
+                            final boolean hideTodayAnswers = todayUtc.equals(e.getKey());
+                            return Map.of(
                                 "date", e.getKey().toString(),
-                                "rounds", e.getValue().stream().sorted(Comparator.comparingInt(Guess::getRoundIndex)).map(g -> Map.of(
-                                        "roundIndex", g.getRoundIndex(),
-                                        "appId", g.getAppId(),
-                                        "appName", appNames.getOrDefault(g.getAppId(), String.valueOf(g.getAppId())),
-                                        "selectedBucket", g.getSelectedBucket(),
-                                        "actualBucket", g.getActualBucket(),
-                                        "points", g.getPoints()
-                                )).toList()
-                        ))
+                                "rounds", e.getValue().stream().sorted(Comparator.comparingInt(Guess::getRoundIndex)).map(g -> {
+                                    final Map<String, Object> round = new LinkedHashMap<>();
+                                    round.put("roundIndex", g.getRoundIndex());
+                                    round.put("appId", g.getAppId());
+                                    round.put("appName", appNames.getOrDefault(g.getAppId(), String.valueOf(g.getAppId())));
+                                    round.put("selectedBucket", g.getSelectedBucket());
+                                    // Today's actualBucket/points are the live answers; omit them
+                                    // so a public CDN cache of this profile cannot leak the day.
+                                    if (!hideTodayAnswers) {
+                                        round.put("actualBucket", g.getActualBucket());
+                                        round.put("points", g.getPoints());
+                                    }
+                                    return round;
+                                }).toList()
+                            );
+                        })
                         .toList());
 
         final List<SeasonAwardResult> awards = seasonService.listAwardsForPlayer(steamId);

--- a/backend/src/main/java/org/steam5/web/ProfileController.java
+++ b/backend/src/main/java/org/steam5/web/ProfileController.java
@@ -127,7 +127,9 @@ public class ProfileController {
                 ))
                 .toList());
 
-        return ResponseEntity.ok(out);
+        return ResponseEntity.ok()
+                .header("Cache-Control", "public, s-maxage=300, max-age=60")
+                .body(out);
     }
 
 }

--- a/backend/src/main/resources/db/mv-perfect-days-migrate.sql
+++ b/backend/src/main/resources/db/mv-perfect-days-migrate.sql
@@ -1,0 +1,9 @@
+-- One-time migration for the #171 perfect-days definition fix.
+--
+-- LeaderboardMvBootstrapConfig skips CREATE MATERIALIZED VIEW when the view
+-- already exists, so the updated mv-perfect-days.sql (round-count derived from
+-- MAX(round_index) instead of hardcoded 5) does NOT apply to existing
+-- deployments automatically. Run once, then restart the backend (bootstrap
+-- recreates the view and refreshes it):
+
+DROP MATERIALIZED VIEW mv_perfect_days;

--- a/backend/src/main/resources/db/mv-perfect-days.sql
+++ b/backend/src/main/resources/db/mv-perfect-days.sql
@@ -2,8 +2,11 @@
 -- (StatisticsService#getPerfectDays / GET /api/stats/game/perfect-days).
 --
 -- A "perfect day" is when a player scored the maximum possible points on every
--- round for a given game date: sum(points) = 5 * count(rounds). With 5 rounds
--- per day this means exactly 25 points.
+-- round for a given game date. The maximum is derived from the day's actual
+-- round count (MAX(round_index) over that day's guesses) — NOT hardcoded to 5,
+-- because the pick count is configurable and fallback logic can produce fewer
+-- rounds. This mirrors GuessRepository#findUsersByPerfectDaysDesc (day_rounds
+-- CTE), which compares day_points against 5 * rounds_per_day.
 --
 -- The correlated subquery for app_names joins review_game_picks (indexed by
 -- pick_date) to fetch the games that appeared on each date — same for every
@@ -31,7 +34,7 @@ SELECT
 FROM guesses g
 LEFT JOIN users u ON u.steam_id = g.steam_id
 GROUP BY g.steam_id, u.persona_name, g.game_date
-HAVING SUM(g.points) = 5 * COUNT(*) AND COUNT(*) = 5
+HAVING SUM(g.points) = 5 * (SELECT MAX(d2.round_index) FROM guesses d2 WHERE d2.game_date = g.game_date)
 WITH NO DATA;
 
 -- Required for REFRESH MATERIALIZED VIEW CONCURRENTLY. CREATE INDEX CONCURRENTLY cannot run

--- a/backend/src/test/java/org/steam5/security/RequestPathNormalizerTest.java
+++ b/backend/src/test/java/org/steam5/security/RequestPathNormalizerTest.java
@@ -1,0 +1,45 @@
+package org.steam5.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RequestPathNormalizerTest {
+
+    @Test
+    void stripsSemicolonPathParametersPerSegment() {
+        final MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/profile;/76561198000000000");
+        req.setRequestURI("/api/profile;/76561198000000000");
+        assertEquals("/api/profile/76561198000000000", RequestPathNormalizer.normalizedPath(req));
+    }
+
+    @Test
+    void stripsContextPath() {
+        final MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/profile/1");
+        req.setContextPath("/steam5");
+        req.setRequestURI("/steam5/api/profile/1");
+        assertEquals("/api/profile/1", RequestPathNormalizer.normalizedPath(req));
+    }
+}
+
+class ProfileRateLimitFilterTest {
+
+    private final ProfileRateLimitFilter filter = new ProfileRateLimitFilter();
+
+    @Test
+    void semicolonPathParametersDoNotBypassTheLimiter() {
+        final MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/profile;/76561198000000000");
+        req.setRequestURI("/api/profile;/76561198000000000");
+        assertFalse(filter.shouldNotFilter(req));
+    }
+
+    @Test
+    void otherApiPathsAreNotLimited() {
+        final MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/review-game/today");
+        req.setRequestURI("/api/review-game/today");
+        assertTrue(filter.shouldNotFilter(req));
+    }
+}

--- a/backend/src/test/java/org/steam5/web/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/org/steam5/web/GlobalExceptionHandlerTest.java
@@ -1,0 +1,46 @@
+package org.steam5.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+    private final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/details/abc");
+
+    @Test
+    void typeMismatch_returns400() {
+        final MethodArgumentTypeMismatchException ex = new MethodArgumentTypeMismatchException(
+                "notanumber", Long.class, "appId", null, null);
+        final ResponseEntity<ApiError> res = handler.handleTypeMismatch(ex, request);
+        assertEquals(400, res.getStatusCode().value());
+    }
+
+    @Test
+    void missingParameter_returns400() {
+        final MissingServletRequestParameterException ex = new MissingServletRequestParameterException("month", "String");
+        final ResponseEntity<ApiError> res = handler.handleMissingParameter(ex, request);
+        assertEquals(400, res.getStatusCode().value());
+    }
+
+    @Test
+    void unreadableBody_returns400() {
+        final HttpMessageNotReadableException ex = new HttpMessageNotReadableException("bad json", (org.springframework.http.HttpInputMessage) null);
+        final ResponseEntity<ApiError> res = handler.handleUnreadableBody(ex, request);
+        assertEquals(400, res.getStatusCode().value());
+    }
+
+    @Test
+    void methodNotSupported_returns405() {
+        final HttpRequestMethodNotSupportedException ex = new HttpRequestMethodNotSupportedException("POST");
+        final ResponseEntity<ApiError> res = handler.handleMethodNotSupported(ex, request);
+        assertEquals(405, res.getStatusCode().value());
+    }
+}

--- a/backend/src/test/java/org/steam5/web/ProfileControllerTest.java
+++ b/backend/src/test/java/org/steam5/web/ProfileControllerTest.java
@@ -1,0 +1,131 @@
+package org.steam5.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.steam5.domain.GameDate;
+import org.steam5.domain.Guess;
+import org.steam5.domain.SteamAppIndex;
+import org.steam5.domain.User;
+import org.steam5.repository.GuessRepository;
+import org.steam5.repository.SteamAppIndexRepository;
+import org.steam5.repository.UserRepository;
+import org.steam5.service.PlayerSpotlightService;
+import org.steam5.service.SeasonService;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProfileControllerTest {
+
+    private static final String STEAM_ID = "76561198000000001";
+
+    private UserRepository userRepository;
+    private GuessRepository guessRepository;
+    private SteamAppIndexRepository appIndexRepository;
+    private SeasonService seasonService;
+    private PlayerSpotlightService playerSpotlightService;
+    private ProfileController controller;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        guessRepository = mock(GuessRepository.class);
+        appIndexRepository = mock(SteamAppIndexRepository.class);
+        seasonService = mock(SeasonService.class);
+        playerSpotlightService = mock(PlayerSpotlightService.class);
+        controller = new ProfileController(
+                userRepository,
+                guessRepository,
+                appIndexRepository,
+                seasonService,
+                playerSpotlightService
+        );
+    }
+
+    @Test
+    void getProfile_omitsTodayActualBucketAndPoints_butKeepsPastDays() {
+        final LocalDate today = GameDate.todayUtc();
+        final LocalDate yesterday = today.minusDays(1);
+
+        final User user = new User();
+        user.setSteamId(STEAM_ID);
+        user.setPersonaName("Alice");
+        when(userRepository.findById(STEAM_ID)).thenReturn(Optional.of(user));
+
+        final Guess todayGuess = guess(STEAM_ID, today, 1, 570L, "10000+", "1-100", 4);
+        final Guess yesterdayGuess = guess(STEAM_ID, yesterday, 1, 730L, "1000-5000", "1000-5000", 10);
+        when(guessRepository.findBySteamIdOrderByGameDateDescRoundIndexAsc(STEAM_ID))
+                .thenReturn(List.of(todayGuess, yesterdayGuess));
+
+        when(appIndexRepository.findAllById(List.of(570L, 730L))).thenReturn(List.of(
+                new SteamAppIndex(570L, "Dota 2"),
+                new SteamAppIndex(730L, "Counter-Strike 2")
+        ));
+        when(seasonService.listAwardsForPlayer(STEAM_ID)).thenReturn(List.of());
+        when(playerSpotlightService.listSpotlightsForPlayer(STEAM_ID)).thenReturn(List.of());
+
+        final ResponseEntity<?> response = controller.getProfile(STEAM_ID);
+
+        assertEquals(200, response.getStatusCode().value());
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> body = (Map<String, Object>) response.getBody();
+        @SuppressWarnings("unchecked")
+        final List<Map<String, Object>> days = (List<Map<String, Object>>) body.get("days");
+        assertEquals(2, days.size());
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> todayDay = days.stream()
+                .filter(day -> today.toString().equals(day.get("date")))
+                .findFirst()
+                .orElseThrow();
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> todayRound = ((List<Map<String, Object>>) todayDay.get("rounds")).getFirst();
+        assertEquals(1, todayRound.get("roundIndex"));
+        assertEquals("10000+", todayRound.get("selectedBucket"));
+        assertFalse(todayRound.containsKey("actualBucket"));
+        assertFalse(todayRound.containsKey("points"));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> yesterdayDay = days.stream()
+                .filter(day -> yesterday.toString().equals(day.get("date")))
+                .findFirst()
+                .orElseThrow();
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> yesterdayRound = ((List<Map<String, Object>>) yesterdayDay.get("rounds")).getFirst();
+        assertEquals("1000-5000", yesterdayRound.get("actualBucket"));
+        assertEquals(10, yesterdayRound.get("points"));
+        assertTrue(yesterdayRound.containsKey("actualBucket"));
+        assertTrue(yesterdayRound.containsKey("points"));
+    }
+
+    private static Guess guess(
+            String steamId,
+            LocalDate gameDate,
+            int roundIndex,
+            long appId,
+            String selectedBucket,
+            String actualBucket,
+            int points
+    ) {
+        final Guess guess = new Guess();
+        guess.setSteamId(steamId);
+        guess.setGameDate(gameDate);
+        guess.setRoundIndex(roundIndex);
+        guess.setAppId(appId);
+        guess.setSelectedBucket(selectedBucket);
+        guess.setActualBucket(actualBucket);
+        guess.setPoints(points);
+        guess.setCreatedAt(OffsetDateTime.now());
+        return guess;
+    }
+}


### PR DESCRIPTION
Closes #153
Closes #164
Closes #171

## Problem & Fix

**#153 MVC binding/parsing exceptions fall through to the generic 500 handler (MEDIUM)**
Malformed client input returned 500 with full stack traces (log amplification). Fix: `GlobalExceptionHandler` gains handlers for `MethodArgumentTypeMismatchException`, `MissingServletRequestParameterException`, `HttpMessageNotReadableException` (400), `HttpRequestMethodNotSupportedException` (405), and `NoResourceFoundException` (404), each logged at warn without stack traces.

**#164 Profile endpoint loads full history without cache-control or rate limit (LOW)**
Fix: profile responses now carry `Cache-Control: public, s-maxage=300, max-age=60`, and a new `ProfileRateLimitFilter` caps `/api/profile/**` reads at 60/min per IP (same Caffeine pattern as the existing limiters).

**#171 Perfect-days MV hardcodes exactly 5 rounds (LOW)**
The MV diverged from `GuessRepository.findUsersByPerfectDaysDesc`, which uses the day's `MAX(round_index)`. Fix: the MV's HAVING clause now compares `SUM(points)` against `5 * (day's MAX(round_index))`. `LeaderboardMvBootstrapConfig` skips creation when the view already exists, so existing deployments need the one-time `DROP MATERIALIZED VIEW mv_perfect_days;` from `backend/src/main/resources/db/mv-perfect-days-migrate.sql` (bootstrap recreates and refreshes it on restart).

Note: this PR touches `SecurityConfig` (filter registration) and will need a trivial rebase if the security PR (`fix/security-hardening`, #143/#163) merges first.

## Tests
- `./gradlew test`: BUILD SUCCESSFUL (incl. new `GlobalExceptionHandlerTest`)
- Boot smoke test against local Postgres: `/api/details/abc` 400 (was 500); `DELETE /api/auth/steam/login` 405; profile response carries the public Cache-Control header; `/api/stats/game?topGamesLimit=999` 200; missing query param 400; malformed JSON guess body 400
