### PR TITLE
Replace achievements table with responsive card grid layout

### DIFF
--- a/frontend/src/components/AchievementsTable.tsx
+++ b/frontend/src/components/AchievementsTable.tsx
@@ -16,7 +16,7 @@ type LeaderEntry = {
 };
 
 /**
- * Renders the achievements leaderboard table.
+ * Renders the achievements leaderboard as a responsive list of cards.
  *
  * @param achievements - Achievement records to display
  * @param serverOffsetMinutes - Server time offset used to calculate achievement metrics and titles
@@ -38,58 +38,40 @@ export default function AchievementsTable({
     return (
         <div className="leaderboard__achievements">
             <h3 className="leaderboard__achievements-title">Achievements</h3>
-            <div className="leaderboard__scroll">
-                <table className="leaderboard__table" aria-label="Achievements">
-                    <thead>
-                        <tr>
-                            <th scope="col">Achievement</th>
-                            <th scope="col">Winner</th>
-                            <th scope="col" className="num">Metric</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {Object.entries(ACHIEVEMENT_LABELS).map(([key, label]) => {
-                            const achievement = achievements.find(a => a.userAchievement === key);
-                            if (!achievement) return null;
-                            const entry = entryBySteamId.get(achievement.steamId);
-                            if (!entry) return null;
+            <ul className="achievements-list" role="list">
+                {Object.entries(ACHIEVEMENT_LABELS).map(([key, label]) => {
+                    const achievement = achievements.find(a => a.userAchievement === key);
+                    if (!achievement) return null;
+                    const entry = entryBySteamId.get(achievement.steamId);
+                    if (!entry) return null;
 
-                            const metricText = achievementMetricText(key, achievement, serverOffsetMinutes);
-                            const icon = ACHIEVEMENT_ICONS[key] ?? '';
-                            const title = getAchievementTitle(key, achievement, serverOffsetMinutes);
+                    const metricText = achievementMetricText(key, achievement, serverOffsetMinutes);
+                    const icon = ACHIEVEMENT_ICONS[key] ?? '';
+                    const title = getAchievementTitle(key, achievement, serverOffsetMinutes);
 
-                            return (
-                                <tr key={key}>
-                                    <td>
-                                        <span className="leaderboard__achievement-label" title={title}>
-                                            <span className="leaderboard__achievement-icon">{icon}</span>
-                                            {label}
-                                        </span>
-                                        <span className="leaderboard__achievement-metric-mobile num">
-                                            {metricText || '—'}
-                                        </span>
-                                    </td>
-                                    <td>
-                                        <div className="leaderboard__player">
-                                            <Avatar src={entry.avatar} name={entry.personaName} size={29}/>
-                                            <a
-                                                href={`/profile/${encodeURIComponent(achievement.steamId)}`}
-                                                className="leaderboard__profile-link"
-                                                title={entry.personaName || achievement.steamId}
-                                            >
-                                                {entry.personaName || achievement.steamId}
-                                            </a>
-                                        </div>
-                                    </td>
-                                    <td className="num leaderboard__achievement-metric-desktop">
-                                        {metricText || '—'}
-                                    </td>
-                                </tr>
-                            );
-                        })}
-                    </tbody>
-                </table>
-            </div>
+                    return (
+                        <li key={key} className="achievements-list__item">
+                            <div className="achievements-list__icon" title={title}>{icon}</div>
+                            <div className="achievements-list__content">
+                                <span className="achievements-list__label">{label}</span>
+                                <div className="achievements-list__winner">
+                                    <Avatar src={entry.avatar} name={entry.personaName} size={24}/>
+                                    <a
+                                        href={`/profile/${encodeURIComponent(achievement.steamId)}`}
+                                        className="leaderboard__profile-link"
+                                        title={entry.personaName || achievement.steamId}
+                                    >
+                                        {entry.personaName || achievement.steamId}
+                                    </a>
+                                </div>
+                            </div>
+                            {metricText && (
+                                <span className="achievements-list__metric">{metricText}</span>
+                            )}
+                        </li>
+                    );
+                })}
+            </ul>
         </div>
     );
 }

--- a/frontend/src/styles/components/leaderboard.css
+++ b/frontend/src/styles/components/leaderboard.css
@@ -275,39 +275,62 @@ html:has(.leaderboard-layout) {
     font-weight: 600;
 }
 
-.leaderboard__achievement-label {
-    display: inline-flex;
-    align-items: center;
+.achievements-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: 0.5rem;
-    font-weight: 500;
 }
 
-.leaderboard__achievement-icon {
-    font-size: 1rem;
+.achievements-list__item {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-surface);
+    transition: background 100ms ease;
+}
+
+.achievements-list__item:hover {
+    background: color-mix(in srgb, var(--color-primary) 4%, var(--color-surface));
+}
+
+.achievements-list__icon {
+    font-size: 1.25rem;
     line-height: 1;
     flex-shrink: 0;
 }
 
-/* Hide metric column on mobile — shown inline in the achievement cell instead */
-.leaderboard__achievement-metric-mobile {
-    display: none;
+.achievements-list__content {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
 }
 
-.leaderboard__achievement-metric-desktop {
+.achievements-list__label {
+    font-weight: 500;
+    font-size: 0.85rem;
     color: var(--color-muted);
 }
 
-@media (max-width: 640px) {
-    .leaderboard__achievement-metric-desktop {
-        display: none;
-    }
+.achievements-list__winner {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+}
 
-    .leaderboard__achievement-metric-mobile {
-        display: inline-block;
-        font-size: 0.8rem;
-        color: var(--color-muted);
-        margin-left: 0.5rem;
-    }
+.achievements-list__metric {
+    flex-shrink: 0;
+    font-size: 0.85rem;
+    color: var(--color-muted);
+    font-variant-numeric: tabular-nums;
 }
 
 /* Leaderboard row hover */


### PR DESCRIPTION
## Summary
- Replaces the `<table>` in the achievements section with a responsive CSS grid of card-style `<li>` elements
- Cards auto-adapt from two columns on desktop to a single column on narrow viewports via `repeat(auto-fill, minmax(280px, 1fr))`
- Removes the mobile/desktop metric duplication hack (separate show/hide elements) — metric is now always visible in one place

Closes #182

## Test plan
- [ ] Verify achievements render correctly on desktop (≥640px)
- [ ] Verify achievements render correctly on mobile (<640px)
- [ ] Confirm hover state works on cards
- [ ] Check that player links and avatars display properly

Made with [Cursor](https://cursor.com)